### PR TITLE
fix image runtime env

### DIFF
--- a/boileroom/backend/apptainer.py
+++ b/boileroom/backend/apptainer.py
@@ -104,7 +104,7 @@ def _get_cached_sif_path(image_uri: str, cache_dir: Path) -> Path:
     Parameters
     ----------
     image_uri : str
-        Docker URI (e.g., 'docker://docker.io/jakublala/boileroom-chai:0.3.0').
+        Docker URI (e.g., 'docker://docker.io/example/boileroom-chai:0.3.0').
     cache_dir : Path
         Base cache directory.
 
@@ -114,7 +114,7 @@ def _get_cached_sif_path(image_uri: str, cache_dir: Path) -> Path:
         Path to cached .sif file.
     """
     # Extract image name from URI
-    # docker://docker.io/jakublala/boileroom-chai:0.3.0 -> boileroom-chai_0.3.0.sif
+    # docker://docker.io/example/boileroom-chai:0.3.0 -> boileroom-chai_0.3.0.sif
     parsed = urlparse(image_uri.replace("docker://", "https://"))
     image_name = parsed.path.lstrip("/").replace("/", "-").replace(":", "_")
     if not image_name.endswith(".sif"):
@@ -261,7 +261,7 @@ def _pull_image(image_uri: str, sif_path: Path, log_file: Path | None = None) ->
     Parameters
     ----------
     image_uri : str
-        Docker URI to pull (e.g., 'docker://docker.io/jakublala/boileroom-chai:0.3.0').
+        Docker URI to pull (e.g., 'docker://docker.io/example/boileroom-chai:0.3.0').
     sif_path : Path
         Path where .sif file should be saved.
     log_file : Path | None
@@ -348,7 +348,7 @@ class ApptainerBackend(Backend):
             Full module path to the Core class (e.g., 'boileroom.models.esm.esm2.ESM2Core').
             This is passed as a string to avoid importing the class in the main process.
         image_uri : str
-            Docker URI for the container image (e.g., 'docker://docker.io/jakublala/boileroom-chai:0.3.0').
+            Docker URI for the container image (e.g., 'docker://docker.io/example/boileroom-chai:0.3.0').
         config : dict | None
             Optional configuration mapping for the model.
         device : str | None

--- a/boileroom/images/Dockerfile
+++ b/boileroom/images/Dockerfile
@@ -22,6 +22,7 @@ RUN micromamba install -y -c conda-forge python=3.12 pip \
     && python -m pip install --upgrade pip
 
 ENV MODEL_DIR=/mnt/models
+ENV TINI_SUBREAPER=1
 ENV PATH=/opt/conda/bin:${PATH}
 
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/boileroom/images/Dockerfile
+++ b/boileroom/images/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 USER ${MAMBA_USER}
 
-RUN micromamba install -y -c conda-forge python=3.12 pip pyyaml \
+RUN micromamba install -y -c conda-forge python=3.12 pip \
     && python -m pip install --upgrade pip
 
 ENV MODEL_DIR=/mnt/models

--- a/boileroom/images/Dockerfile
+++ b/boileroom/images/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 USER ${MAMBA_USER}
 
-RUN micromamba install -y -c conda-forge python=3.12 pip \
+RUN micromamba install -y -c conda-forge python=3.12 pip pyyaml \
     && python -m pip install --upgrade pip
 
 ENV MODEL_DIR=/mnt/models

--- a/boileroom/images/base.py
+++ b/boileroom/images/base.py
@@ -2,6 +2,7 @@
 
 from modal import Image
 
-from .metadata import BASE_IMAGE_SPEC, format_image_reference, get_modal_image_tag
+from .metadata import MODAL_IMAGE_TAG_ENV, get_modal_base_image_reference, get_modal_image_tag
 
-base_image = Image.from_registry(format_image_reference(BASE_IMAGE_SPEC.image_name, get_modal_image_tag()))
+_base_image_tag = get_modal_image_tag()
+base_image = Image.from_registry(get_modal_base_image_reference()).env({MODAL_IMAGE_TAG_ENV: _base_image_tag})

--- a/boileroom/images/base.py
+++ b/boileroom/images/base.py
@@ -2,9 +2,6 @@
 
 from modal import Image
 
-from .metadata import BASE_IMAGE_SPEC, MODAL_IMAGE_TAG_ENV, format_image_reference, get_modal_image_tag
+from .metadata import BASE_IMAGE_SPEC, format_image_reference, get_modal_image_tag
 
-_base_image_tag = get_modal_image_tag()
-base_image = Image.from_registry(format_image_reference(BASE_IMAGE_SPEC.image_name, _base_image_tag)).env(
-    {MODAL_IMAGE_TAG_ENV: _base_image_tag}
-)
+base_image = Image.from_registry(format_image_reference(BASE_IMAGE_SPEC.image_name, get_modal_image_tag()))

--- a/boileroom/images/base.py
+++ b/boileroom/images/base.py
@@ -2,6 +2,9 @@
 
 from modal import Image
 
-from .metadata import BASE_IMAGE_SPEC, format_image_reference, get_modal_image_tag
+from .metadata import BASE_IMAGE_SPEC, MODAL_IMAGE_TAG_ENV, format_image_reference, get_modal_image_tag
 
-base_image = Image.from_registry(format_image_reference(BASE_IMAGE_SPEC.image_name, get_modal_image_tag()))
+_base_image_tag = get_modal_image_tag()
+base_image = Image.from_registry(format_image_reference(BASE_IMAGE_SPEC.image_name, _base_image_tag)).env(
+    {MODAL_IMAGE_TAG_ENV: _base_image_tag}
+)

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -218,9 +218,12 @@ def get_supported_cuda(spec: RuntimeImageSpec) -> tuple[str, ...]:
     return tuple(supported_cuda)
 
 
-def render_modal_runtime_env(spec: RuntimeImageSpec, model_dir: str) -> dict[str, str]:
+def render_modal_runtime_env(spec: RuntimeImageSpec, model_dir: str, image_tag: str | None = None) -> dict[str, str]:
     """Render runtime environment overrides for Modal."""
-    env = {"MODEL_DIR": model_dir}
+    env = {
+        "MODEL_DIR": model_dir,
+        MODAL_IMAGE_TAG_ENV: normalize_requested_tag(image_tag),
+    }
     for key, value in spec.modal_runtime_env:
         env[key] = value.replace("{MODEL_DIR}", model_dir)
     return env

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -218,12 +218,9 @@ def get_supported_cuda(spec: RuntimeImageSpec) -> tuple[str, ...]:
     return tuple(supported_cuda)
 
 
-def render_modal_runtime_env(spec: RuntimeImageSpec, model_dir: str, image_tag: str | None = None) -> dict[str, str]:
+def render_modal_runtime_env(spec: RuntimeImageSpec, model_dir: str) -> dict[str, str]:
     """Render runtime environment overrides for Modal."""
-    env = {
-        "MODEL_DIR": model_dir,
-        MODAL_IMAGE_TAG_ENV: normalize_requested_tag(image_tag),
-    }
+    env = {"MODEL_DIR": model_dir}
     for key, value in spec.modal_runtime_env:
         env[key] = value.replace("{MODEL_DIR}", model_dir)
     return env

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -11,12 +11,12 @@ from functools import cache
 from pathlib import Path
 from typing import Final
 
-import yaml
-
-DOCKER_REGISTRY: Final = "docker.io/jakublala"
 PACKAGE_NAME: Final = "boileroom"
 DEFAULT_CUDA_VERSION: Final = "12.6"
+DOCKER_REGISTRY_ENV: Final = "BOILEROOM_DOCKER_REGISTRY"
 MODAL_IMAGE_TAG_ENV: Final = "BOILEROOM_MODAL_IMAGE_TAG"
+MODAL_BASE_IMAGE_REF_ENV: Final = "BOILEROOM_MODAL_BASE_IMAGE"
+DEFAULT_DOCKER_REGISTRY: Final = "docker.io/jakublala"
 
 CUDA_MICROMAMBA_BASE: Final[dict[str, str]] = {
     "11.8": "mambaorg/micromamba:2.4-cuda11.8.0-ubuntu22.04",
@@ -95,11 +95,31 @@ def get_repo_root() -> Path:
 
 
 @cache
-def get_default_image_tag() -> str:
-    """Return the default runtime image tag for this installed package."""
+def get_pyproject_config() -> dict:
+    """Return the local pyproject configuration when available."""
     pyproject_path = get_repo_root() / "pyproject.toml"
     if pyproject_path.exists():
-        return tomllib.loads(pyproject_path.read_text(encoding="utf-8"))["project"]["version"].strip()
+        return tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    return {}
+
+
+def get_docker_registry() -> str:
+    """Return the Docker registry namespace used for published runtime images."""
+    override = os.environ.get(DOCKER_REGISTRY_ENV)
+    if override:
+        normalized = override.strip().rstrip("/")
+        if normalized:
+            return normalized
+
+    return DEFAULT_DOCKER_REGISTRY
+
+
+@cache
+def get_default_image_tag() -> str:
+    """Return the default runtime image tag for this installed package."""
+    pyproject_config = get_pyproject_config()
+    if pyproject_config:
+        return pyproject_config["project"]["version"].strip()
     try:
         return importlib.metadata.version(PACKAGE_NAME).strip()
     except importlib.metadata.PackageNotFoundError:
@@ -170,19 +190,29 @@ def published_tags(cuda_version: str, tag: str | None) -> tuple[str, ...]:
 def format_image_reference(image_name: str, tag: str | None = None) -> str:
     """Return a fully qualified Docker image reference."""
     resolved_tag = resolve_registry_tag(tag)
-    return f"{DOCKER_REGISTRY}/{image_name}:{resolved_tag}"
+    return f"{get_docker_registry()}/{image_name}:{resolved_tag}"
 
 
 def published_image_references(image_name: str, cuda_version: str, tag: str | None) -> tuple[str, ...]:
     """Return all published references for a built image."""
     return tuple(
-        f"{DOCKER_REGISTRY}/{image_name}:{published_tag}" for published_tag in published_tags(cuda_version, tag)
+        f"{get_docker_registry()}/{image_name}:{published_tag}" for published_tag in published_tags(cuda_version, tag)
     )
 
 
 def get_modal_image_tag() -> str:
     """Return the tag Modal should pull from the registry."""
     return resolve_registry_tag(os.environ.get(MODAL_IMAGE_TAG_ENV))
+
+
+def get_modal_base_image_reference() -> str:
+    """Return the base image Modal should use for the shared runtime layer."""
+    override = os.environ.get(MODAL_BASE_IMAGE_REF_ENV)
+    if override:
+        normalized = override.strip()
+        if normalized:
+            return normalized
+    return format_image_reference(BASE_IMAGE_SPEC.image_name, get_modal_image_tag())
 
 
 def get_model_image_spec(identifier: str) -> RuntimeImageSpec:
@@ -204,6 +234,8 @@ def get_supported_cuda(spec: RuntimeImageSpec) -> tuple[str, ...]:
     if not config_path.exists():
         return tuple(sorted(CUDA_MICROMAMBA_BASE))
 
+    import yaml
+
     config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     raw_supported_cuda = config.get("supported_cuda", [])
     if isinstance(raw_supported_cuda, list):
@@ -220,7 +252,7 @@ def get_supported_cuda(spec: RuntimeImageSpec) -> tuple[str, ...]:
 
 def render_modal_runtime_env(spec: RuntimeImageSpec, model_dir: str) -> dict[str, str]:
     """Render runtime environment overrides for Modal."""
-    env = {"MODEL_DIR": model_dir}
+    env = {"MODEL_DIR": model_dir, MODAL_IMAGE_TAG_ENV: get_modal_image_tag()}
     for key, value in spec.modal_runtime_env:
         env[key] = value.replace("{MODEL_DIR}", model_dir)
     return env

--- a/boileroom/images/modal.py
+++ b/boileroom/images/modal.py
@@ -11,6 +11,5 @@ from .metadata import format_image_reference, get_modal_image_tag, get_model_ima
 def get_modal_image(identifier: str) -> Image:
     """Return a Modal image sourced from the published Docker image for a model."""
     spec = get_model_image_spec(identifier)
-    image_tag = get_modal_image_tag()
-    image = Image.from_registry(format_image_reference(spec.image_name, image_tag))
-    return image.env(render_modal_runtime_env(spec, MODAL_MODEL_DIR, image_tag=image_tag))
+    image = Image.from_registry(format_image_reference(spec.image_name, get_modal_image_tag()))
+    return image.env(render_modal_runtime_env(spec, MODAL_MODEL_DIR))

--- a/boileroom/images/modal.py
+++ b/boileroom/images/modal.py
@@ -11,5 +11,6 @@ from .metadata import format_image_reference, get_modal_image_tag, get_model_ima
 def get_modal_image(identifier: str) -> Image:
     """Return a Modal image sourced from the published Docker image for a model."""
     spec = get_model_image_spec(identifier)
-    image = Image.from_registry(format_image_reference(spec.image_name, get_modal_image_tag()))
-    return image.env(render_modal_runtime_env(spec, MODAL_MODEL_DIR))
+    image_tag = get_modal_image_tag()
+    image = Image.from_registry(format_image_reference(spec.image_name, image_tag))
+    return image.env(render_modal_runtime_env(spec, MODAL_MODEL_DIR, image_tag=image_tag))

--- a/boileroom/models/boltz/Dockerfile
+++ b/boileroom/models/boltz/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG BUILDPLATFORM
 
-ARG BASE_IMAGE=docker.io/jakublala/boileroom-base:local
+ARG BASE_IMAGE=boileroom-base:local
 FROM ${BASE_IMAGE}
 
 ARG ENV_FILE=environment.yml

--- a/boileroom/models/boltz/core.py
+++ b/boileroom/models/boltz/core.py
@@ -8,7 +8,7 @@ import logging
 import os
 import shutil
 from collections.abc import Iterator, Sequence
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, ClassVar, cast
@@ -351,7 +351,7 @@ class Boltz2Core(FoldingAlgorithm):
                 index = cast(dict[str, dict[str, Any]], index)
                 cached_paths: dict[str, Path] = {}
                 index_updated = False
-                now = datetime.utcnow().isoformat()
+                now = datetime.now(timezone.utc).isoformat()
 
                 for sequence in sequences:
                     seq_hash = self._get_sequence_hash(sequence)
@@ -434,7 +434,7 @@ class Boltz2Core(FoldingAlgorithm):
             # Update index under lock so concurrent writers cannot clobber entries.
             with self._locked_msa_cache_index() as index:
                 index = cast(dict[str, dict[str, Any]], index)
-                now = datetime.utcnow().isoformat()
+                now = datetime.now(timezone.utc).isoformat()
                 relative_path = f"{seq_hash[:2]}/{seq_hash[2:4]}/{seq_hash}.csv"
                 index[seq_hash] = {
                     "msa_path": relative_path,

--- a/boileroom/models/chai/Dockerfile
+++ b/boileroom/models/chai/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG BUILDPLATFORM
 
-ARG BASE_IMAGE=docker.io/jakublala/boileroom-base:local
+ARG BASE_IMAGE=boileroom-base:local
 FROM ${BASE_IMAGE}
 
 ARG ENV_FILE=environment.yml

--- a/boileroom/models/chai/environment.yml
+++ b/boileroom/models/chai/environment.yml
@@ -15,3 +15,5 @@ dependencies:
     - fastapi
     - uvicorn
     - pydantic
+    # pydantic imports typing_extensions.Sentinel, which is missing from older releases.
+    - typing_extensions>=4.15.0

--- a/boileroom/models/esm/Dockerfile
+++ b/boileroom/models/esm/Dockerfile
@@ -3,7 +3,7 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG BUILDPLATFORM
 
-ARG BASE_IMAGE=docker.io/jakublala/boileroom-base:local
+ARG BASE_IMAGE=boileroom-base:local
 FROM ${BASE_IMAGE}
 
 ARG ENV_FILE=environment.yml

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -1,12 +1,14 @@
 ## Boileroom Docker images
 
 ### What exists today
-- **base**: `boileroom/images/Dockerfile` → CUDA-enabled micromamba base with Python 3.12. Tag: `docker.io/jakublala/boileroom-base`.
-- **boltz**: `boileroom/models/boltz/Dockerfile` → copies `environment.yml` and installs the Boltz env. Tag: `docker.io/jakublala/boileroom-boltz`.
-- **chai1**: `boileroom/models/chai/Dockerfile` → copies `environment.yml`, installs chai-specific deps, sets HF env vars. Tag: `docker.io/jakublala/boileroom-chai1`.
-- **esm**: `boileroom/models/esm/Dockerfile` → copies `environment.yml` shared by esm2/esmfold. Tag: `docker.io/jakublala/boileroom-esm`.
+- **base**: `boileroom/images/Dockerfile` → CUDA-enabled micromamba base with Python 3.12. Tag: `${BOILEROOM_DOCKER_REGISTRY}/boileroom-base`.
+  - The shared entrypoint uses Tini with `TINI_SUBREAPER=1` so child processes are re-parented correctly when Tini is not PID 1.
+- **boltz**: `boileroom/models/boltz/Dockerfile` → copies `environment.yml` and installs the Boltz env. Tag: `${BOILEROOM_DOCKER_REGISTRY}/boileroom-boltz`.
+- **chai1**: `boileroom/models/chai/Dockerfile` → copies `environment.yml`, installs chai-specific deps, sets HF env vars. Tag: `${BOILEROOM_DOCKER_REGISTRY}/boileroom-chai1`.
+- **esm**: `boileroom/models/esm/Dockerfile` → copies `environment.yml` shared by esm2/esmfold. Tag: `${BOILEROOM_DOCKER_REGISTRY}/boileroom-esm`.
 
 Dockerfiles are the canonical image definition for all runtimes. Docker/Apptainer images are built from these Dockerfiles, and Modal pulls the corresponding published model image from Docker Hub instead of maintaining a separate handwritten dependency stack.
+The default registry namespace is compiled into `boileroom.images.metadata` and can be overridden with `BOILEROOM_DOCKER_REGISTRY`.
 
 ### Tag scheme
 - Canonical published tags are CUDA-qualified, for example `cuda12.6-0.3.0`, `cuda11.8-0.3.0`, or `cuda12.6-sha-abc1234`.
@@ -24,9 +26,12 @@ uv run python scripts/images/build_model_images.py --cuda-version=12.6 --platfor
 uv run python scripts/images/build_model_images.py --no-cache ...
 uv run python scripts/images/build_model_images.py --all-cuda --tag=0.3.0 --push ...
 uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=sha-$(git rev-parse --short HEAD) --push ...
+uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=0.3.0 --push --skip-existing ...
+uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=0.3.0 --push --plain-progress ...
 ```
 
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
+When pushing, plain buildx logs are available only when `--plain-progress` is set; otherwise the script keeps the terminal quiet and writes per-image log files.
 
 ### 🔖 Tag policy
 - Docker Hub is kept clean for users. The long-lived public tags are version tags such as `0.3.0` and the corresponding CUDA-qualified tags such as `cuda12.6-0.3.0` and `cuda11.8-0.3.0`.
@@ -67,7 +72,7 @@ The GitHub Actions workflow (`.github/workflows/build-docker-images.yml`) runs t
 ```bash
 docker build \
   --platform linux/amd64 \
-  -t docker.io/jakublala/boileroom-base:local \
+  -t "${BOILEROOM_DOCKER_REGISTRY}/boileroom-base:local" \
   -f boileroom/images/Dockerfile \
   boileroom/images
 ```
@@ -76,8 +81,8 @@ docker build \
 ```bash
 docker build \
   --platform linux/amd64 \
-  --build-arg BASE_IMAGE=docker.io/jakublala/boileroom-base:local \
-  -t docker.io/jakublala/boileroom-boltz:local \
+  --build-arg BASE_IMAGE="${BOILEROOM_DOCKER_REGISTRY}/boileroom-base:local" \
+  -t "${BOILEROOM_DOCKER_REGISTRY}/boileroom-boltz:local" \
   -f boileroom/models/boltz/Dockerfile \
   boileroom/models/boltz
 ```
@@ -86,8 +91,8 @@ docker build \
 ```bash
 docker build \
   --platform linux/amd64 \
-  --build-arg BASE_IMAGE=docker.io/jakublala/boileroom-base:local \
-  -t docker.io/jakublala/boileroom-chai1:local \
+  --build-arg BASE_IMAGE="${BOILEROOM_DOCKER_REGISTRY}/boileroom-base:local" \
+  -t "${BOILEROOM_DOCKER_REGISTRY}/boileroom-chai1:local" \
   -f boileroom/models/chai/Dockerfile \
   boileroom/models/chai
 ```
@@ -96,8 +101,8 @@ docker build \
 ```bash
 docker build \
   --platform linux/amd64 \
-  --build-arg BASE_IMAGE=docker.io/jakublala/boileroom-base:local \
-  -t docker.io/jakublala/boileroom-esm:local \
+  --build-arg BASE_IMAGE="${BOILEROOM_DOCKER_REGISTRY}/boileroom-base:local" \
+  -t "${BOILEROOM_DOCKER_REGISTRY}/boileroom-esm:local" \
   -f boileroom/models/esm/Dockerfile \
   boileroom/models/esm
 ```
@@ -128,25 +133,25 @@ If your cluster uses Apptainer/Singularity for job execution, you can convert th
 1) Directly from the registry (simplest):
 ```bash
 # Version-matched aliases on the default CUDA line
-apptainer pull base.sif  docker://docker.io/jakublala/boileroom-base:0.3.0
-apptainer pull chai1.sif docker://docker.io/jakublala/boileroom-chai1:0.3.0
+apptainer pull base.sif  "docker://${BOILEROOM_DOCKER_REGISTRY}/boileroom-base:0.3.0"
+apptainer pull chai1.sif "docker://${BOILEROOM_DOCKER_REGISTRY}/boileroom-chai1:0.3.0"
 
 # Explicit CUDA-qualified tags
-apptainer pull chai1-cu118.sif docker://docker.io/jakublala/boileroom-chai1:cuda11.8-0.3.0
-apptainer pull chai1-cu126.sif docker://docker.io/jakublala/boileroom-chai1:cuda12.6-0.3.0
+apptainer pull chai1-cu118.sif "docker://${BOILEROOM_DOCKER_REGISTRY}/boileroom-chai1:cuda11.8-0.3.0"
+apptainer pull chai1-cu126.sif "docker://${BOILEROOM_DOCKER_REGISTRY}/boileroom-chai1:cuda12.6-0.3.0"
 
 # If the repository is private, authenticate first to Docker Hub:
 # This will prompt for your Docker Hub credentials if needed.
 apptainer remote login docker://docker.io
-apptainer pull base.sif  docker://docker.io/jakublala/boileroom-base:0.3.0
-apptainer pull chai1.sif docker://docker.io/jakublala/boileroom-chai1:0.3.0
+apptainer pull base.sif  "docker://${BOILEROOM_DOCKER_REGISTRY}/boileroom-base:0.3.0"
+apptainer pull chai1.sif "docker://${BOILEROOM_DOCKER_REGISTRY}/boileroom-chai1:0.3.0"
 ```
 
 2) From a local Docker image (no registry pull on the cluster) (🚨 **THIS HAS NOT BEEN TESTED, AND IS NOT RECOMMENDED** 🚨):
 ```bash
 # On a build machine (e.g., your workstation):
-docker pull docker.io/jakublala/boileroom-chai1:cuda12.6-0.3.0
-docker save --format oci-archive -o chai1-oci.tar docker.io/jakublala/boileroom-chai1:cuda12.6-0.3.0
+docker pull "${BOILEROOM_DOCKER_REGISTRY}/boileroom-chai1:cuda12.6-0.3.0"
+docker save --format oci-archive -o chai1-oci.tar "${BOILEROOM_DOCKER_REGISTRY}/boileroom-chai1:cuda12.6-0.3.0"
 
 # Transfer chai1-oci.tar to the cluster, then:
 apptainer build chai1.sif oci-archive://chai1-oci.tar
@@ -166,7 +171,7 @@ Docker example:
 docker run --rm \
   -e MODEL_DIR=/data/models \
   -v /data/models:/data/models \
-  docker.io/jakublala/boileroom-chai1:0.3.0 python -c "import os; print(os.getenv('MODEL_DIR'))"
+  "${BOILEROOM_DOCKER_REGISTRY}/boileroom-chai1:0.3.0" python -c "import os; print(os.getenv('MODEL_DIR'))"
 ```
 
 Apptainer examples:
@@ -182,7 +187,7 @@ apptainer exec --env MODEL_DIR=/scratch/weights -B /scratch/weights:/scratch/wei
 ### 🧩 Add your own image
 1) Create a `Dockerfile` under `boileroom/models/<your_image>/Dockerfile` that starts FROM the local base image:
 ```Dockerfile
-ARG BASE_IMAGE=docker.io/jakublala/boileroom-base:local
+ARG BASE_IMAGE=boileroom-base:local
 FROM ${BASE_IMAGE}
 ```
 2) Build it locally (adjust path and tag):

--- a/scripts/check_gcc_summary.sh
+++ b/scripts/check_gcc_summary.sh
@@ -10,9 +10,10 @@ from pathlib import Path
 print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])
 PY
 )"
+DOCKER_REGISTRY="$(uv run python -c 'from boileroom.images.metadata import get_docker_registry; print(get_docker_registry())')"
 IMAGE_TAG="${BOILEROOM_IMAGE_TAG:-cuda12.6-${DEFAULT_VERSION}}"
-MODEL_IMAGE="docker.io/jakublala/boileroom-boltz:${IMAGE_TAG}"
-BASE_IMAGE="docker.io/jakublala/boileroom-base:${IMAGE_TAG}"
+MODEL_IMAGE="${DOCKER_REGISTRY}/boileroom-boltz:${IMAGE_TAG}"
+BASE_IMAGE="${DOCKER_REGISTRY}/boileroom-base:${IMAGE_TAG}"
 
 echo "=========================================="
 echo "GCC Verification Summary for Boltz-2"

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -198,6 +198,16 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--push", action="store_true", help="Push built images to Docker Hub.")
     parser.add_argument(
+        "--skip-existing",
+        action="store_true",
+        help="Skip build and push steps when all published tags for an image already exist on Docker Hub.",
+    )
+    parser.add_argument(
+        "--plain-progress",
+        action="store_true",
+        help="Stream plain buildx progress output to the terminal while building and pushing.",
+    )
+    parser.add_argument(
         "--load",
         action="store_true",
         help="Load single-platform builds into the local Docker daemon. Incompatible with --push and multi-platform builds.",
@@ -248,6 +258,27 @@ def should_use_local_docker_build(push: bool, platform: str) -> bool:
     return not push and "," not in platform
 
 
+def docker_manifest_exists(image_reference: str) -> bool:
+    """Return whether a Docker image reference is already published."""
+    result = subprocess.run(
+        ["docker", "manifest", "inspect", image_reference],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0:
+        return True
+    detail = (result.stderr or result.stdout).strip()
+    suffix = f": {detail}" if detail else "."
+    log_warn(f"Could not confirm Docker manifest exists for {image_reference}{suffix}")
+    return False
+
+
+def all_image_references_exist(image_references: tuple[str, ...]) -> bool:
+    """Return whether every published tag for an image already exists remotely."""
+    return all(docker_manifest_exists(reference) for reference in image_references)
+
+
 def build_base(
     cuda_version: str,
     tag: str,
@@ -255,6 +286,8 @@ def build_base(
     output_flag: str | None,
     no_cache: bool,
     use_local_docker_build: bool,
+    skip_existing: bool,
+    plain_progress: bool,
 ) -> str:
     """Build the shared base image and return its canonical reference."""
     image_references = published_image_references(BASE_IMAGE_SPEC.image_name, cuda_version, tag)
@@ -266,6 +299,10 @@ def build_base(
     log_info(f"Using micromamba base: {micromamba_base}")
     log_info(f"Publishing tags: {', '.join(image_references)}")
 
+    if skip_existing and not use_local_docker_build and all_image_references_exist(image_references):
+        log_info("Skipping base build; all published tags already exist on Docker Hub.")
+        return canonical_reference
+
     log_file = Path.cwd() / f"{canonical_reference.replace('/', '_').replace(':', '_')}.log"
     if use_local_docker_build:
         cmd = [
@@ -286,6 +323,8 @@ def build_base(
             "--build-arg",
             f"MICROMAMBA_BASE={micromamba_base}",
         ]
+        if plain_progress:
+            cmd.insert(5, "--progress=plain")
     for image_reference in image_references:
         cmd.extend(["-t", image_reference])
     cmd.extend(["-f", str(BASE_IMAGE_SPEC.dockerfile_path), str(BASE_IMAGE_SPEC.context_path)])
@@ -294,7 +333,7 @@ def build_base(
     if not use_local_docker_build and output_flag is not None:
         cmd.append(output_flag)
 
-    run(cmd, log_file=log_file, echo=False)
+    run(cmd, log_file=log_file, echo=plain_progress)
     return canonical_reference
 
 
@@ -304,6 +343,8 @@ def build_model(
     output_flag: str | None,
     no_cache: bool,
     use_local_docker_build: bool,
+    skip_existing: bool,
+    plain_progress: bool,
 ) -> tuple[str, ...]:
     """Build a single model image and return all published references."""
     image_references = published_image_references(task.image_spec.image_name, task.cuda_version, task.tag)
@@ -311,6 +352,10 @@ def build_model(
 
     log_info(Colors.wrap(f"--- Building {task.image_spec.key} for CUDA {task.cuda_version}: {canonical_reference}", Colors.bold))
     log_info(f"Publishing tags: {', '.join(image_references)}")
+
+    if skip_existing and not use_local_docker_build and all_image_references_exist(image_references):
+        log_info("Skipping model build; all published tags already exist on Docker Hub.")
+        return image_references
 
     log_file = Path.cwd() / f"{canonical_reference.replace('/', '_').replace(':', '_')}.log"
     if use_local_docker_build:
@@ -336,6 +381,8 @@ def build_model(
             "--build-arg",
             f"TORCH_WHEEL_INDEX={CUDA_TORCH_WHEEL_INDEX[task.cuda_version]}",
         ]
+        if plain_progress:
+            cmd.insert(5, "--progress=plain")
     for image_reference in image_references:
         cmd.extend(["-t", image_reference])
     cmd.extend(["-f", str(task.image_spec.dockerfile_path), str(task.image_spec.context_path)])
@@ -344,7 +391,7 @@ def build_model(
     if not use_local_docker_build and output_flag is not None:
         cmd.append(output_flag)
 
-    run(cmd, log_file=log_file, echo=False)
+    run(cmd, log_file=log_file, echo=plain_progress)
     return image_references
 
 
@@ -389,6 +436,8 @@ def main() -> None:
                 output_flag,
                 args.no_cache,
                 use_local_docker_build,
+                args.skip_existing,
+                args.plain_progress,
             )
         except Exception as exc:
             log_error(f"Failed to build base image for CUDA {cuda_version}: {exc}")
@@ -419,7 +468,15 @@ def main() -> None:
         for task in tasks:
             try:
                 built_references.extend(
-                    build_model(task, args.platform, output_flag, args.no_cache, use_local_docker_build)
+                    build_model(
+                        task,
+                        args.platform,
+                        output_flag,
+                        args.no_cache,
+                        use_local_docker_build,
+                        args.skip_existing,
+                        args.plain_progress,
+                    )
                 )
             except Exception as exc:
                 log_error(f"Failed to build {task.image_spec.image_name} for CUDA {task.cuda_version}: {exc}")
@@ -435,6 +492,8 @@ def main() -> None:
                     output_flag,
                     args.no_cache,
                     use_local_docker_build,
+                    args.skip_existing,
+                    args.plain_progress,
                 ): task
                 for task in tasks
             }

--- a/scripts/verify_gcc_complete.sh
+++ b/scripts/verify_gcc_complete.sh
@@ -10,8 +10,9 @@ from pathlib import Path
 print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])
 PY
 )"
+DOCKER_REGISTRY="$(uv run python -c 'from boileroom.images.metadata import get_docker_registry; print(get_docker_registry())')"
 IMAGE_TAG="${BOILEROOM_IMAGE_TAG:-cuda12.6-${DEFAULT_VERSION}}"
-IMAGE_DOCKER="docker.io/jakublala/boileroom-boltz:${IMAGE_TAG}"
+IMAGE_DOCKER="${DOCKER_REGISTRY}/boileroom-boltz:${IMAGE_TAG}"
 IMAGE_URI="docker://${IMAGE_DOCKER}"
 SIF_PATH="/tmp/boltz-verify.sif"
 

--- a/scripts/verify_gcc_in_apptainer.sh
+++ b/scripts/verify_gcc_in_apptainer.sh
@@ -10,8 +10,9 @@ from pathlib import Path
 print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])
 PY
 )"
+DOCKER_REGISTRY="$(uv run python -c 'from boileroom.images.metadata import get_docker_registry; print(get_docker_registry())')"
 IMAGE_TAG="${BOILEROOM_IMAGE_TAG:-cuda12.6-${DEFAULT_VERSION}}"
-IMAGE_URI="docker://docker.io/jakublala/boileroom-boltz:${IMAGE_TAG}"
+IMAGE_URI="docker://${DOCKER_REGISTRY}/boileroom-boltz:${IMAGE_TAG}"
 CACHE_DIR="${HOME}/.cache/boileroom/images"
 SIF_NAME="boltz_${IMAGE_TAG}.sif"
 SIF_PATH="${CACHE_DIR}/${SIF_NAME}"

--- a/scripts/verify_gcc_in_docker.sh
+++ b/scripts/verify_gcc_in_docker.sh
@@ -10,8 +10,9 @@ from pathlib import Path
 print(tomllib.loads(Path('pyproject.toml').read_text(encoding='utf-8'))['project']['version'])
 PY
 )"
+DOCKER_REGISTRY="$(uv run python -c 'from boileroom.images.metadata import get_docker_registry; print(get_docker_registry())')"
 IMAGE_TAG="${BOILEROOM_IMAGE_TAG:-cuda12.6-${DEFAULT_VERSION}}"
-IMAGE_NAME="docker.io/jakublala/boileroom-boltz:${IMAGE_TAG}"
+IMAGE_NAME="${DOCKER_REGISTRY}/boileroom-boltz:${IMAGE_TAG}"
 
 echo "=========================================="
 echo "Verifying GCC in Boltz-2 Docker Image"
@@ -58,7 +59,7 @@ EOF
 
 echo ""
 echo "6. Checking base image (boileroom-base:${IMAGE_TAG})..."
-BASE_IMAGE="docker.io/jakublala/boileroom-base:${IMAGE_TAG}"
+BASE_IMAGE="${DOCKER_REGISTRY}/boileroom-base:${IMAGE_TAG}"
 if docker run --rm "$BASE_IMAGE" which gcc > /dev/null 2>&1; then
     echo "   ✓ Base image also has GCC"
     docker run --rm "$BASE_IMAGE" gcc --version | head -1

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -1,0 +1,35 @@
+"""Fast contract tests for Docker image build helpers."""
+
+import subprocess
+
+from scripts.images import build_model_images
+
+
+def test_docker_manifest_exists_uses_docker_exit_status(monkeypatch) -> None:
+    """Published-image checks should reflect the Docker manifest command status."""
+
+    def fake_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        assert cmd == ["docker", "manifest", "inspect", "docker.io/example/image:tag"]
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["check"] is False
+        return subprocess.CompletedProcess(cmd, 0, stdout="{}", stderr="")
+
+    monkeypatch.setattr(build_model_images.subprocess, "run", fake_run)
+
+    assert build_model_images.docker_manifest_exists("docker.io/example/image:tag") is True
+
+
+def test_docker_manifest_exists_warns_on_lookup_failure(monkeypatch, capsys) -> None:
+    """Failed manifest checks should stay fail-open while leaving debugging context."""
+
+    def fake_run(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="network unavailable")
+
+    monkeypatch.setattr(build_model_images.subprocess, "run", fake_run)
+
+    assert build_model_images.docker_manifest_exists("docker.io/example/image:missing") is False
+
+    captured = capsys.readouterr()
+    assert "Could not confirm Docker manifest exists for docker.io/example/image:missing" in captured.err
+    assert "network unavailable" in captured.err

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -6,12 +6,19 @@ import pytest
 
 from boileroom.images.import_checks import compute_cuda_versions, iter_image_targets, package_name_to_import_name
 from boileroom.images.metadata import (
+    DEFAULT_DOCKER_REGISTRY,
+    DOCKER_REGISTRY_ENV,
+    MODAL_BASE_IMAGE_REF_ENV,
+    MODAL_IMAGE_TAG_ENV,
     format_image_reference,
     get_default_image_tag,
+    get_docker_registry,
+    get_modal_base_image_reference,
     get_modal_image_tag,
     get_model_image_spec,
     get_supported_cuda,
     published_tags,
+    render_modal_runtime_env,
     resolve_registry_tag,
 )
 
@@ -45,16 +52,52 @@ def test_model_specs_report_supported_cuda_from_config() -> None:
     assert get_supported_cuda(get_model_image_spec("esm")) == ("11.8", "12.6")
 
 
+def test_docker_registry_uses_compiled_default(monkeypatch) -> None:
+    """Registry lookup should fall back to the canonical compiled default."""
+    monkeypatch.delenv(DOCKER_REGISTRY_ENV, raising=False)
+    assert get_docker_registry() == "docker.io/jakublala"
+    assert DEFAULT_DOCKER_REGISTRY == "docker.io/jakublala"
+
+
+def test_docker_registry_uses_env_override(monkeypatch) -> None:
+    """Registry lookup should respect and normalize the environment override."""
+    monkeypatch.setenv(DOCKER_REGISTRY_ENV, " docker.io/example/ ")
+    assert get_docker_registry() == "docker.io/example"
+
+
 def test_modal_tag_uses_env_override(monkeypatch) -> None:
     """Modal image lookups should respect an optional tag override."""
-    monkeypatch.delenv("BOILEROOM_MODAL_IMAGE_TAG", raising=False)
+    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
     assert get_modal_image_tag() == get_default_image_tag()
 
-    monkeypatch.setenv("BOILEROOM_MODAL_IMAGE_TAG", "0.3.0")
+    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "0.3.0")
     assert get_modal_image_tag() == "0.3.0"
 
-    monkeypatch.setenv("BOILEROOM_MODAL_IMAGE_TAG", "cuda12.6")
+    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "cuda12.6")
     assert get_modal_image_tag() == f"cuda12.6-{get_default_image_tag()}"
+
+
+def test_modal_base_image_reference_uses_env_override(monkeypatch) -> None:
+    """Modal base image lookups should respect an optional image reference override."""
+    monkeypatch.setenv(MODAL_BASE_IMAGE_REF_ENV, "docker.io/example/custom-base:1.2.3")
+    assert get_modal_base_image_reference() == "docker.io/example/custom-base:1.2.3"
+
+
+def test_modal_base_image_reference_uses_default_registry(monkeypatch) -> None:
+    """Modal base image lookup should default through the shared image reference formatter."""
+    monkeypatch.delenv(MODAL_BASE_IMAGE_REF_ENV, raising=False)
+    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "0.3.0")
+    assert get_modal_base_image_reference() == "docker.io/jakublala/boileroom-base:0.3.0"
+
+
+def test_modal_runtime_env_includes_image_tag(monkeypatch) -> None:
+    """Model Modal images should receive the tag override inside their container env."""
+    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "sha-test")
+    assert render_modal_runtime_env(get_model_image_spec("chai"), "/models") == {
+        "MODEL_DIR": "/models",
+        MODAL_IMAGE_TAG_ENV: "sha-test",
+        "CHAI_DOWNLOADS_DIR": "/models/chai",
+    }
 
 
 def test_format_image_reference_uses_central_namespace() -> None:


### PR DESCRIPTION
  Updated PR status:

  - The fix is in the Dockerfile, but existing published images still do not contain yaml.
  - The failing tests are expected until the new base image and downstream model images are
    rebuilt and pushed.
  - Once the refreshed images are published, Modal should stop throwing ModuleNotFoundError:
    No module named 'yaml'.

  Short PR summary:

  - Added pyyaml to the shared base image.
  - Propagated the resolved image tag into runtime env so Modal imports work without repo
    metadata.

## Test plan
 - Tests still fail until images are rebuilt with the new base layer.

### Runner logs:

```Runner failed with exception: RuntimeError('Unable to determine the default boileroom image tag. Install boileroom or set BOILEROOM_MODAL_IMAGE_TAG explicitly.')
--
  | [WARN  tini (2)] Tini is not running as PID 1 and isn't registered as a child subreaper. Zombie processes will not be re-parented to Tini, so zombie reaping won't work. To fix the problem, use the -s option or set the environment variable TINI_SUBREAPER to register Tini as a child subreaper, or run Tini as PID 1.
  | Traceback (most recent call last):
  | File "/pkg/modal/_runtime/container_io_manager.py", line 906, in handle_user_exception     yield
  | File "/pkg/modal/_container_entrypoint.py", line 313, in main     service = import_class_service(               ^^^^^^^^^^^^^^^^^^^^^
  | File "/pkg/modal/_runtime/user_code_imports.py", line 523, in import_class_service     module = importlib.import_module(function_def.module_name)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/opt/conda/lib/python3.12/importlib/__init__.py", line 90, in import_module     return _bootstrap._gcd_import(name[level:], package, level)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  | File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  | File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  | File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  | File "<frozen importlib._bootstrap_external>", line 999, in exec_module
  | File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  | File "/root/boileroom/models/boltz/boltz2.py", line 12, in <module>     from .image import boltz_image
  | File "/root/boileroom/models/boltz/image.py", line 5, in <module>     boltz_image = get_modal_image("boltz")                   ^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/root/boileroom/images/modal.py", line 14, in get_modal_image     image = Image.from_registry(format_image_reference(spec.image_name, get_modal_image_tag()))                                                                         ^^^^^^^^^^^^^^^^^^^^^
  | File "/root/boileroom/images/metadata.py", line 185, in get_modal_image_tag     return resolve_registry_tag(os.environ.get(MODAL_IMAGE_TAG_ENV))            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/root/boileroom/images/metadata.py", line 148, in resolve_registry_tag     normalized_tag = normalize_requested_tag(tag)                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  | File "/root/boileroom/images/metadata.py", line 114, in normalize_requested_tag     normalized = (tag or get_default_image_tag()).strip()                          ^^^^^^^^^^^^^^^^^^^^^^^
  | File "/root/boileroom/images/metadata.py", line 106, in get_default_image_tag     raise RuntimeError(
  | RuntimeError: Unable to determine the default boileroom image tag. Install boileroom or set BOILEROOM_MODAL_IMAGE_TAG explicitly.

Once that was fixed the chia container failed with:
Runner failed with exception: ModuleNotFoundError("No module named 'yaml'")
```



## Checklist

- [x] Tests pass (`uv run pytest -n 4`)
- [x] Linting passes (`pre-commit run --all-files`)
- [x] Documentation updated (if needed)
- [x] Version bumped (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker registry is now configurable via `BOILEROOM_DOCKER_REGISTRY` environment variable with sensible defaults
  * Modal base image customizable via `BOILEROOM_MODAL_BASE_IMAGE` environment variable
  * Build script supports `--skip-existing` to skip builds when remote images exist and `--plain-progress` for detailed build output

* **Documentation**
  * Updated guides documenting new environment variable customization options
<!-- end of auto-generated comment: release notes by coderabbit.ai -->