### PR TITLE
ci: speed up docker image publishing workflow

### DIFF
--- a/.github/workflows/arm64-image-smoke.yml
+++ b/.github/workflows/arm64-image-smoke.yml
@@ -3,8 +3,6 @@ name: ARM64 Image Smoke
 on:
   pull_request:
     branches: [ main ]
-  push:
-    branches: [ main ]
   workflow_dispatch:
 
 permissions:
@@ -34,10 +32,19 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
+      - name: Determine default CUDA version
+        id: image_metadata
+        run: |
+          uv run python - <<'PY' >> "$GITHUB_OUTPUT"
+          from boileroom.images.metadata import DEFAULT_CUDA_VERSION
+
+          print(f"default_cuda_version={DEFAULT_CUDA_VERSION}")
+          PY
+
       - name: Build ARM64 image set
         run: |
           uv run python scripts/images/build_model_images.py \
-            --cuda-version=12.6 \
+            --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
             --tag=arm64-ci \
             --platform=linux/arm64 \
             --max-workers=3 \
@@ -46,11 +53,11 @@ jobs:
       - name: Run ARM64 import smoke
         run: |
           uv run python scripts/images/check_model_imports.py \
-            --cuda-version=12.6 \
+            --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
             --tag=arm64-ci
 
       - name: Run ARM64 server health smoke
         run: |
           uv run python scripts/images/check_model_server_health.py \
-            --cuda-version=12.6 \
+            --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
             --tag=arm64-ci

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -2,17 +2,51 @@ name: Build and Push Boileroom Images
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
   workflow_dispatch:
+    inputs:
+      promote:
+        description: Promote validated images to the derived release version. Only allowed from main.
+        required: true
+        type: boolean
+        default: false
+      docker_repository:
+        description: Docker repository namespace for manual runs, for example docker.io/my-dockerhub-user.
+        required: true
+        type: string
+        default: docker.io/jakublala
+      dockerhub_username:
+        description: Docker Hub username for manual runs.
+        required: true
+        type: string
+        default: jakublala
+      dockerhub_token_secret:
+        description: Name of the GitHub secret containing the Docker Hub token for manual runs.
+        required: true
+        type: string
+        default: DOCKERHUB_TOKEN
 
 permissions:
   contents: read
 
 concurrency: dockerhub-builds-${{ github.ref }}
 
+env:
+  BOILEROOM_DOCKER_REPOSITORY: ${{ github.event.inputs.docker_repository || 'docker.io/jakublala' }}
+  DOCKERHUB_USERNAME_FOR_RUN: ${{ github.event.inputs.dockerhub_username || secrets.DOCKERHUB_USERNAME }}
+  DOCKERHUB_TOKEN_SECRET_FOR_RUN: ${{ github.event.inputs.dockerhub_token_secret || 'DOCKERHUB_TOKEN' }}
+  IMAGE_BUILD_MAX_WORKERS: "3"
+  SHOULD_PROMOTE: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.promote }}
+
 jobs:
-  build-and-push:
+  prepare-release:
     runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.release_version.outputs.pep440 }}
+      validation_tag: ${{ steps.validation_tag.outputs.value }}
+      cuda_versions: ${{ steps.image_metadata.outputs.cuda_versions }}
+      default_cuda_version: ${{ steps.image_metadata.outputs.default_cuda_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -21,10 +55,169 @@ jobs:
 
       - name: Validate release ref
         run: |
-          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
-            echo "This publishing workflow only derives release versions from main."
+          if [ "$SHOULD_PROMOTE" = "true" ] && [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "Publishing release tags is only allowed from main."
             exit 1
           fi
+          if [ "$SHOULD_PROMOTE" != "true" ]; then
+            echo "Running validation-only image workflow for $GITHUB_REF."
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Determine Boileroom release version
+        id: release_version
+        run: |
+          uv run python ./scripts/ci/derive_version.py --github-output "$GITHUB_OUTPUT"
+
+      - name: Determine validation tag
+        id: validation_tag
+        run: echo "value=sha-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - name: Determine image metadata
+        id: image_metadata
+        run: |
+          uv run python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+
+          from boileroom.images.metadata import CUDA_MICROMAMBA_BASE, DEFAULT_CUDA_VERSION
+
+          print(f"cuda_versions={json.dumps(sorted(CUDA_MICROMAMBA_BASE))}")
+          print(f"default_cuda_version={DEFAULT_CUDA_VERSION}")
+          PY
+
+  build-validation-images:
+    needs: prepare-release
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        cuda_version: ${{ fromJSON(needs.prepare-release.outputs.cuda_versions) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ env.DOCKERHUB_USERNAME_FOR_RUN }}
+          password: ${{ secrets[env.DOCKERHUB_TOKEN_SECRET_FOR_RUN] }}
+
+      - name: Build and push validation images
+        run: |
+          uv run python ./scripts/images/build_model_images.py \
+            --cuda-version=${{ matrix.cuda_version }} \
+            --tag=${{ needs.prepare-release.outputs.validation_tag }} \
+            --platform=linux/amd64 \
+            --push \
+            --local-base \
+            --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
+            --verbose
+
+      - name: Verify local canonical validation image imports
+        run: |
+          uv run python ./scripts/images/check_model_imports.py \
+            --cuda-version=${{ matrix.cuda_version }} \
+            --tag=${{ needs.prepare-release.outputs.validation_tag }}
+
+      - name: Verify local canonical validation image server health
+        run: |
+          uv run python ./scripts/images/check_model_server_health.py \
+            --cuda-version=${{ matrix.cuda_version }} \
+            --tag=${{ needs.prepare-release.outputs.validation_tag }}
+
+      - name: Verify local validation alias image imports
+        if: matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
+        run: |
+          uv run python ./scripts/images/check_model_imports.py \
+            --tag=${{ needs.prepare-release.outputs.validation_tag }}
+
+      - name: Verify local validation alias image server health
+        if: matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
+        run: |
+          uv run python ./scripts/images/check_model_server_health.py \
+            --tag=${{ needs.prepare-release.outputs.validation_tag }}
+
+      - name: Free disk space after build
+        if: always()
+        run: |
+          docker builder prune --all --force
+
+  arm64-image-smoke:
+    name: ARM64 Image Smoke
+    needs: prepare-release
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 180
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Build ARM64 image set
+        run: |
+          uv run python ./scripts/images/build_model_images.py \
+            --cuda-version=${{ needs.prepare-release.outputs.default_cuda_version }} \
+            --tag=${{ needs.prepare-release.outputs.validation_tag }} \
+            --platform=linux/arm64 \
+            --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
+            --verbose
+
+      - name: Verify local ARM64 image imports
+        run: |
+          uv run python ./scripts/images/check_model_imports.py \
+            --cuda-version=${{ needs.prepare-release.outputs.default_cuda_version }} \
+            --tag=${{ needs.prepare-release.outputs.validation_tag }}
+
+      - name: Verify local ARM64 image server health
+        run: |
+          uv run python ./scripts/images/check_model_server_health.py \
+            --cuda-version=${{ needs.prepare-release.outputs.default_cuda_version }} \
+            --tag=${{ needs.prepare-release.outputs.validation_tag }}
+
+  promote-validated-images:
+    needs: [ prepare-release, build-validation-images, arm64-image-smoke ]
+    runs-on: ubuntu-latest
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.promote }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -46,42 +239,12 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: docker.io
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Determine Boileroom release version
-        id: release_version
-        run: |
-          uv run python ./scripts/ci/derive_version.py --github-output "$GITHUB_OUTPUT"
-
-      - name: Determine validation tag
-        id: validation_tag
-        run: echo "value=sha-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
-
-      - name: Build and push validation images
-        run: |
-          uv run python ./scripts/images/build_model_images.py --all-cuda --tag=${{ steps.validation_tag.outputs.value }} --platform=linux/amd64 --push
-
-      - name: Free disk space after build
-        run: |
-          docker builder prune --all --force
-
-      - name: Verify canonical validation image imports
-        run: |
-          uv run python ./scripts/images/check_model_imports.py --all-cuda --tag=${{ steps.validation_tag.outputs.value }} --pull --cleanup
-
-      - name: Verify canonical validation image server health
-        run: |
-          uv run python ./scripts/images/check_model_server_health.py --all-cuda --tag=${{ steps.validation_tag.outputs.value }} --pull --cleanup
-
-      - name: Verify validation alias image imports
-        run: |
-          uv run python ./scripts/images/check_model_imports.py --tag=${{ steps.validation_tag.outputs.value }} --pull --cleanup
-
-      - name: Verify validation alias image server health
-        run: |
-          uv run python ./scripts/images/check_model_server_health.py --tag=${{ steps.validation_tag.outputs.value }} --pull --cleanup
+          username: ${{ env.DOCKERHUB_USERNAME_FOR_RUN }}
+          password: ${{ secrets[env.DOCKERHUB_TOKEN_SECRET_FOR_RUN] }}
 
       - name: Promote validated images to version tag
         run: |
-          uv run python ./scripts/images/promote_image_tags.py --all-cuda --source-tag=${{ steps.validation_tag.outputs.value }} --target-tag=${{ steps.release_version.outputs.pep440 }}
+          uv run python ./scripts/images/promote_image_tags.py \
+            --all-cuda \
+            --source-tag=${{ needs.prepare-release.outputs.validation_tag }} \
+            --target-tag=${{ needs.prepare-release.outputs.release_version }}

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -99,11 +99,17 @@ jobs:
 
   build-validation-images:
     needs: prepare-release
-    runs-on: ubuntu-latest
+    name: Build Validation Images (${{ matrix.platform }}, CUDA ${{ matrix.cuda_version }})
+    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
         cuda_version: ${{ fromJSON(needs.prepare-release.outputs.cuda_versions) }}
+        platform: [linux/amd64]
+        include:
+          - cuda_version: ${{ needs.prepare-release.outputs.default_cuda_version }}
+            platform: linux/arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -122,20 +128,26 @@ jobs:
         run: uv sync --extra dev
 
       - name: Log in to Docker Hub
+        if: matrix.platform == 'linux/amd64'
         uses: docker/login-action@v3
         with:
           registry: docker.io
           username: ${{ env.DOCKERHUB_USERNAME_FOR_RUN }}
           password: ${{ secrets[env.DOCKERHUB_TOKEN_SECRET_FOR_RUN] }}
 
-      - name: Build and push validation images
+      - name: Build validation images
+        shell: bash
         run: |
+          build_args=()
+          if [ "${{ matrix.platform }}" = "linux/amd64" ]; then
+            build_args+=(--push --local-base)
+          fi
+
           uv run python ./scripts/images/build_model_images.py \
             --cuda-version=${{ matrix.cuda_version }} \
             --tag=${{ needs.prepare-release.outputs.validation_tag }} \
-            --platform=linux/amd64 \
-            --push \
-            --local-base \
+            --platform=${{ matrix.platform }} \
+            "${build_args[@]}" \
             --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
             --verbose
 
@@ -152,13 +164,13 @@ jobs:
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
       - name: Verify local validation alias image imports
-        if: matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
+        if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
           uv run python ./scripts/images/check_model_imports.py \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
       - name: Verify local validation alias image server health
-        if: matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
+        if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
           uv run python ./scripts/images/check_model_server_health.py \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
@@ -168,51 +180,8 @@ jobs:
         run: |
           docker builder prune --all --force
 
-  arm64-image-smoke:
-    name: ARM64 Image Smoke
-    needs: prepare-release
-    runs-on: ubuntu-24.04-arm
-    timeout-minutes: 180
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        run: uv sync --extra dev
-
-      - name: Build ARM64 image set
-        run: |
-          uv run python ./scripts/images/build_model_images.py \
-            --cuda-version=${{ needs.prepare-release.outputs.default_cuda_version }} \
-            --tag=${{ needs.prepare-release.outputs.validation_tag }} \
-            --platform=linux/arm64 \
-            --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
-            --verbose
-
-      - name: Verify local ARM64 image imports
-        run: |
-          uv run python ./scripts/images/check_model_imports.py \
-            --cuda-version=${{ needs.prepare-release.outputs.default_cuda_version }} \
-            --tag=${{ needs.prepare-release.outputs.validation_tag }}
-
-      - name: Verify local ARM64 image server health
-        run: |
-          uv run python ./scripts/images/check_model_server_health.py \
-            --cuda-version=${{ needs.prepare-release.outputs.default_cuda_version }} \
-            --tag=${{ needs.prepare-release.outputs.validation_tag }}
-
   promote-validated-images:
-    needs: [ prepare-release, build-validation-images, arm64-image-smoke ]
+    needs: [ prepare-release, build-validation-images ]
     runs-on: ubuntu-latest
     if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.promote }}
     steps:

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -47,7 +47,7 @@ Single-platform non-push builds auto-load into the local Docker daemon. Multi-pl
 Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.
 Pass `--verbose` to stream Docker build output and plain BuildKit progress while still writing per-image log files.
 In CI, the release workflow splits CUDA lines across separate GitHub-hosted runners and passes `--max-workers` within each CUDA job. That keeps the base image dependency order intact while letting model image builds and Docker Hub transfers overlap.
-For single-platform publishing, pass `--local-base` to build and tag images through the local Docker daemon before pushing. This keeps dependent model builds from waiting on Docker Hub to receive and then re-serve the base image.
+For single-platform publishing, pass `--local-base` to build and tag images through the local Docker daemon before pushing. This keeps dependent model builds from waiting on Docker Hub to receive and then re-serve the base image, and ensures model Dockerfiles can resolve the locally built base tag in `FROM`. Because this path uses `docker build` instead of the isolated buildx `docker-container` builder, it relies on the runner-local Docker cache rather than the registry cache import/export path.
 
 ### ARM64 smoke workflow
 The `.github/workflows/arm64-image-smoke.yml` workflow runs on pull requests to `main` and on manual dispatch. It uses an `ubuntu-24.04-arm` runner, builds the image set for `linux/arm64` with the `arm64-ci` tag, and then runs the import and server-health smoke checks. It is informational and does not push images.
@@ -153,7 +153,7 @@ GitHub Actions at `.github/workflows/build-docker-images.yml` now drives the rel
 - The `0.3.x` patch component is the number of commits after the configured main-line baseline, so it increases with every new commit on `main`.
 - Each successful run publishes canonical CUDA-qualified tags and the unqualified version alias for the default `12.6` line.
 - The official release path currently publishes `linux/amd64` only. If you want to experiment with additional architectures, pass an explicit multi-platform `--platform` value and validate it separately before treating it as supported.
-- Future merges inherit dependency cache layers through BuildKit registry caches, keeping CI times reasonable even on fresh GitHub-hosted runners.
+- Non-`--local-base` pushed buildx runs can inherit dependency cache layers through BuildKit registry caches. The release workflow's `--local-base` path favors runner-local base visibility for dependent model builds.
 - PyPI is not published by this workflow. Python package publication happens later from the GitHub release workflow, which injects the `0.3.x` release tag into `pyproject.toml` before building.
 
 To test the publishing workflow before merging:

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -47,7 +47,7 @@ Single-platform non-push builds auto-load into the local Docker daemon. Multi-pl
 Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.
 Pass `--verbose` to stream Docker build output and plain BuildKit progress while still writing per-image log files.
 In CI, the release workflow splits CUDA lines across separate GitHub-hosted runners and passes `--max-workers` within each CUDA job. That keeps the base image dependency order intact while letting model image builds and Docker Hub transfers overlap.
-For single-platform publishing, pass `--local-base` to build and tag images through the local Docker daemon before pushing. This keeps dependent model builds from waiting on Docker Hub to receive and then re-serve the base image, and ensures model Dockerfiles can resolve the locally built base tag in `FROM`. Because this path uses `docker build` instead of the isolated buildx `docker-container` builder, it relies on the runner-local Docker cache rather than the registry cache import/export path.
+For single-platform publishing, pass `--local-base` to build and tag images with `buildx --load` before pushing. This keeps dependent model builds from waiting on Docker Hub to receive and then re-serve the base image. Model builds also receive the loaded base tag as a named `docker-image://` build context so their `FROM` instruction resolves locally while preserving BuildKit registry cache import/export.
 
 ### ARM64 smoke workflow
 The `.github/workflows/arm64-image-smoke.yml` workflow runs on pull requests to `main` and on manual dispatch. It uses an `ubuntu-24.04-arm` runner, builds the image set for `linux/arm64` with the `arm64-ci` tag, and then runs the import and server-health smoke checks. It is informational and does not push images.
@@ -153,7 +153,7 @@ GitHub Actions at `.github/workflows/build-docker-images.yml` now drives the rel
 - The `0.3.x` patch component is the number of commits after the configured main-line baseline, so it increases with every new commit on `main`.
 - Each successful run publishes canonical CUDA-qualified tags and the unqualified version alias for the default `12.6` line.
 - The official release path currently publishes `linux/amd64` only. If you want to experiment with additional architectures, pass an explicit multi-platform `--platform` value and validate it separately before treating it as supported.
-- Non-`--local-base` pushed buildx runs can inherit dependency cache layers through BuildKit registry caches. The release workflow's `--local-base` path favors runner-local base visibility for dependent model builds.
+- Future merges inherit dependency cache layers through BuildKit registry caches, keeping CI times reasonable even on fresh GitHub-hosted runners.
 - PyPI is not published by this workflow. Python package publication happens later from the GitHub release workflow, which injects the `0.3.x` release tag into `pyproject.toml` before building.
 
 To test the publishing workflow before merging:

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -24,6 +24,7 @@ uv run python scripts/images/build_model_images.py --cuda-version=12.6 --platfor
 uv run python scripts/images/build_model_images.py --no-cache ...
 uv run python scripts/images/build_model_images.py --verbose ...
 uv run python scripts/images/build_model_images.py --all-cuda --tag=0.3.0 --push ...
+uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=0.3.0 --push --local-base ...
 uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=sha-$(git rev-parse --short HEAD) --push ...
 ```
 
@@ -45,9 +46,13 @@ export BOILEROOM_MODAL_IMAGE_TAG=0.3.0
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
 Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.
 Pass `--verbose` to stream Docker build output and plain BuildKit progress while still writing per-image log files.
+In CI, the release workflow splits CUDA lines across separate GitHub-hosted runners and passes `--max-workers` within each CUDA job. That keeps the base image dependency order intact while letting model image builds and Docker Hub transfers overlap.
+For single-platform publishing, pass `--local-base` to build and tag images through the local Docker daemon before pushing. This keeps dependent model builds from waiting on Docker Hub to receive and then re-serve the base image.
 
 ### ARM64 smoke workflow
-The `.github/workflows/arm64-image-smoke.yml` workflow runs on an `ubuntu-24.04-arm` runner, builds the image set for `linux/arm64` with the `arm64-ci` tag, and then runs the import and server-health smoke checks. It is informational and does not push images.
+The `.github/workflows/arm64-image-smoke.yml` workflow runs on pull requests to `main` and on manual dispatch. It uses an `ubuntu-24.04-arm` runner, builds the image set for `linux/arm64` with the `arm64-ci` tag, and then runs the import and server-health smoke checks. It is informational and does not push images.
+
+On `main`, ARM64 image smoke is folded into the Docker publishing workflow instead of running as a second separate workflow. That keeps the branch smoke path fast and local while making release promotion wait for the same ARM64 smoke coverage.
 
 To reproduce the same path locally on an ARM64 machine, run:
 
@@ -140,12 +145,36 @@ This publishes:
 ### 📦 CI publishing (production)
 GitHub Actions at `.github/workflows/build-docker-images.yml` now drives the release pipeline:
 - Triggers automatically on pushes to `main` and can also be run manually via **Run workflow** from `main`.
+- Manual runs can also be dispatched from a non-`main` branch with `promote` left disabled. That validation-only path builds and pushes temporary `sha-<commit>` validation images, runs the local AMD64 and ARM64 smoke checks, and skips public version-tag promotion.
 - Builds a temporary `sha-<commit>` validation tag, verifies that exact pushed artifact, and only then promotes it to an automatically derived `0.3.x` version from `scripts/ci/derive_version.py`.
+- Builds each CUDA line in its own job, with model images parallelized behind the matching locally available base image by `--local-base` and `--max-workers`.
+- Verifies canonical CUDA-qualified tags from the same runner-local images after each CUDA build. The default-CUDA alias is checked locally in the `12.6` job.
+- Runs the ARM64 smoke build and checks in the same publishing workflow on `main`; the standalone ARM64 workflow is reserved for pull requests and manual runs.
 - The `0.3.x` patch component is the number of commits after the configured main-line baseline, so it increases with every new commit on `main`.
 - Each successful run publishes canonical CUDA-qualified tags and the unqualified version alias for the default `12.6` line.
 - The official release path currently publishes `linux/amd64` only. If you want to experiment with additional architectures, pass an explicit multi-platform `--platform` value and validate it separately before treating it as supported.
 - Future merges inherit dependency cache layers through BuildKit registry caches, keeping CI times reasonable even on fresh GitHub-hosted runners.
 - PyPI is not published by this workflow. Python package publication happens later from the GitHub release workflow, which injects the `0.3.x` release tag into `pyproject.toml` before building.
+
+To test the publishing workflow before merging:
+1. Push your branch.
+2. Open **Build and Push Boileroom Images** in GitHub Actions.
+3. Choose **Run workflow**, select your branch, leave `promote` disabled, and optionally set `docker_repository` to a temporary namespace such as `docker.io/my-dockerhub-user`.
+4. After the run, delete the temporary `sha-<commit>` validation tags if you no longer need them.
+
+The same branch validation run can be triggered with GitHub CLI:
+```bash
+gh secret set DOCKERHUB_TEST_TOKEN
+
+gh workflow run build-docker-images.yml \
+  --ref "$(git branch --show-current)" \
+  -f promote=false \
+  -f docker_repository=docker.io/my-dockerhub-user \
+  -f dockerhub_username=my-dockerhub-user \
+  -f dockerhub_token_secret=DOCKERHUB_TEST_TOKEN
+```
+
+The `gh secret set` command reads the token from your terminal and stores it as a repository secret. Avoid passing Docker Hub tokens through workflow inputs because inputs are visible in run metadata.
 
 ### 🧱 Convert Docker images to Apptainer (SIF)
 If your cluster uses Apptainer/Singularity for job execution, you can convert the Docker images to a `.sif` image in two common ways:

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -339,7 +339,8 @@ def build_base(
 
     log_file = Path.cwd() / f"{canonical_reference.replace('/', '_').replace(':', '_')}.log"
     effective_output_flag = "--load" if push_after_build else output_flag
-    if use_local_docker_build:
+    build_with_local_daemon = use_local_docker_build or push_after_build
+    if build_with_local_daemon:
         cmd = [
             "docker",
             "build",
@@ -372,7 +373,7 @@ def build_base(
     cmd.extend(["-f", str(BASE_IMAGE_SPEC.dockerfile_path), str(BASE_IMAGE_SPEC.context_path)])
     if no_cache:
         cmd.append("--no-cache")
-    if not use_local_docker_build and effective_output_flag is not None:
+    if not build_with_local_daemon and effective_output_flag is not None:
         cmd.append(effective_output_flag)
 
     log_info(f"Build log: {log_file}")
@@ -400,7 +401,8 @@ def build_model(
 
     log_file = Path.cwd() / f"{canonical_reference.replace('/', '_').replace(':', '_')}.log"
     effective_output_flag = "--load" if push_after_build else output_flag
-    if use_local_docker_build:
+    build_with_local_daemon = use_local_docker_build or push_after_build
+    if build_with_local_daemon:
         cmd = [
             "docker",
             "build",
@@ -437,7 +439,7 @@ def build_model(
     cmd.extend(["-f", str(task.image_spec.dockerfile_path), str(task.image_spec.context_path)])
     if no_cache:
         cmd.append("--no-cache")
-    if not use_local_docker_build and effective_output_flag is not None:
+    if not build_with_local_daemon and effective_output_flag is not None:
         cmd.append(effective_output_flag)
 
     log_info(f"Build log: {log_file}")
@@ -462,7 +464,7 @@ def main() -> None:
                 raise ValueError("--local-base only applies to pushed builds.")
             if "," in args.platform:
                 raise ValueError("--local-base requires a single --platform value.")
-            use_local_docker_build = False
+            use_local_docker_build = True
         if not use_local_docker_build:
             ensure_buildx_builder()
     except Exception as exc:
@@ -470,7 +472,7 @@ def main() -> None:
         raise SystemExit(1) from exc
 
     if args.local_base:
-        log_info("Using buildx --load for single-platform pushed images so model builds inherit the local base image.")
+        log_info("Using plain docker build for single-platform pushed images so model builds inherit the local base image.")
     elif use_local_docker_build:
         log_info("Using plain docker build for single-platform local images.")
     elif output_flag is None:

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -102,6 +102,12 @@ def append_registry_cache_args(
     )
 
 
+def push_image_references(image_references: tuple[str, ...]) -> None:
+    """Push all tags for a locally built image."""
+    for image_reference in image_references:
+        run(["docker", "push", image_reference])
+
+
 def run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
     """Run a command and optionally capture the full output to a log file."""
     pretty = Colors.wrap("$ " + " ".join(shlex.quote(part) for part in cmd), Colors.blue)
@@ -217,7 +223,7 @@ def parse_args() -> argparse.Namespace:
         "--cuda-version",
         action="append",
         dest="cuda_versions",
-        help="CUDA version to build (repeatable). Supported values: 11.8, 12.6.",
+        help=f"CUDA version to build (repeatable). Supported values: {', '.join(sorted(CUDA_MICROMAMBA_BASE))}.",
     )
     parser.add_argument("--all-cuda", action="store_true", help="Build all supported CUDA variants.")
     parser.add_argument(
@@ -248,6 +254,14 @@ def parse_args() -> argparse.Namespace:
         help="Ignore --skip-existing and rebuild even when matching tags already exist.",
     )
     parser.add_argument("--max-workers", type=int, default=1, help="Maximum concurrent model-image builds.")
+    parser.add_argument(
+        "--local-base",
+        action="store_true",
+        help=(
+            "For single-platform pushed builds, load the base into the local Docker daemon and build model images "
+            "from that local base before pushing their tags."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -311,6 +325,7 @@ def build_base(
     no_cache: bool,
     use_local_docker_build: bool,
     verbose: bool = False,
+    push_after_build: bool = False,
 ) -> str:
     """Build the shared base image and return its canonical reference."""
     image_references = published_image_references(BASE_IMAGE_SPEC.image_name, cuda_version, tag)
@@ -323,6 +338,7 @@ def build_base(
     log_info(f"Publishing tags: {', '.join(image_references)}")
 
     log_file = Path.cwd() / f"{canonical_reference.replace('/', '_').replace(':', '_')}.log"
+    effective_output_flag = "--load" if push_after_build else output_flag
     if use_local_docker_build:
         cmd = [
             "docker",
@@ -346,7 +362,7 @@ def build_base(
             cmd,
             BASE_IMAGE_SPEC.image_name,
             cuda_version,
-            push=output_flag == "--push",
+            push=output_flag == "--push" or push_after_build,
             no_cache=no_cache,
         )
     if verbose:
@@ -356,11 +372,13 @@ def build_base(
     cmd.extend(["-f", str(BASE_IMAGE_SPEC.dockerfile_path), str(BASE_IMAGE_SPEC.context_path)])
     if no_cache:
         cmd.append("--no-cache")
-    if not use_local_docker_build and output_flag is not None:
-        cmd.append(output_flag)
+    if not use_local_docker_build and effective_output_flag is not None:
+        cmd.append(effective_output_flag)
 
     log_info(f"Build log: {log_file}")
     run(cmd, log_file=log_file, echo=verbose)
+    if push_after_build:
+        push_image_references(image_references)
     return canonical_reference
 
 
@@ -371,6 +389,7 @@ def build_model(
     no_cache: bool,
     use_local_docker_build: bool,
     verbose: bool = False,
+    push_after_build: bool = False,
 ) -> tuple[str, ...]:
     """Build a single model image and return all published references."""
     image_references = published_image_references(task.image_spec.image_name, task.cuda_version, task.tag)
@@ -380,6 +399,7 @@ def build_model(
     log_info(f"Publishing tags: {', '.join(image_references)}")
 
     log_file = Path.cwd() / f"{canonical_reference.replace('/', '_').replace(':', '_')}.log"
+    effective_output_flag = "--load" if push_after_build else output_flag
     if use_local_docker_build:
         cmd = [
             "docker",
@@ -407,7 +427,7 @@ def build_model(
             cmd,
             task.image_spec.image_name,
             task.cuda_version,
-            push=output_flag == "--push",
+            push=output_flag == "--push" or push_after_build,
             no_cache=no_cache,
         )
     if verbose:
@@ -417,11 +437,13 @@ def build_model(
     cmd.extend(["-f", str(task.image_spec.dockerfile_path), str(task.image_spec.context_path)])
     if no_cache:
         cmd.append("--no-cache")
-    if not use_local_docker_build and output_flag is not None:
-        cmd.append(output_flag)
+    if not use_local_docker_build and effective_output_flag is not None:
+        cmd.append(effective_output_flag)
 
     log_info(f"Build log: {log_file}")
     run(cmd, log_file=log_file, echo=verbose)
+    if push_after_build:
+        push_image_references(image_references)
     return image_references
 
 
@@ -435,13 +457,21 @@ def main() -> None:
         cuda_versions = compute_cuda_versions(args.cuda_versions, args.all_cuda)
         output_flag = resolve_output_flag(args.push, args.load, args.platform)
         use_local_docker_build = should_use_local_docker_build(args.push, args.platform)
+        if args.local_base:
+            if not args.push:
+                raise ValueError("--local-base only applies to pushed builds.")
+            if "," in args.platform:
+                raise ValueError("--local-base requires a single --platform value.")
+            use_local_docker_build = False
         if not use_local_docker_build:
             ensure_buildx_builder()
     except Exception as exc:
         log_error(str(exc))
         raise SystemExit(1) from exc
 
-    if use_local_docker_build:
+    if args.local_base:
+        log_info("Using buildx --load for single-platform pushed images so model builds inherit the local base image.")
+    elif use_local_docker_build:
         log_info("Using plain docker build for single-platform local images.")
     elif output_flag is None:
         log_warn(
@@ -485,6 +515,7 @@ def main() -> None:
                     args.no_cache,
                     use_local_docker_build,
                     args.verbose,
+                    push_after_build=args.local_base,
                 )
         except Exception as exc:
             log_error(f"Failed to build base image for CUDA {cuda_version}: {exc}")
@@ -530,6 +561,7 @@ def main() -> None:
                         args.no_cache,
                         use_local_docker_build,
                         args.verbose,
+                        push_after_build=args.local_base,
                     )
                 )
             except Exception as exc:
@@ -547,6 +579,7 @@ def main() -> None:
                     args.no_cache,
                     use_local_docker_build,
                     args.verbose,
+                    push_after_build=args.local_base,
                 ): task
                 for task in tasks
             }

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -102,6 +102,11 @@ def append_registry_cache_args(
     )
 
 
+def append_local_image_context_args(cmd: list[str], image_reference: str) -> None:
+    """Make a locally loaded image reference available to buildx FROM resolution."""
+    cmd.extend(["--build-context", f"{image_reference}=docker-image://{image_reference}"])
+
+
 def push_image_references(image_references: tuple[str, ...]) -> None:
     """Push all tags for a locally built image."""
     for image_reference in image_references:
@@ -339,8 +344,7 @@ def build_base(
 
     log_file = Path.cwd() / f"{canonical_reference.replace('/', '_').replace(':', '_')}.log"
     effective_output_flag = "--load" if push_after_build else output_flag
-    build_with_local_daemon = use_local_docker_build or push_after_build
-    if build_with_local_daemon:
+    if use_local_docker_build:
         cmd = [
             "docker",
             "build",
@@ -373,7 +377,7 @@ def build_base(
     cmd.extend(["-f", str(BASE_IMAGE_SPEC.dockerfile_path), str(BASE_IMAGE_SPEC.context_path)])
     if no_cache:
         cmd.append("--no-cache")
-    if not build_with_local_daemon and effective_output_flag is not None:
+    if not use_local_docker_build and effective_output_flag is not None:
         cmd.append(effective_output_flag)
 
     log_info(f"Build log: {log_file}")
@@ -401,8 +405,7 @@ def build_model(
 
     log_file = Path.cwd() / f"{canonical_reference.replace('/', '_').replace(':', '_')}.log"
     effective_output_flag = "--load" if push_after_build else output_flag
-    build_with_local_daemon = use_local_docker_build or push_after_build
-    if build_with_local_daemon:
+    if use_local_docker_build:
         cmd = [
             "docker",
             "build",
@@ -432,6 +435,8 @@ def build_model(
             push=output_flag == "--push" or push_after_build,
             no_cache=no_cache,
         )
+        if push_after_build:
+            append_local_image_context_args(cmd, task.base_image_reference)
     if verbose:
         cmd.extend(["--progress", "plain"])
     for image_reference in image_references:
@@ -439,7 +444,7 @@ def build_model(
     cmd.extend(["-f", str(task.image_spec.dockerfile_path), str(task.image_spec.context_path)])
     if no_cache:
         cmd.append("--no-cache")
-    if not build_with_local_daemon and effective_output_flag is not None:
+    if not use_local_docker_build and effective_output_flag is not None:
         cmd.append(effective_output_flag)
 
     log_info(f"Build log: {log_file}")
@@ -464,7 +469,7 @@ def main() -> None:
                 raise ValueError("--local-base only applies to pushed builds.")
             if "," in args.platform:
                 raise ValueError("--local-base requires a single --platform value.")
-            use_local_docker_build = True
+            use_local_docker_build = False
         if not use_local_docker_build:
             ensure_buildx_builder()
     except Exception as exc:
@@ -472,7 +477,10 @@ def main() -> None:
         raise SystemExit(1) from exc
 
     if args.local_base:
-        log_info("Using plain docker build for single-platform pushed images so model builds inherit the local base image.")
+        log_info(
+            "Using buildx --load and named image contexts for single-platform pushed images so model builds "
+            "inherit the local base image."
+        )
     elif use_local_docker_build:
         log_info("Using plain docker build for single-platform local images.")
     elif output_flag is None:

--- a/scripts/images/promote_image_tags.py
+++ b/scripts/images/promote_image_tags.py
@@ -13,6 +13,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from boileroom.images.metadata import (  # noqa: E402
     BASE_IMAGE_SPEC,
+    CUDA_MICROMAMBA_BASE,
     MODEL_IMAGE_SPECS,
     RuntimeImageSpec,
     get_supported_cuda,
@@ -31,7 +32,7 @@ def parse_args() -> argparse.Namespace:
         "--cuda-version",
         action="append",
         dest="cuda_versions",
-        help="CUDA version to promote (repeatable). Supported values: 11.8, 12.6.",
+        help=f"CUDA version to promote (repeatable). Supported values: {', '.join(sorted(CUDA_MICROMAMBA_BASE))}.",
     )
     parser.add_argument("--all-cuda", action="store_true", help="Promote all supported CUDA variants.")
     return parser.parse_args()

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -114,8 +114,8 @@ def test_build_base_verbose_echoes_plain_progress(monkeypatch, tmp_path) -> None
     assert echo is True
 
 
-def test_build_base_local_base_uses_daemon_builder_then_push(monkeypatch, tmp_path) -> None:
-    """Local-base builds should publish tags from the daemon image store."""
+def test_build_base_local_base_uses_buildx_cache_load_then_push(monkeypatch, tmp_path) -> None:
+    """Local-base builds should keep BuildKit cache while loading tags locally."""
     calls: list[tuple[list[str], Path | None, bool]] = []
 
     def fake_run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
@@ -136,19 +136,19 @@ def test_build_base_local_base_uses_daemon_builder_then_push(monkeypatch, tmp_pa
 
     build_cmd = calls[0][0]
     push_cmds = [call[0] for call in calls[1:]]
-    assert build_cmd[:2] == ["docker", "build"]
-    assert "--load" not in build_cmd
+    assert build_cmd[:3] == ["docker", "buildx", "build"]
+    assert "--load" in build_cmd
     assert "--push" not in build_cmd
-    assert "--cache-from" not in build_cmd
-    assert "--cache-to" not in build_cmd
+    assert "--cache-from" in build_cmd
+    assert "--cache-to" in build_cmd
     assert push_cmds == [
         ["docker", "push", f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"],
         ["docker", "push", "docker.io/jakublala/boileroom-base:sha-test"],
     ]
 
 
-def test_build_model_local_base_uses_daemon_builder_then_push(monkeypatch, tmp_path) -> None:
-    """Local-base model builds should resolve FROM tags from the daemon image store."""
+def test_build_model_local_base_uses_buildx_cache_context_then_push(monkeypatch, tmp_path) -> None:
+    """Local-base model builds should expose the loaded base image to buildx."""
     calls: list[tuple[list[str], Path | None, bool]] = []
 
     def fake_run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
@@ -158,11 +158,12 @@ def test_build_model_local_base_uses_daemon_builder_then_push(monkeypatch, tmp_p
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(build_model_images, "run", fake_run)
 
+    base_image_reference = f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"
     build_model_images.build_model(
         build_model_images.BuildTask(
             cuda_version=DEFAULT_CUDA_VERSION,
             image_spec=model_spec,
-            base_image_reference=f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test",
+            base_image_reference=base_image_reference,
             tag="sha-test",
         ),
         "linux/amd64",
@@ -174,11 +175,13 @@ def test_build_model_local_base_uses_daemon_builder_then_push(monkeypatch, tmp_p
 
     build_cmd = calls[0][0]
     push_cmds = [call[0] for call in calls[1:]]
-    assert build_cmd[:2] == ["docker", "build"]
-    assert "--load" not in build_cmd
+    assert build_cmd[:3] == ["docker", "buildx", "build"]
+    assert "--load" in build_cmd
     assert "--push" not in build_cmd
-    assert "--cache-from" not in build_cmd
-    assert "--cache-to" not in build_cmd
+    assert "--cache-from" in build_cmd
+    assert "--cache-to" in build_cmd
+    assert "--build-context" in build_cmd
+    assert f"{base_image_reference}=docker-image://{base_image_reference}" in build_cmd
     assert push_cmds == [
         ["docker", "push", f"docker.io/jakublala/{model_spec.image_name}:cuda{DEFAULT_CUDA_VERSION}-sha-test"],
         ["docker", "push", f"docker.io/jakublala/{model_spec.image_name}:sha-test"],
@@ -319,10 +322,10 @@ def test_local_base_push_builds_locally_then_pushes(monkeypatch, tmp_path) -> No
 
     build_model_images.main()
 
-    assert buildx_calls == 0
-    assert base_calls == [(True, True)]
+    assert buildx_calls == 1
+    assert base_calls == [(False, True)]
     assert model_calls == [
-        (True, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
-        (True, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
-        (True, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
+        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
+        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
+        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
     ]

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -4,6 +4,7 @@ import sys
 from argparse import Namespace
 from pathlib import Path
 
+from boileroom.images.metadata import DEFAULT_CUDA_VERSION
 from scripts.images import build_model_images
 
 
@@ -18,7 +19,7 @@ def test_build_base_push_uses_registry_cache(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(build_model_images, "run", fake_run)
 
     build_model_images.build_base(
-        "12.6",
+        DEFAULT_CUDA_VERSION,
         "sha-test",
         "linux/amd64",
         "--push",
@@ -28,9 +29,9 @@ def test_build_base_push_uses_registry_cache(monkeypatch, tmp_path) -> None:
 
     cmd, _, _ = calls[0]
     assert "--cache-from" in cmd
-    assert "type=registry,ref=docker.io/jakublala/boileroom-base:buildcache-cuda12.6" in cmd
+    assert f"type=registry,ref=docker.io/jakublala/boileroom-base:buildcache-cuda{DEFAULT_CUDA_VERSION}" in cmd
     assert "--cache-to" in cmd
-    assert "type=registry,ref=docker.io/jakublala/boileroom-base:buildcache-cuda12.6,mode=max" in cmd
+    assert f"type=registry,ref=docker.io/jakublala/boileroom-base:buildcache-cuda{DEFAULT_CUDA_VERSION},mode=max" in cmd
 
 
 def test_build_base_no_cache_disables_registry_cache(monkeypatch, tmp_path) -> None:
@@ -44,7 +45,7 @@ def test_build_base_no_cache_disables_registry_cache(monkeypatch, tmp_path) -> N
     monkeypatch.setattr(build_model_images, "run", fake_run)
 
     build_model_images.build_base(
-        "12.6",
+        DEFAULT_CUDA_VERSION,
         "sha-test",
         "linux/amd64",
         "--push",
@@ -61,8 +62,8 @@ def test_build_base_no_cache_disables_registry_cache(monkeypatch, tmp_path) -> N
 def test_build_cache_reference_uses_repository_env(monkeypatch) -> None:
     """Build cache tags should follow the same repository override as image tags."""
     monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
-    assert build_model_images.build_cache_reference("boileroom-base", "12.6") == (
-        "docker.io/example/boileroom-base:buildcache-cuda12.6"
+    assert build_model_images.build_cache_reference("boileroom-base", DEFAULT_CUDA_VERSION) == (
+        f"docker.io/example/boileroom-base:buildcache-cuda{DEFAULT_CUDA_VERSION}"
     )
 
 
@@ -76,6 +77,7 @@ def test_parse_args_exposes_documented_flags(monkeypatch) -> None:
             "--skip-existing",
             "--force-rebuild",
             "--verbose",
+            "--local-base",
         ],
     )
 
@@ -83,6 +85,7 @@ def test_parse_args_exposes_documented_flags(monkeypatch) -> None:
     assert args.skip_existing is True
     assert args.force_rebuild is True
     assert args.verbose is True
+    assert args.local_base is True
 
 
 def test_build_base_verbose_echoes_plain_progress(monkeypatch, tmp_path) -> None:
@@ -96,7 +99,7 @@ def test_build_base_verbose_echoes_plain_progress(monkeypatch, tmp_path) -> None
     monkeypatch.setattr(build_model_images, "run", fake_run)
 
     build_model_images.build_base(
-        "12.6",
+        DEFAULT_CUDA_VERSION,
         "sha-test",
         "linux/amd64",
         "--load",
@@ -111,11 +114,82 @@ def test_build_base_verbose_echoes_plain_progress(monkeypatch, tmp_path) -> None
     assert echo is True
 
 
+def test_build_base_local_base_uses_buildx_cache_load_then_push(monkeypatch, tmp_path) -> None:
+    """Local-base builds should keep BuildKit cache while loading tags locally."""
+    calls: list[tuple[list[str], Path | None, bool]] = []
+
+    def fake_run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
+        calls.append((cmd, log_file, echo))
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(build_model_images, "run", fake_run)
+
+    build_model_images.build_base(
+        DEFAULT_CUDA_VERSION,
+        "sha-test",
+        "linux/amd64",
+        "--push",
+        no_cache=False,
+        use_local_docker_build=False,
+        push_after_build=True,
+    )
+
+    build_cmd = calls[0][0]
+    push_cmds = [call[0] for call in calls[1:]]
+    assert build_cmd[:3] == ["docker", "buildx", "build"]
+    assert "--load" in build_cmd
+    assert "--push" not in build_cmd
+    assert "--cache-from" in build_cmd
+    assert "--cache-to" in build_cmd
+    assert push_cmds == [
+        ["docker", "push", f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"],
+        ["docker", "push", "docker.io/jakublala/boileroom-base:sha-test"],
+    ]
+
+
+def test_build_model_local_base_uses_buildx_cache_load_then_push(monkeypatch, tmp_path) -> None:
+    """Local-base model builds should use BuildKit cache before pushing tags."""
+    calls: list[tuple[list[str], Path | None, bool]] = []
+
+    def fake_run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
+        calls.append((cmd, log_file, echo))
+
+    model_spec = build_model_images.MODEL_IMAGE_SPECS[0]
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(build_model_images, "run", fake_run)
+
+    build_model_images.build_model(
+        build_model_images.BuildTask(
+            cuda_version=DEFAULT_CUDA_VERSION,
+            image_spec=model_spec,
+            base_image_reference=f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test",
+            tag="sha-test",
+        ),
+        "linux/amd64",
+        "--push",
+        no_cache=False,
+        use_local_docker_build=False,
+        push_after_build=True,
+    )
+
+    build_cmd = calls[0][0]
+    push_cmds = [call[0] for call in calls[1:]]
+    assert build_cmd[:3] == ["docker", "buildx", "build"]
+    assert "--load" in build_cmd
+    assert "--push" not in build_cmd
+    assert "--cache-from" in build_cmd
+    assert "--cache-to" in build_cmd
+    assert push_cmds == [
+        ["docker", "push", f"docker.io/jakublala/{model_spec.image_name}:cuda{DEFAULT_CUDA_VERSION}-sha-test"],
+        ["docker", "push", f"docker.io/jakublala/{model_spec.image_name}:sha-test"],
+    ]
+
+
 def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
     """The main build flow should skip existing tags when skip-existing is set."""
     args = Namespace(
         tag="sha-test",
-        cuda_versions=["12.6"],
+        cuda_versions=[DEFAULT_CUDA_VERSION],
         all_cuda=False,
         platform="linux/amd64",
         push=False,
@@ -125,6 +199,7 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
         skip_existing=True,
         force_rebuild=False,
         max_workers=1,
+        local_base=False,
     )
 
     built_tasks: list[tuple[str, str]] = []
@@ -139,9 +214,11 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
 
     def fake_image_reference_exists(image_reference: str) -> bool:
         checked_refs.append(image_reference)
-        return image_reference.endswith("boileroom-base:cuda12.6-sha-test") or image_reference.endswith(
-            "boileroom-boltz:cuda12.6-sha-test"
+        existing_refs = (
+            f"boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test",
+            f"boileroom-boltz:cuda{DEFAULT_CUDA_VERSION}-sha-test",
         )
+        return image_reference.endswith(existing_refs)
 
     def fake_build_base(cuda_version: str, tag: str, *_args, **_kwargs) -> str:
         built_bases.append(f"{cuda_version}:{tag}")
@@ -166,12 +243,86 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
 
     assert built_bases == []
     assert built_tasks == [
-        ("boileroom-chai1", "docker.io/jakublala/boileroom-base:cuda12.6-sha-test"),
-        ("boileroom-esm", "docker.io/jakublala/boileroom-base:cuda12.6-sha-test"),
+        ("boileroom-chai1", f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
+        ("boileroom-esm", f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
     ]
     assert checked_refs == [
-        "docker.io/jakublala/boileroom-base:cuda12.6-sha-test",
-        "docker.io/jakublala/boileroom-boltz:cuda12.6-sha-test",
-        "docker.io/jakublala/boileroom-chai1:cuda12.6-sha-test",
-        "docker.io/jakublala/boileroom-esm:cuda12.6-sha-test",
+        f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test",
+        f"docker.io/jakublala/boileroom-boltz:cuda{DEFAULT_CUDA_VERSION}-sha-test",
+        f"docker.io/jakublala/boileroom-chai1:cuda{DEFAULT_CUDA_VERSION}-sha-test",
+        f"docker.io/jakublala/boileroom-esm:cuda{DEFAULT_CUDA_VERSION}-sha-test",
+    ]
+
+
+def test_local_base_push_builds_locally_then_pushes(monkeypatch, tmp_path) -> None:
+    """Local-base push mode should keep FROM dependencies in the local Docker daemon."""
+    args = Namespace(
+        tag="sha-test",
+        cuda_versions=[DEFAULT_CUDA_VERSION],
+        all_cuda=False,
+        platform="linux/amd64",
+        push=True,
+        load=False,
+        no_cache=False,
+        verbose=False,
+        skip_existing=False,
+        force_rebuild=False,
+        max_workers=1,
+        local_base=True,
+    )
+
+    base_calls: list[tuple[bool, bool]] = []
+    model_calls: list[tuple[bool, bool, str]] = []
+    buildx_calls = 0
+
+    def fake_parse_args() -> Namespace:
+        return args
+
+    def fake_ensure_buildx_builder() -> None:
+        nonlocal buildx_calls
+        buildx_calls += 1
+
+    def fake_build_base(
+        cuda_version: str,
+        tag: str,
+        _platform: str,
+        _output_flag: str,
+        _no_cache: bool,
+        use_local_docker_build: bool,
+        _verbose: bool,
+        push_after_build: bool = False,
+    ) -> str:
+        base_calls.append((use_local_docker_build, push_after_build))
+        return f"docker.io/jakublala/boileroom-base:cuda{cuda_version}-{tag}"
+
+    def fake_build_model(
+        task,
+        _platform: str,
+        _output_flag: str,
+        _no_cache: bool,
+        use_local_docker_build: bool,
+        _verbose: bool,
+        push_after_build: bool = False,
+    ):
+        model_calls.append((use_local_docker_build, push_after_build, task.base_image_reference))
+        return (f"{task.image_spec.image_name}:built",)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(build_model_images, "parse_args", fake_parse_args)
+    monkeypatch.setattr(build_model_images, "ensure_docker", lambda: None)
+    monkeypatch.setattr(build_model_images, "ensure_buildx_builder", fake_ensure_buildx_builder)
+    monkeypatch.setattr(build_model_images, "build_base", fake_build_base)
+    monkeypatch.setattr(build_model_images, "build_model", fake_build_model)
+    monkeypatch.setattr(build_model_images, "log_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(build_model_images, "log_warn", lambda *args, **kwargs: None)
+    monkeypatch.setattr(build_model_images, "log_success", lambda *args, **kwargs: None)
+
+    build_model_images.main()
+
+    assert buildx_calls == 1
+    assert base_calls == [(False, True)]
+    assert model_calls == [
+        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
+        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
+        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
     ]

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -114,8 +114,8 @@ def test_build_base_verbose_echoes_plain_progress(monkeypatch, tmp_path) -> None
     assert echo is True
 
 
-def test_build_base_local_base_uses_buildx_cache_load_then_push(monkeypatch, tmp_path) -> None:
-    """Local-base builds should keep BuildKit cache while loading tags locally."""
+def test_build_base_local_base_uses_daemon_builder_then_push(monkeypatch, tmp_path) -> None:
+    """Local-base builds should publish tags from the daemon image store."""
     calls: list[tuple[list[str], Path | None, bool]] = []
 
     def fake_run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
@@ -136,19 +136,19 @@ def test_build_base_local_base_uses_buildx_cache_load_then_push(monkeypatch, tmp
 
     build_cmd = calls[0][0]
     push_cmds = [call[0] for call in calls[1:]]
-    assert build_cmd[:3] == ["docker", "buildx", "build"]
-    assert "--load" in build_cmd
+    assert build_cmd[:2] == ["docker", "build"]
+    assert "--load" not in build_cmd
     assert "--push" not in build_cmd
-    assert "--cache-from" in build_cmd
-    assert "--cache-to" in build_cmd
+    assert "--cache-from" not in build_cmd
+    assert "--cache-to" not in build_cmd
     assert push_cmds == [
         ["docker", "push", f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"],
         ["docker", "push", "docker.io/jakublala/boileroom-base:sha-test"],
     ]
 
 
-def test_build_model_local_base_uses_buildx_cache_load_then_push(monkeypatch, tmp_path) -> None:
-    """Local-base model builds should use BuildKit cache before pushing tags."""
+def test_build_model_local_base_uses_daemon_builder_then_push(monkeypatch, tmp_path) -> None:
+    """Local-base model builds should resolve FROM tags from the daemon image store."""
     calls: list[tuple[list[str], Path | None, bool]] = []
 
     def fake_run(cmd: list[str], log_file: Path | None = None, echo: bool = True) -> None:
@@ -174,11 +174,11 @@ def test_build_model_local_base_uses_buildx_cache_load_then_push(monkeypatch, tm
 
     build_cmd = calls[0][0]
     push_cmds = [call[0] for call in calls[1:]]
-    assert build_cmd[:3] == ["docker", "buildx", "build"]
-    assert "--load" in build_cmd
+    assert build_cmd[:2] == ["docker", "build"]
+    assert "--load" not in build_cmd
     assert "--push" not in build_cmd
-    assert "--cache-from" in build_cmd
-    assert "--cache-to" in build_cmd
+    assert "--cache-from" not in build_cmd
+    assert "--cache-to" not in build_cmd
     assert push_cmds == [
         ["docker", "push", f"docker.io/jakublala/{model_spec.image_name}:cuda{DEFAULT_CUDA_VERSION}-sha-test"],
         ["docker", "push", f"docker.io/jakublala/{model_spec.image_name}:sha-test"],
@@ -319,10 +319,10 @@ def test_local_base_push_builds_locally_then_pushes(monkeypatch, tmp_path) -> No
 
     build_model_images.main()
 
-    assert buildx_calls == 1
-    assert base_calls == [(False, True)]
+    assert buildx_calls == 0
+    assert base_calls == [(True, True)]
     assert model_calls == [
-        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
-        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
-        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
+        (True, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
+        (True, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
+        (True, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
     ]


### PR DESCRIPTION
## Summary

- Split Docker image publishing into prepare, validation, and promotion jobs.
- Add a manual validation-only path for branch testing with temporary `sha-<commit>` tags.
- Build AMD64 validation images for all supported CUDA versions, and keep ARM64 as a local smoke gate for the default CUDA version.
- Keep `--local-base` on buildx so registry cache still works, while passing the loaded base image as a named build context for model image builds.
- Update docs and contract tests for the new release flow and local-base behavior.

## Notes

- Closes #74.
- Release images are still AMD64 only; ARM64 remains smoke validation.
- This branch is rebased onto `main`; the repository does not have a `master` branch.
- Example Build and Push run - https://github.com/softnanolab/boileroom/actions/runs/24645962025
  - 73 mins --> 13 mins

## Validation

- `uv run pre-commit run --all-files`
- `uv run pytest tests/contracts/test_build_model_images.py tests/contracts/test_image_metadata.py`
- `uv run pre-commit run --files .github/workflows/build-docker-images.yml`
- `uv run pre-commit run --files scripts/images/build_model_images.py tests/contracts/test_build_model_images.py docs/docker_images.md`
