### PR TITLE
Speed up pushed image builds with registry cache

### DIFF
--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -27,6 +27,7 @@ uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=sha
 ```
 
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
+Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.
 
 ### 🔖 Tag policy
 - Docker Hub is kept clean for users. The long-lived public tags are version tags such as `0.3.0` and the corresponding CUDA-qualified tags such as `cuda12.6-0.3.0` and `cuda11.8-0.3.0`.
@@ -119,7 +120,7 @@ GitHub Actions at `.github/workflows/build-docker-images.yml` now drives the rel
 - The promoted Docker tags therefore track the Python package version declared in `pyproject.toml`, even though PyPI publication is handled separately.
 - Each successful run publishes canonical CUDA-qualified tags and the unqualified version alias for the default `12.6` line.
 - The official release path currently publishes `linux/amd64` only. If you want to experiment with additional architectures, pass an explicit multi-platform `--platform` value and validate it separately before treating it as supported.
-- Future merges inherit the cache layers thanks to BuildKit, keeping CI times reasonable.
+- Future merges inherit dependency cache layers through BuildKit registry caches, keeping CI times reasonable even on fresh GitHub-hosted runners.
 - PyPI is not published by this workflow. Python package publication happens later from the GitHub release workflow, so Docker Hub can be used as the earlier staged release channel.
 
 ### 🧱 Convert Docker images to Apptainer (SIF)

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -19,6 +19,7 @@ from boileroom.images.metadata import (  # noqa: E402
     BASE_IMAGE_SPEC,
     CUDA_MICROMAMBA_BASE,
     CUDA_TORCH_WHEEL_INDEX,
+    DOCKER_REGISTRY,
     MODEL_IMAGE_SPECS,
     RuntimeImageSpec,
     get_supported_cuda,
@@ -71,6 +72,34 @@ def log_warn(message: str) -> None:
 
 def log_error(message: str) -> None:
     print(Colors.wrap(message, Colors.red), file=sys.stderr)
+
+
+def build_cache_reference(image_name: str, cuda_version: str) -> str:
+    """Return the stable registry cache reference for a build output."""
+    return f"{DOCKER_REGISTRY}/{image_name}:buildcache-cuda{cuda_version}"
+
+
+def append_registry_cache_args(
+    cmd: list[str],
+    image_name: str,
+    cuda_version: str,
+    *,
+    push: bool,
+    no_cache: bool,
+) -> None:
+    """Add BuildKit registry cache flags for pushed buildx builds."""
+    if not push or no_cache:
+        return
+
+    cache_reference = build_cache_reference(image_name, cuda_version)
+    cmd.extend(
+        [
+            "--cache-from",
+            f"type=registry,ref={cache_reference}",
+            "--cache-to",
+            f"type=registry,ref={cache_reference},mode=max",
+        ]
+    )
 
 
 def run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
@@ -286,6 +315,13 @@ def build_base(
             "--build-arg",
             f"MICROMAMBA_BASE={micromamba_base}",
         ]
+        append_registry_cache_args(
+            cmd,
+            BASE_IMAGE_SPEC.image_name,
+            cuda_version,
+            push=output_flag == "--push",
+            no_cache=no_cache,
+        )
     for image_reference in image_references:
         cmd.extend(["-t", image_reference])
     cmd.extend(["-f", str(BASE_IMAGE_SPEC.dockerfile_path), str(BASE_IMAGE_SPEC.context_path)])
@@ -336,6 +372,13 @@ def build_model(
             "--build-arg",
             f"TORCH_WHEEL_INDEX={CUDA_TORCH_WHEEL_INDEX[task.cuda_version]}",
         ]
+        append_registry_cache_args(
+            cmd,
+            task.image_spec.image_name,
+            task.cuda_version,
+            push=output_flag == "--push",
+            no_cache=no_cache,
+        )
     for image_reference in image_references:
         cmd.extend(["-t", image_reference])
     cmd.extend(["-f", str(task.image_spec.dockerfile_path), str(task.image_spec.context_path)])

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -1,0 +1,56 @@
+"""Fast contract tests for Docker image build helpers."""
+
+from pathlib import Path
+
+from scripts.images import build_model_images
+
+
+def test_build_base_push_uses_registry_cache(monkeypatch, tmp_path) -> None:
+    """Pushed buildx builds should import and export stable registry cache layers."""
+    calls: list[tuple[list[str], Path | None, bool]] = []
+
+    def fake_run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
+        calls.append((cmd, log_file, echo))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(build_model_images, "run", fake_run)
+
+    build_model_images.build_base(
+        "12.6",
+        "sha-test",
+        "linux/amd64",
+        "--push",
+        no_cache=False,
+        use_local_docker_build=False,
+    )
+
+    cmd, _, _ = calls[0]
+    assert "--cache-from" in cmd
+    assert "type=registry,ref=docker.io/jakublala/boileroom-base:buildcache-cuda12.6" in cmd
+    assert "--cache-to" in cmd
+    assert "type=registry,ref=docker.io/jakublala/boileroom-base:buildcache-cuda12.6,mode=max" in cmd
+
+
+def test_build_base_no_cache_disables_registry_cache(monkeypatch, tmp_path) -> None:
+    """Explicit no-cache builds should not import or export BuildKit registry cache."""
+    calls: list[tuple[list[str], Path | None, bool]] = []
+
+    def fake_run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
+        calls.append((cmd, log_file, echo))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(build_model_images, "run", fake_run)
+
+    build_model_images.build_base(
+        "12.6",
+        "sha-test",
+        "linux/amd64",
+        "--push",
+        no_cache=True,
+        use_local_docker_build=False,
+    )
+
+    cmd, _, _ = calls[0]
+    assert "--no-cache" in cmd
+    assert "--cache-from" not in cmd
+    assert "--cache-to" not in cmd

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -54,3 +54,62 @@ def test_build_base_no_cache_disables_registry_cache(monkeypatch, tmp_path) -> N
     assert "--no-cache" in cmd
     assert "--cache-from" not in cmd
     assert "--cache-to" not in cmd
+
+
+def test_build_model_push_uses_registry_cache(monkeypatch, tmp_path) -> None:
+    """Pushed model buildx builds should import and export stable registry cache layers."""
+    calls: list[tuple[list[str], Path | None, bool]] = []
+
+    def fake_run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
+        calls.append((cmd, log_file, echo))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(build_model_images, "run", fake_run)
+
+    build_model_images.build_model(
+        build_model_images.BuildTask(
+            cuda_version="12.6",
+            image_spec=build_model_images.MODEL_IMAGE_SPECS[0],
+            base_image_reference="docker.io/jakublala/boileroom-base:cuda12.6-sha-test",
+            tag="sha-test",
+        ),
+        "linux/amd64",
+        "--push",
+        no_cache=False,
+        use_local_docker_build=False,
+    )
+
+    cmd, _, _ = calls[0]
+    assert "--cache-from" in cmd
+    assert "type=registry,ref=docker.io/jakublala/boileroom-boltz:buildcache-cuda12.6" in cmd
+    assert "--cache-to" in cmd
+    assert "type=registry,ref=docker.io/jakublala/boileroom-boltz:buildcache-cuda12.6,mode=max" in cmd
+
+
+def test_build_model_no_cache_disables_registry_cache(monkeypatch, tmp_path) -> None:
+    """Explicit no-cache model builds should not import or export BuildKit registry cache."""
+    calls: list[tuple[list[str], Path | None, bool]] = []
+
+    def fake_run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
+        calls.append((cmd, log_file, echo))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(build_model_images, "run", fake_run)
+
+    build_model_images.build_model(
+        build_model_images.BuildTask(
+            cuda_version="12.6",
+            image_spec=build_model_images.MODEL_IMAGE_SPECS[0],
+            base_image_reference="docker.io/jakublala/boileroom-base:cuda12.6-sha-test",
+            tag="sha-test",
+        ),
+        "linux/amd64",
+        "--push",
+        no_cache=True,
+        use_local_docker_build=False,
+    )
+
+    cmd, _, _ = calls[0]
+    assert "--no-cache" in cmd
+    assert "--cache-from" not in cmd
+    assert "--cache-to" not in cmd


### PR DESCRIPTION
## Summary

Fixes #57.

This adds BuildKit registry cache import/export flags for pushed Docker Buildx builds. Each image now gets a stable per-CUDA cache reference such as `boileroom-chai1:buildcache-cuda12.6`, allowing fresh GitHub Actions runners to reuse unchanged dependency layers across validation tags and releases.

The change keeps `--no-cache` strict by skipping registry cache flags when that option is used.

## Validation

- `uv run pytest tests/contracts/test_build_model_images.py tests/contracts/test_image_metadata.py`
- `git diff --check --cached`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to specify how multi-platform Docker builds create and publish stable registry caches that improve dependency layer reuse across releases
  * Documented the `--no-cache` flag for bypassing caches
  * Clarified that dependency caching improves CI performance even on fresh build environments

* **Tests**
  * Added contract tests to validate registry cache behavior in build scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
