### PR TITLE
Allow overriding the Docker image repository

### DIFF
--- a/boileroom/images/Dockerfile
+++ b/boileroom/images/Dockerfile
@@ -22,6 +22,7 @@ RUN micromamba install -y -c conda-forge python=3.12 pip \
     && python -m pip install --upgrade pip
 
 ENV MODEL_DIR=/mnt/models
+ENV TINI_SUBREAPER=1
 ENV PATH=/opt/conda/bin:${PATH}
 
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/boileroom/images/base.py
+++ b/boileroom/images/base.py
@@ -2,6 +2,6 @@
 
 from modal import Image
 
-from .metadata import BASE_IMAGE_SPEC, format_image_reference, get_modal_image_tag
+from .metadata import get_modal_base_image_reference
 
-base_image = Image.from_registry(format_image_reference(BASE_IMAGE_SPEC.image_name, get_modal_image_tag()))
+base_image = Image.from_registry(get_modal_base_image_reference())

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -11,12 +11,13 @@ from functools import cache
 from pathlib import Path
 from typing import Final
 
-import yaml
-
-DOCKER_REGISTRY: Final = "docker.io/jakublala"
+DEFAULT_DOCKER_REPOSITORY: Final = "docker.io/jakublala"
+DOCKER_REGISTRY: Final = DEFAULT_DOCKER_REPOSITORY
 PACKAGE_NAME: Final = "boileroom"
 DEFAULT_CUDA_VERSION: Final = "12.6"
+DOCKER_REPOSITORY_ENV: Final = "BOILEROOM_DOCKER_REPOSITORY"
 MODAL_IMAGE_TAG_ENV: Final = "BOILEROOM_MODAL_IMAGE_TAG"
+MODAL_BASE_IMAGE_REF_ENV: Final = "BOILEROOM_MODAL_BASE_IMAGE"
 
 CUDA_MICROMAMBA_BASE: Final[dict[str, str]] = {
     "11.8": "mambaorg/micromamba:2.4-cuda11.8.0-ubuntu22.04",
@@ -167,22 +168,44 @@ def published_tags(cuda_version: str, tag: str | None) -> tuple[str, ...]:
     return tuple(tags)
 
 
+def get_docker_repository() -> str:
+    """Return the Docker repository namespace for published runtime images."""
+    override = os.environ.get(DOCKER_REPOSITORY_ENV)
+    if override is None or not override.strip():
+        return DEFAULT_DOCKER_REPOSITORY
+
+    repository = override.strip()
+    if not repository.startswith("docker.io/") or repository.endswith("/"):
+        raise ValueError(f"{DOCKER_REPOSITORY_ENV} must use the form 'docker.io/<repository>'.")
+    return repository
+
+
 def format_image_reference(image_name: str, tag: str | None = None) -> str:
     """Return a fully qualified Docker image reference."""
     resolved_tag = resolve_registry_tag(tag)
-    return f"{DOCKER_REGISTRY}/{image_name}:{resolved_tag}"
+    return f"{get_docker_repository()}/{image_name}:{resolved_tag}"
 
 
 def published_image_references(image_name: str, cuda_version: str, tag: str | None) -> tuple[str, ...]:
     """Return all published references for a built image."""
     return tuple(
-        f"{DOCKER_REGISTRY}/{image_name}:{published_tag}" for published_tag in published_tags(cuda_version, tag)
+        f"{get_docker_repository()}/{image_name}:{published_tag}" for published_tag in published_tags(cuda_version, tag)
     )
 
 
 def get_modal_image_tag() -> str:
     """Return the tag Modal should pull from the registry."""
     return resolve_registry_tag(os.environ.get(MODAL_IMAGE_TAG_ENV))
+
+
+def get_modal_base_image_reference() -> str:
+    """Return the base image Modal should use for the shared runtime layer."""
+    override = os.environ.get(MODAL_BASE_IMAGE_REF_ENV)
+    if override:
+        normalized = override.strip()
+        if normalized:
+            return normalized
+    return format_image_reference(BASE_IMAGE_SPEC.image_name, get_modal_image_tag())
 
 
 def get_model_image_spec(identifier: str) -> RuntimeImageSpec:
@@ -203,6 +226,8 @@ def get_supported_cuda(spec: RuntimeImageSpec) -> tuple[str, ...]:
     config_path = get_repo_root() / spec.config_relative_path
     if not config_path.exists():
         return tuple(sorted(CUDA_MICROMAMBA_BASE))
+
+    import yaml
 
     config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
     raw_supported_cuda = config.get("supported_cuda", [])

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -175,7 +175,13 @@ def get_docker_repository() -> str:
         return DEFAULT_DOCKER_REPOSITORY
 
     repository = override.strip()
-    if not repository.startswith("docker.io/") or repository.endswith("/"):
+    if (
+        re.fullmatch(
+            r"docker\.io/(?:[a-z0-9]+(?:[._-][a-z0-9]+)*)(?:/(?:[a-z0-9]+(?:[._-][a-z0-9]+)*))*",
+            repository,
+        )
+        is None
+    ):
         raise ValueError(f"{DOCKER_REPOSITORY_ENV} must use the form 'docker.io/<repository>'.")
     return repository
 

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -245,7 +245,13 @@ def get_supported_cuda(spec: RuntimeImageSpec) -> tuple[str, ...]:
 
 def render_modal_runtime_env(spec: RuntimeImageSpec, model_dir: str) -> dict[str, str]:
     """Render runtime environment overrides for Modal."""
-    env = {"MODEL_DIR": model_dir}
+    env = {
+        "MODEL_DIR": model_dir,
+        DOCKER_REPOSITORY_ENV: get_docker_repository(),
+        MODAL_IMAGE_TAG_ENV: get_modal_image_tag(),
+    }
+    if (override := os.environ.get(MODAL_BASE_IMAGE_REF_ENV)) and (normalized := override.strip()):
+        env[MODAL_BASE_IMAGE_REF_ENV] = normalized
     for key, value in spec.modal_runtime_env:
         env[key] = value.replace("{MODEL_DIR}", model_dir)
     return env

--- a/boileroom/models/boltz/core.py
+++ b/boileroom/models/boltz/core.py
@@ -8,7 +8,7 @@ import logging
 import os
 import shutil
 from collections.abc import Iterator, Sequence
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any, ClassVar, cast
@@ -351,7 +351,7 @@ class Boltz2Core(FoldingAlgorithm):
                 index = cast(dict[str, dict[str, Any]], index)
                 cached_paths: dict[str, Path] = {}
                 index_updated = False
-                now = datetime.utcnow().isoformat()
+                now = datetime.now(UTC).isoformat()
 
                 for sequence in sequences:
                     seq_hash = self._get_sequence_hash(sequence)
@@ -434,7 +434,7 @@ class Boltz2Core(FoldingAlgorithm):
             # Update index under lock so concurrent writers cannot clobber entries.
             with self._locked_msa_cache_index() as index:
                 index = cast(dict[str, dict[str, Any]], index)
-                now = datetime.utcnow().isoformat()
+                now = datetime.now(UTC).isoformat()
                 relative_path = f"{seq_hash[:2]}/{seq_hash[2:4]}/{seq_hash}.csv"
                 index[seq_hash] = {
                     "msa_path": relative_path,

--- a/boileroom/models/chai/environment.yml
+++ b/boileroom/models/chai/environment.yml
@@ -15,3 +15,4 @@ dependencies:
     - fastapi
     - uvicorn
     - pydantic
+    - typing_extensions>=4.15.0

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -34,6 +34,13 @@ export BOILEROOM_DOCKER_REPOSITORY=docker.io/my-dockerhub-user
 
 The same variable is used by Modal and Apptainer image lookups, so pytest runs that import Modal wrappers will pull from the same repository override. `BOILEROOM_MODAL_IMAGE_TAG` still controls only the tag.
 
+For Modal pytest runs against images in a custom namespace, set both values:
+
+```bash
+export BOILEROOM_DOCKER_REPOSITORY=docker.io/my-dockerhub-user
+export BOILEROOM_MODAL_IMAGE_TAG=0.3.0
+```
+
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
 Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.
 

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -26,6 +26,14 @@ uv run python scripts/images/build_model_images.py --all-cuda --tag=0.3.0 --push
 uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=sha-$(git rev-parse --short HEAD) --push ...
 ```
 
+Images publish to `docker.io/jakublala` by default. Set `BOILEROOM_DOCKER_REPOSITORY` to build and run against another namespace:
+
+```bash
+export BOILEROOM_DOCKER_REPOSITORY=docker.io/my-dockerhub-user
+```
+
+The same variable is used by Modal and Apptainer image lookups, so pytest runs that import Modal wrappers will pull from the same repository override. `BOILEROOM_MODAL_IMAGE_TAG` still controls only the tag.
+
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
 Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.
 

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -19,9 +19,9 @@ from boileroom.images.metadata import (  # noqa: E402
     BASE_IMAGE_SPEC,
     CUDA_MICROMAMBA_BASE,
     CUDA_TORCH_WHEEL_INDEX,
-    DOCKER_REGISTRY,
     MODEL_IMAGE_SPECS,
     RuntimeImageSpec,
+    get_docker_repository,
     get_supported_cuda,
     normalize_cuda_version,
     normalize_requested_tag,
@@ -76,7 +76,7 @@ def log_error(message: str) -> None:
 
 def build_cache_reference(image_name: str, cuda_version: str) -> str:
     """Return the stable registry cache reference for a build output."""
-    return f"{DOCKER_REGISTRY}/{image_name}:buildcache-cuda{cuda_version}"
+    return f"{get_docker_repository()}/{image_name}:buildcache-cuda{cuda_version}"
 
 
 def append_registry_cache_args(
@@ -437,6 +437,7 @@ def main() -> None:
         )
 
     log_info(Colors.wrap(f"Boileroom repo root: {REPO_ROOT}", Colors.magenta))
+    log_info(f"Docker repository: {get_docker_repository()}")
     log_info(f"Model images: {', '.join(spec.image_name for spec in MODEL_IMAGE_SPECS)}")
     log_info(f"CUDA versions: {', '.join(cuda_versions)}")
     log_info(f"Platforms: {args.platform}")

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -58,6 +58,14 @@ def test_build_base_no_cache_disables_registry_cache(monkeypatch, tmp_path) -> N
     assert "--cache-to" not in cmd
 
 
+def test_build_cache_reference_uses_repository_env(monkeypatch) -> None:
+    """Build cache tags should follow the same repository override as image tags."""
+    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
+    assert build_model_images.build_cache_reference("boileroom-base", "12.6") == (
+        "docker.io/example/boileroom-base:buildcache-cuda12.6"
+    )
+
+
 def test_parse_args_exposes_skip_controls(monkeypatch) -> None:
     """The build helper should accept the documented skip flags."""
     monkeypatch.setattr(

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -97,6 +97,22 @@ def test_docker_repository_rejects_partial_or_non_docker_io_override(monkeypatch
         get_docker_repository()
 
 
+@pytest.mark.parametrize(
+    ("override", "label"),
+    [
+        ("docker.io/Example", "uppercase"),
+        ("docker.io/example repo", "spaces"),
+        ("docker.io/example//repo", "double slash"),
+        ("docker.io/example/", "trailing slash"),
+    ],
+)
+def test_docker_repository_rejects_malformed_docker_io_override(monkeypatch, override: str, label: str) -> None:
+    """Repository overrides should reject malformed Docker Hub namespaces."""
+    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", override)
+    with pytest.raises(ValueError, match="BOILEROOM_DOCKER_REPOSITORY"):
+        get_docker_repository()
+
+
 def test_format_image_reference_uses_central_namespace() -> None:
     """All runtime image references should use the central Docker namespace."""
     assert format_image_reference("boileroom-boltz", None) == (

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -8,6 +8,8 @@ from boileroom.images.import_checks import compute_cuda_versions, iter_image_tar
 from boileroom.images.metadata import (
     format_image_reference,
     get_default_image_tag,
+    get_docker_repository,
+    get_modal_base_image_reference,
     get_modal_image_tag,
     get_model_image_spec,
     get_supported_cuda,
@@ -55,6 +57,30 @@ def test_modal_tag_uses_env_override(monkeypatch) -> None:
 
     monkeypatch.setenv("BOILEROOM_MODAL_IMAGE_TAG", "cuda12.6")
     assert get_modal_image_tag() == f"cuda12.6-{get_default_image_tag()}"
+
+
+def test_modal_base_image_reference_uses_env_override(monkeypatch) -> None:
+    """Modal base image lookups should respect an optional image reference override."""
+    monkeypatch.setenv("BOILEROOM_MODAL_BASE_IMAGE", "docker.io/example/custom-base:1.2.3")
+    assert get_modal_base_image_reference() == "docker.io/example/custom-base:1.2.3"
+
+
+def test_docker_repository_uses_env_override(monkeypatch) -> None:
+    """Image references should support a shared Docker repository override."""
+    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
+    assert get_docker_repository() == "docker.io/example"
+    assert format_image_reference("boileroom-boltz", "0.3.0") == "docker.io/example/boileroom-boltz:0.3.0"
+
+
+def test_docker_repository_rejects_partial_or_non_docker_io_override(monkeypatch) -> None:
+    """Repository overrides should use the same full Docker Hub namespace format as the default."""
+    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "example")
+    with pytest.raises(ValueError, match="BOILEROOM_DOCKER_REPOSITORY"):
+        get_docker_repository()
+
+    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "ghcr.io/example")
+    with pytest.raises(ValueError, match="BOILEROOM_DOCKER_REPOSITORY"):
+        get_docker_repository()
 
 
 def test_format_image_reference_uses_central_namespace() -> None:

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -14,6 +14,7 @@ from boileroom.images.metadata import (
     get_model_image_spec,
     get_supported_cuda,
     published_tags,
+    render_modal_runtime_env,
     resolve_registry_tag,
 )
 
@@ -63,6 +64,19 @@ def test_modal_base_image_reference_uses_env_override(monkeypatch) -> None:
     """Modal base image lookups should respect an optional image reference override."""
     monkeypatch.setenv("BOILEROOM_MODAL_BASE_IMAGE", "docker.io/example/custom-base:1.2.3")
     assert get_modal_base_image_reference() == "docker.io/example/custom-base:1.2.3"
+
+
+def test_modal_runtime_env_carries_image_lookup_overrides(monkeypatch) -> None:
+    """Modal containers should re-import wrappers with the same resolved image lookup settings."""
+    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
+    monkeypatch.setenv("BOILEROOM_MODAL_IMAGE_TAG", "0.3.0.1")
+    monkeypatch.setenv("BOILEROOM_MODAL_BASE_IMAGE", "docker.io/example/boileroom-base:0.3.0.1")
+
+    env = render_modal_runtime_env(get_model_image_spec("boltz"), "/mnt/models")
+
+    assert env["BOILEROOM_DOCKER_REPOSITORY"] == "docker.io/example"
+    assert env["BOILEROOM_MODAL_IMAGE_TAG"] == "0.3.0.1"
+    assert env["BOILEROOM_MODAL_BASE_IMAGE"] == "docker.io/example/boileroom-base:0.3.0.1"
 
 
 def test_docker_repository_uses_env_override(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Add BOILEROOM_DOCKER_REPOSITORY as a shared Docker Hub namespace override for runtime image references.
- Apply the override to build outputs, registry cache references, Modal image loading, and Apptainer image references through the shared metadata helpers.
- Propagate resolved Modal image lookup settings into Modal containers so remote wrapper re-imports do not fall back to package metadata.
- Reduce Docker integration runtime warnings by enabling tini subreaper mode, using timezone-aware Boltz cache timestamps, and pinning Chai typing_extensions support.
- Document the required docker.io/<repository> format and add contract coverage for valid and invalid override values.

## Validation
- uv run pytest tests/contracts/test_image_metadata.py tests/contracts/test_build_model_images.py
- uv run pre-commit run --all-files

Closes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for overriding the default Docker repository namespace via env config.
  * Support for overriding the Modal base image reference.
  * Docker image now sets TINI_SUBREAPER=1 to adjust init-process behavior.

* **Documentation**
  * Guidance added for customizing Docker namespaces and Modal image tags.

* **Bug Fixes**
  * Cache timestamps now use timezone-aware ISO-8601 format.

* **Chores**
  * Added typing_extensions dependency.

* **Tests**
  * New contract tests for repository and Modal image override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->