### PR TITLE
fix: free disk space during CI image validation

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -56,21 +56,25 @@ jobs:
         run: |
           uv run python ./scripts/images/build_model_images.py --all-cuda --tag=${{ steps.validation_tag.outputs.value }} --platform=linux/amd64 --push
 
+      - name: Free disk space after build
+        run: |
+          docker builder prune --all --force
+
       - name: Verify canonical validation image imports
         run: |
-          uv run python ./scripts/images/check_model_imports.py --all-cuda --tag=${{ steps.validation_tag.outputs.value }} --pull
+          uv run python ./scripts/images/check_model_imports.py --all-cuda --tag=${{ steps.validation_tag.outputs.value }} --pull --cleanup
 
       - name: Verify canonical validation image server health
         run: |
-          uv run python ./scripts/images/check_model_server_health.py --all-cuda --tag=${{ steps.validation_tag.outputs.value }} --pull
+          uv run python ./scripts/images/check_model_server_health.py --all-cuda --tag=${{ steps.validation_tag.outputs.value }} --pull --cleanup
 
       - name: Verify validation alias image imports
         run: |
-          uv run python ./scripts/images/check_model_imports.py --tag=${{ steps.validation_tag.outputs.value }} --pull
+          uv run python ./scripts/images/check_model_imports.py --tag=${{ steps.validation_tag.outputs.value }} --pull --cleanup
 
       - name: Verify validation alias image server health
         run: |
-          uv run python ./scripts/images/check_model_server_health.py --tag=${{ steps.validation_tag.outputs.value }} --pull
+          uv run python ./scripts/images/check_model_server_health.py --tag=${{ steps.validation_tag.outputs.value }} --pull --cleanup
 
       - name: Promote validated images to version tag
         run: |

--- a/scripts/images/check_model_imports.py
+++ b/scripts/images/check_model_imports.py
@@ -37,7 +37,9 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--all-cuda", action="store_true", help="Validate all supported CUDA variants canonically.")
     parser.add_argument("--pull", action="store_true", help="Pull images before running checks.")
+    parser.add_argument("--cleanup", action="store_true", help="Remove each image after checking to free disk space.")
     return parser.parse_args()
+
 
 def ensure_docker() -> None:
     """Ensure Docker is available."""
@@ -52,12 +54,25 @@ def ensure_docker() -> None:
         raise RuntimeError("Docker is required but was not found on PATH.") from exc
 
 
+def _remove_image(image_reference: str) -> None:
+    """Remove a Docker image to free disk space."""
+    result = subprocess.run(
+        ["docker", "rmi", "--force", image_reference],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        print(f"WARNING: failed to remove image {image_reference}: {result.stderr.decode().strip()}", file=sys.stderr)
+
+
 def check_image(
     image_key: str,
     image_reference: str,
     env_path: Path,
     core_path: Path,
     pull: bool,
+    cleanup: bool = False,
 ) -> None:
     """Run the import smoke test for one image."""
     print(f"Checking imports for {image_key} ({image_reference})")
@@ -154,6 +169,9 @@ for dep in deps:
         check=True,
     )
 
+    if cleanup:
+        _remove_image(image_reference)
+
 
 def main() -> None:
     """Run the import smoke workflow."""
@@ -165,7 +183,7 @@ def main() -> None:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 
     for image_key, image_reference, _display_tag, env_path, core_path in targets:
-        check_image(image_key, image_reference, env_path, core_path, args.pull)
+        check_image(image_key, image_reference, env_path, core_path, args.pull, args.cleanup)
 
     print(f"All module imports succeeded for tag selection: {normalize_requested_tag(args.tag)}")
 

--- a/scripts/images/check_model_imports.py
+++ b/scripts/images/check_model_imports.py
@@ -61,9 +61,11 @@ def _remove_image(image_reference: str) -> None:
         check=False,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
+        text=True,
     )
     if result.returncode != 0:
-        print(f"WARNING: failed to remove image {image_reference}: {result.stderr.decode().strip()}", file=sys.stderr)
+        err = (result.stderr or "").strip()
+        print(f"WARNING: failed to remove image {image_reference}: {err}", file=sys.stderr)
 
 
 def check_image(

--- a/scripts/images/check_model_server_health.py
+++ b/scripts/images/check_model_server_health.py
@@ -38,6 +38,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--all-cuda", action="store_true", help="Validate all supported CUDA variants canonically.")
     parser.add_argument("--pull", action="store_true", help="Pull images before running checks.")
+    parser.add_argument("--cleanup", action="store_true", help="Remove each image after checking to free disk space.")
     parser.add_argument("--timeout", type=float, default=30.0, help="Seconds to wait for each container health check.")
     return parser.parse_args()
 
@@ -80,7 +81,25 @@ def _wait_for_health(port: int, timeout: float) -> None:
     raise RuntimeError(f"Timed out waiting for {url}: {last_error}")
 
 
-def check_server_health(image_key: str, image_reference: str, pull: bool, timeout: float) -> None:
+def _remove_image(image_reference: str) -> None:
+    """Remove a Docker image to free disk space."""
+    result = subprocess.run(
+        ["docker", "rmi", "--force", image_reference],
+        check=False,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    if result.returncode != 0:
+        print(f"WARNING: failed to remove image {image_reference}: {result.stderr.decode().strip()}", file=sys.stderr)
+
+
+def check_server_health(
+    image_key: str,
+    image_reference: str,
+    pull: bool,
+    timeout: float,
+    cleanup: bool = False,
+) -> None:
     """Run the server /health smoke test for one image."""
     print(f"Checking server health for {image_key} ({image_reference})")
 
@@ -146,6 +165,9 @@ def check_server_health(image_key: str, image_reference: str, pull: bool, timeou
             stderr=subprocess.DEVNULL,
         )
 
+    if cleanup:
+        _remove_image(image_reference)
+
 
 def main() -> None:
     """Run the server health-smoke workflow."""
@@ -157,7 +179,7 @@ def main() -> None:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 
     for image_key, image_reference, _display_tag, _env_path, _core_path in targets:
-        check_server_health(image_key, image_reference, args.pull, args.timeout)
+        check_server_health(image_key, image_reference, args.pull, args.timeout, args.cleanup)
 
     print(f"All server health checks succeeded for tag selection: {normalize_requested_tag(args.tag)}")
 

--- a/scripts/images/check_model_server_health.py
+++ b/scripts/images/check_model_server_health.py
@@ -88,9 +88,11 @@ def _remove_image(image_reference: str) -> None:
         check=False,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.PIPE,
+        text=True,
     )
     if result.returncode != 0:
-        print(f"WARNING: failed to remove image {image_reference}: {result.stderr.decode().strip()}", file=sys.stderr)
+        err = (result.stderr or "").strip()
+        print(f"WARNING: failed to remove image {image_reference}: {err}", file=sys.stderr)
 
 
 def check_server_health(


### PR DESCRIPTION
## Summary
- Add `--cleanup` flag to `check_model_imports.py` and `check_model_server_health.py` that removes each Docker image after validation passes, keeping only one image on disk at a time
- Prune buildx builder cache after the build step to reclaim space before validation pulls begin
- Fixes the `no space left on device` failure on the `main` branch build-docker-images workflow (run [24099322354](https://github.com/softnanolab/boileroom/actions/runs/24099322354))

## Test plan
- [ ] CI `Build and Push Boileroom Images` workflow completes without disk space errors
- [ ] Promote step succeeds (uses remote registry, unaffected by local cleanup)
- [ ] Validation scripts still work without `--cleanup` (opt-in flag, no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--cleanup` flag to image validation scripts for optional Docker image removal after testing.

* **Chores**
  * Updated build pipeline to automatically prune Docker images following validation builds.
  * Enhanced image verification commands with cleanup options during validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->