### PR TITLE
feat: add local execution for testing of models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/
+.model_cache/
 .venv/
 dist/

--- a/boileroom/models/esm/esm2.py
+++ b/boileroom/models/esm/esm2.py
@@ -1,5 +1,6 @@
 import modal
 import numpy as np
+import os
 from dataclasses import dataclass
 from typing import List, Union, Optional, TYPE_CHECKING
 
@@ -89,14 +90,16 @@ class ESM2(EmbeddingAlgorithm):
 
     @modal.enter()
     def _initialize(self) -> None:
-        self.model_dir = MODEL_DIR
+        self.model_dir = os.environ.get("MODEL_DIR", MODEL_DIR)
         self._load()
 
     def _load(self) -> None:
         if self.tokenizer is None:
-            self.tokenizer = AutoTokenizer.from_pretrained(f"facebook/{self.config['model_name']}")
+            self.tokenizer = AutoTokenizer.from_pretrained(
+                f"facebook/{self.config['model_name']}", cache_dir=self.model_dir
+            )
         if self.model is None:
-            self.model = EsmModel.from_pretrained(f"facebook/{self.config['model_name']}")
+            self.model = EsmModel.from_pretrained(f"facebook/{self.config['model_name']}", cache_dir=self.model_dir)
         self.device = "cuda"
         self.model = self.model.cuda()
         self.model.eval()

--- a/boileroom/models/esm/esmfold.py
+++ b/boileroom/models/esm/esmfold.py
@@ -214,7 +214,7 @@ class ESMFold(FoldingAlgorithm):
     @modal.enter()
     def _initialize(self) -> None:
         """Initialize the model during container startup. This helps us determine whether we run locally or remotely."""
-        self.model_dir = os.environ.get("HF_MODEL_DIR", MODEL_DIR)
+        self.model_dir = os.environ.get("MODEL_DIR", MODEL_DIR)
         self._load()
 
     def _load(self) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boileroom"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     { name="Jakub Lála", email="jakublala@gmail.com" },
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,34 @@
+"""Pytest configuration for the boileroom package."""
+
+import os
 import pathlib
 import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--backend",
+        action="store",
+        default="modal",
+        choices=("modal", "local"),
+        help="Execution backend for models in tests: modal (default) or local",
+    )
+
+
+@pytest.fixture(autouse=True, scope="session")
+def model_dir():
+    os.environ["MODEL_DIR"] = str(pathlib.Path(__file__).parent.parent / ".model_cache")
+
+
+@pytest.fixture
+def run_backend(request):
+    mode = request.config.getoption("--backend")
+
+    def select(method):
+        # method is e.g. model.fold or model.embed
+        return getattr(method, "local" if mode == "local" else "remote")
+
+    return select
 
 
 @pytest.fixture

--- a/tests/esm/test_esmfold.py
+++ b/tests/esm/test_esmfold.py
@@ -21,32 +21,28 @@ def esmfold_model(config={}) -> Generator[ESMFold, None, None]:
         yield ESMFold(config=config)
 
 
-def test_esmfold_basic(test_sequences: dict[str, str]):
+def test_esmfold_basic(test_sequences: dict[str, str], esmfold_model: ESMFold, run_backend):
     """Test basic ESMFold functionality."""
-    with enable_output():
-        with app.run():
-            model = ESMFold()
-            result = model.fold.remote(test_sequences["short"])
+    result = run_backend(esmfold_model.fold)(test_sequences["short"])
 
-            assert isinstance(result, ESMFoldOutput), "Result should be an ESMFoldOutput"
+    assert isinstance(result, ESMFoldOutput), "Result should be an ESMFoldOutput"
 
-            seq_len = len(test_sequences["short"])
-            positions_shape = result.positions.shape
+    seq_len = len(test_sequences["short"])
+    positions_shape = result.positions.shape
 
-            assert positions_shape[-1] == 3, "Coordinate dimension mismatch. Expected: 3, Got: {positions_shape[-1]}"
-            assert (
-                positions_shape[-3] == seq_len
-            ), "Number of residues mismatch. Expected: {seq_len}, Got: {positions_shape[-3]}"
-            assert np.all(result.plddt >= 0), "pLDDT scores should be non-negative"
-            assert np.all(result.plddt <= 100), "pLDDT scores should be less than or equal to 100"
+    assert positions_shape[-1] == 3, "Coordinate dimension mismatch. Expected: 3, Got: {positions_shape[-1]}"
+    assert (
+        positions_shape[-3] == seq_len
+    ), "Number of residues mismatch. Expected: {seq_len}, Got: {positions_shape[-3]}"
+    assert np.all(result.plddt >= 0), "pLDDT scores should be non-negative"
+    assert np.all(result.plddt <= 100), "pLDDT scores should be less than or equal to 100"
 
 
-def test_esmfold_multimer(test_sequences):
+def test_esmfold_multimer(test_sequences, run_backend):
     """Test ESMFold multimer functionality."""
-    with enable_output():
-        with app.run():
-            model = ESMFold(config={"output_pdb": True})
-            result = model.fold.remote(test_sequences["multimer"])
+    with enable_output(), app.run():  # TODO: make this better with a fixture, re-using the logic
+        model = ESMFold(config={"output_pdb": True})
+        result = run_backend(model.fold)(test_sequences["multimer"])
 
     assert result.pdb is not None, "PDB output should be generated"
     assert result.positions.shape[2] == len(test_sequences["multimer"].replace(":", "")), "Number of residues mismatch"
@@ -108,7 +104,7 @@ def test_esmfold_linker_map():
     assert torch.all(linker_map == gt_map), "Linker map mismatch"
 
 
-def test_esmfold_no_glycine_linker(test_sequences):
+def test_esmfold_no_glycine_linker(test_sequences, run_backend):
     """Test ESMFold no glycine linker."""
     model = ESMFold(
         config={
@@ -118,7 +114,7 @@ def test_esmfold_no_glycine_linker(test_sequences):
 
     with enable_output():
         with app.run():
-            result = model.fold.remote(test_sequences["multimer"])
+            result = run_backend(model.fold)(test_sequences["multimer"])
 
     assert result.positions is not None, "Positions should be generated"
     assert result.positions.shape[2] == len(test_sequences["multimer"].replace(":", "")), "Number of residues mismatch"
@@ -156,14 +152,14 @@ def test_esmfold_chain_indices():
     assert np.array_equal(chain_indices[0], expected_chain_indices), "Chain indices mismatch"
 
 
-def test_esmfold_batch(esmfold_model: ESMFold, test_sequences: dict[str, str]):
+def test_esmfold_batch(esmfold_model: ESMFold, test_sequences: dict[str, str], run_backend):
     """Test ESMFold batch prediction."""
 
     # Define input sequences
     sequences = [test_sequences["short"], test_sequences["medium"]]
 
     # Make prediction
-    result = esmfold_model.fold.remote(sequences)
+    result = run_backend(esmfold_model.fold)(sequences)
 
     max_seq_length = max(len(seq) for seq in sequences)
     assert (
@@ -221,7 +217,7 @@ def test_esmfold_batch(esmfold_model: ESMFold, test_sequences: dict[str, str]):
 #     assert set(tokenized_input.keys()) >= {"input_ids", "attention_mask", "position_ids"}
 
 
-def test_sequence_validation(esmfold_model: ESMFold, test_sequences: dict[str, str]):
+def test_sequence_validation(esmfold_model: ESMFold, test_sequences: dict[str, str], run_backend):
     """Test sequence validation in FoldingAlgorithm."""
 
     # Test single sequence
@@ -245,11 +241,11 @@ def test_sequence_validation(esmfold_model: ESMFold, test_sequences: dict[str, s
 
     # Test that fold method uses validation
     with pytest.raises(ValueError) as exc_info:
-        esmfold_model.fold.remote(test_sequences["invalid"])
+        run_backend(esmfold_model.fold)(test_sequences["invalid"])
     assert "Invalid amino acid" in str(exc_info.value), f"Expected 'Invalid amino acid', got {str(exc_info.value)}"
 
 
-def test_esmfold_output_pdb_cif(data_dir: pathlib.Path, test_sequences: dict[str, str]):
+def test_esmfold_output_pdb_cif(data_dir: pathlib.Path, test_sequences: dict[str, str], run_backend):
     """Test ESMFold output PDB and CIF."""
 
     def recover_sequence(atomarray: AtomArray) -> str:
@@ -263,7 +259,7 @@ def test_esmfold_output_pdb_cif(data_dir: pathlib.Path, test_sequences: dict[str
             model = ESMFold(config={"output_pdb": True, "output_cif": False, "output_atomarray": True})
             # Define input sequences
             sequences = [test_sequences["short"], test_sequences["medium"]]
-            result = model.fold.remote(sequences)
+            result = run_backend(model.fold)(sequences)
 
     assert result.pdb is not None, "PDB output should be generated"
     assert result.cif is None, "CIF output should be None"

--- a/uv.lock
+++ b/uv.lock
@@ -172,7 +172,7 @@ wheels = [
 
 [[package]]
 name = "boileroom"
-version = "0.1.3"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "biotite" },


### PR DESCRIPTION
- Added .model_cache/ to .gitignore.
- Updated version of the boileroom package in uv.lock to 0.2.0.
- Modified ESM2 and ESMFold classes to retrieve model directory from environment variables.
- Enhanced test configurations to support backend selection for model execution.

Also, made a (somewhat) API-breaking change for `HF_MODEL_DIR` to `MODEL_DIR`. Going to keep it at version 0.2