### PR TITLE
Remove local dependency on transformers from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,6 @@ dev = [
     "pytest-xdist>=3.6.1",
     "pytest-mock>=3.14.0",
 ]
-local = [
-    "transformers @ git+https://github.com/jakublala/my_transformers.git"
-]
 
 [project.urls]
 Homepage = "https://github.com/jakublala/boileroom"


### PR DESCRIPTION
Otherwise, we cannot publish the package with a direct git reference to a dependency