### PR TITLE
[codex] Use pyproject as release version anchor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 .venv/
 dist/
 .cursor/
+.idea/
 .claude/
 script.py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boileroom"
+# Release automation treats this as the base release line. Change it only
+# when starting a new minor line; CI derives patch versions automatically.
 version = "0.3.0"
 authors = [
     { name="Jakub Lála", email="jakublala@gmail.com" },

--- a/scripts/ci/derive_version.py
+++ b/scripts/ci/derive_version.py
@@ -5,13 +5,12 @@ from __future__ import annotations
 import argparse
 import re
 import subprocess
+import tomllib
 from pathlib import Path
 
-MAIN_VERSION_MAJOR = 0
-MAIN_VERSION_MINOR = 3
-MAIN_VERSION_BASE_PATCH = 0
 MAIN_VERSION_BASE_SHA = "48e8a23fbde63e95a0e39fe0d5748c3f338b30b3"
-RELEASE_TAG_PATTERN = re.compile(r"^(?P<version>0\.3\.\d+)$")
+DEFAULT_PYPROJECT_PATH = Path(__file__).resolve().parents[2] / "pyproject.toml"
+VERSION_PATTERN = re.compile(r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$")
 
 
 def run_git(args: list[str]) -> str:
@@ -20,25 +19,42 @@ def run_git(args: list[str]) -> str:
     return result.stdout.strip()
 
 
-def main_patch_for_head(head_ref: str = "HEAD") -> int:
+def pyproject_version(path: Path = DEFAULT_PYPROJECT_PATH) -> str:
+    """Return the static project version from ``pyproject.toml``."""
+    return tomllib.loads(path.read_text(encoding="utf-8"))["project"]["version"].strip()
+
+
+def parse_version(version: str) -> tuple[int, int, int]:
+    """Return integer major, minor, and patch components for a simple version."""
+    match = VERSION_PATTERN.fullmatch(version)
+    if match is None:
+        raise ValueError(f"Expected a version like 0.3.0, got {version!r}.")
+    return int(match.group("major")), int(match.group("minor")), int(match.group("patch"))
+
+
+def main_patch_for_head(head_ref: str = "HEAD", base_patch: int | None = None) -> int:
     """Return the patch version offset for ``head_ref`` on the main release line."""
     commit_count = run_git(["rev-list", "--count", f"{MAIN_VERSION_BASE_SHA}..{head_ref}"])
-    return MAIN_VERSION_BASE_PATCH + int(commit_count)
+    if base_patch is None:
+        base_patch = parse_version(pyproject_version())[2]
+    return base_patch + int(commit_count)
 
 
-def main_version(head_ref: str = "HEAD") -> str:
+def main_version(head_ref: str = "HEAD", base_version: str | None = None) -> str:
     """Return the PEP 440 version for ``head_ref`` on the main release line."""
-    patch = main_patch_for_head(head_ref)
-    return f"{MAIN_VERSION_MAJOR}.{MAIN_VERSION_MINOR}.{patch}"
+    major, minor, base_patch = parse_version(base_version or pyproject_version())
+    patch = main_patch_for_head(head_ref, base_patch)
+    return f"{major}.{minor}.{patch}"
 
 
-def version_from_release_tag(tag: str) -> str:
+def version_from_release_tag(tag: str, base_version: str | None = None) -> str:
     """Return a PEP 440 version from a release tag such as ``0.3.7``."""
     normalized = tag.removeprefix("refs/tags/")
-    match = RELEASE_TAG_PATTERN.fullmatch(normalized)
-    if match is None:
-        raise ValueError(f"Expected a release tag like 0.3.x, got {tag!r}.")
-    return match.group("version")
+    base_major, base_minor, _ = parse_version(base_version or pyproject_version())
+    release_major, release_minor, _ = parse_version(normalized)
+    if (release_major, release_minor) != (base_major, base_minor):
+        raise ValueError(f"Expected a release tag like {base_major}.{base_minor}.x, got {tag!r}.")
+    return normalized
 
 
 def write_pyproject_version(path: Path, version: str) -> None:
@@ -61,6 +77,12 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--head-ref", default="HEAD", help="Git ref to version. Defaults to HEAD.")
     parser.add_argument("--release-tag", help="Release tag to normalize, for example 0.3.7.")
+    parser.add_argument(
+        "--base-pyproject",
+        type=Path,
+        default=DEFAULT_PYPROJECT_PATH,
+        help="Path to the pyproject.toml version anchor. Defaults to the repository pyproject.toml.",
+    )
     parser.add_argument("--write-pyproject", type=Path, help="Optional pyproject.toml path to update.")
     parser.add_argument(
         "--github-output",
@@ -73,7 +95,12 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     """CLI entrypoint."""
     args = parse_args()
-    version = version_from_release_tag(args.release_tag) if args.release_tag else main_version(args.head_ref)
+    base_version = pyproject_version(args.base_pyproject)
+    version = (
+        version_from_release_tag(args.release_tag, base_version)
+        if args.release_tag
+        else main_version(args.head_ref, base_version)
+    )
     if args.write_pyproject is not None:
         write_pyproject_version(args.write_pyproject, version)
     if args.github_output is not None:

--- a/tests/contracts/test_derive_version.py
+++ b/tests/contracts/test_derive_version.py
@@ -19,6 +19,26 @@ def test_main_version_uses_commit_count_after_baseline(monkeypatch) -> None:
     assert derive_version.main_version() == "0.3.7"
 
 
+def test_main_version_uses_pyproject_version_as_release_line(monkeypatch) -> None:
+    """The pyproject version should be the only maintained release-line version."""
+
+    def fake_run_git(args: list[str]) -> str:
+        assert args == ["rev-list", "--count", f"{derive_version.MAIN_VERSION_BASE_SHA}..HEAD"]
+        return "7"
+
+    monkeypatch.setattr(derive_version, "run_git", fake_run_git)
+
+    assert derive_version.main_version(base_version="0.4.2") == "0.4.9"
+
+
+def test_pyproject_version_reads_project_version(tmp_path) -> None:
+    """The derivation script should read the static pyproject anchor."""
+    pyproject_path = tmp_path / "pyproject.toml"
+    pyproject_path.write_text('[project]\nname = "boileroom"\nversion = "0.4.2"\n', encoding="utf-8")
+
+    assert derive_version.pyproject_version(pyproject_path) == "0.4.2"
+
+
 def test_github_output_includes_pep440_version(tmp_path) -> None:
     """GitHub Actions should receive the package-compatible version."""
     output_path = tmp_path / "github-output.txt"
@@ -30,15 +50,22 @@ def test_github_output_includes_pep440_version(tmp_path) -> None:
 
 def test_version_from_release_tag_accepts_plain_version_tag() -> None:
     """Release tags should become package-compatible versions."""
-    assert derive_version.version_from_release_tag("0.3.9") == "0.3.9"
-    assert derive_version.version_from_release_tag("refs/tags/0.3.10") == "0.3.10"
+    assert derive_version.version_from_release_tag("0.3.9", "0.3.0") == "0.3.9"
+    assert derive_version.version_from_release_tag("refs/tags/0.3.10", "0.3.0") == "0.3.10"
 
 
-@pytest.mark.parametrize("tag", ["", "main", "refs/heads/main", "v0.3.1", "0.3", "0.3.x"])
+@pytest.mark.parametrize("tag", ["0.2.1", "0.4.1"])
 def test_version_from_release_tag_rejects_invalid_inputs(tag: str) -> None:
     """Invalid release tags should fail fast."""
     with pytest.raises(ValueError, match="Expected a release tag like 0.3.x"):
-        derive_version.version_from_release_tag(tag)
+        derive_version.version_from_release_tag(tag, "0.3.0")
+
+
+@pytest.mark.parametrize("tag", ["", "main", "refs/heads/main", "v0.3.1", "0.3", "0.3.x"])
+def test_version_from_release_tag_rejects_malformed_inputs(tag: str) -> None:
+    """Malformed release tags should fail fast."""
+    with pytest.raises(ValueError, match="Expected a version like 0.3.0"):
+        derive_version.version_from_release_tag(tag, "0.3.0")
 
 
 def test_write_pyproject_version_replaces_static_project_version(tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Read the release-line base version from `pyproject.toml` in `derive_version.py`.
- Keep commit-count patch derivation intact while removing duplicated major/minor constants from the script.
- Document `pyproject.toml` as the release-line anchor so future changes know to update it only when starting a new minor line.
- Ignore local `.idea/` project files.
- Add contract coverage for reading the pyproject anchor, deriving from alternate release lines, and validating release tags.

## Why
Maintaining the release line in both `pyproject.toml` and `scripts/ci/derive_version.py` adds avoidable release overhead. This makes `pyproject.toml` the single maintained anchor, so future release-line bumps only need one source edit unless the commit-count baseline is intentionally reset.

## Publishing behavior
- `pyproject.toml` remains at the base release-line version, for example `0.3.0`; it is not expected to change for every derived patch release.
- Docker publishing derives patch versions only from commits on `main`. The image publishing workflow runs on `push` to `main` and also exits unless `GITHUB_REF` is `refs/heads/main`.
- PR branches can compute a branch-local derived version when tests or local commands call `derive_version.py`, but those values are not promoted or published.
- PyPI publication runs from GitHub Releases. The release workflow takes the GitHub release tag, writes that version into `pyproject.toml` inside the CI runner, then builds and publishes the artifact.

Closes #65.

## Validation
- `uv run pytest tests/contracts/test_derive_version.py`
- `uv run python scripts/ci/derive_version.py` confirmed the expected derived version for the checked-out branch context
