### PR TITLE
fix: transformers use cache

### DIFF
--- a/boileroom/models/esm/esm2.py
+++ b/boileroom/models/esm/esm2.py
@@ -143,7 +143,6 @@ class ESM2(EmbeddingAlgorithm):
             multimer_properties = None
         tokenized = tokenized.to(self.device)
         tokenized["output_hidden_states"] = self.config["output_hidden_states"]
-        tokenized["use_cache"] = True
 
         with Timer("Model Inference") as timer:
             with torch.inference_mode():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boileroom"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     { name="Jakub Lála", email="jakublala@gmail.com" },
 ]


### PR DESCRIPTION
This pull request includes a version bump for the `boileroom` package and a small change to the ESM2 model inference code. The most important changes are:

Versioning:

* Updated the project version from `0.2.0` to `0.2.1` in `pyproject.toml` to reflect the latest changes.

Model inference:

* Removed the unnecessary `use_cache` parameter from the tokenized input in the `embed` method of `esm2.py`, simplifying the model inference process.