### PR TITLE
feat: add agent-first repo harness

### DIFF
--- a/.github/workflows/python-checks.yaml
+++ b/.github/workflows/python-checks.yaml
@@ -7,6 +7,27 @@ on:
     branches: [ main ]
 
 jobs:
+  harness-checks:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      - name: Install dependencies
+        run: uv sync --extra dev
+
+      - name: Run repo harness
+        run: uv run python scripts/harness/check_repo.py
+
   lint-checks:
     runs-on: "ubuntu-latest"
     steps:

--- a/.github/workflows/python-checks.yaml
+++ b/.github/workflows/python-checks.yaml
@@ -23,7 +23,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
 
       - name: Install dependencies
-        run: uv sync --extra dev
+        run: uv sync
 
       - name: Run repo harness
         run: uv run python scripts/harness/check_repo.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@
 ## Commands
 - Use `uv run` for repo commands. Do not rely on system Python.
 - Setup: `uv python install 3.12 && uv sync`
+- Repo harness: `uv run python scripts/harness/check_repo.py`
 - Tests: `uv run pytest`
 - Parallel tests: use `-n 4` if needed; do not use `-n auto`
 - Lint/type checks: `uv run pre-commit run --all-files`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,18 @@ uv run pre-commit run --all-files
 
 This runs **ruff** and **mypy**.
 
+## Repo harness
+
+Before opening a model-family, backend, or image-related PR, run:
+
+```bash
+uv run python scripts/harness/check_repo.py
+```
+
+The harness checks objective implementation contracts such as model-family files,
+lightweight output types, registry/image links, public wrapper exports, and image
+smoke target coverage. See [docs/agent_harness.md](docs/agent_harness.md).
+
 ## Pull request expectations
 
 - All CI checks must pass.

--- a/boileroom/images/import_checks.py
+++ b/boileroom/images/import_checks.py
@@ -45,7 +45,7 @@ def package_name_to_import_name(package_name: str) -> str | None:
     return IMPORT_NAME_OVERRIDES.get(package_name, package_name.replace("-", "_"))
 
 
-def iter_image_targets(tag: str, cuda_versions: list[str]) -> list[tuple[str, str, str, Path, Path]]:
+def iter_image_targets(tag: str | None, cuda_versions: list[str]) -> list[tuple[str, str, str, Path, Path]]:
     """Return model-image targets for smoke checks.
 
     Returns tuples of ``(image_key, image_reference, display_tag, env_path, core_path)``.

--- a/boileroom/images/import_checks.py
+++ b/boileroom/images/import_checks.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Final
 
 from .metadata import (
     CUDA_MICROMAMBA_BASE,
     MODEL_IMAGE_SPECS,
+    RuntimeImageSpec,
     format_image_reference,
     get_supported_cuda,
     normalize_cuda_version,
@@ -45,7 +47,12 @@ def package_name_to_import_name(package_name: str) -> str | None:
     return IMPORT_NAME_OVERRIDES.get(package_name, package_name.replace("-", "_"))
 
 
-def iter_image_targets(tag: str | None, cuda_versions: list[str]) -> list[tuple[str, str, str, Path, Path]]:
+def iter_image_targets(
+    tag: str | None,
+    cuda_versions: list[str],
+    *,
+    image_specs: Sequence[RuntimeImageSpec] | None = None,
+) -> list[tuple[str, str, str, Path, Path]]:
     """Return model-image targets for smoke checks.
 
     Returns tuples of ``(image_key, image_reference, display_tag, env_path, core_path)``.
@@ -54,8 +61,9 @@ def iter_image_targets(tag: str | None, cuda_versions: list[str]) -> list[tuple[
     if cuda_versions and _CUDA_TAG_PATTERN.fullmatch(normalized_tag):
         raise ValueError("Do not combine --all-cuda/--cuda-version with an already CUDA-qualified --tag.")
 
+    specs = MODEL_IMAGE_SPECS if image_specs is None else image_specs
     targets: list[tuple[str, str, str, Path, Path]] = []
-    for spec in MODEL_IMAGE_SPECS:
+    for spec in specs:
         env_path = spec.context_path / "environment.yml"
         core_path = spec.context_path / "core.py"
         if cuda_versions:

--- a/docs/agent_harness.md
+++ b/docs/agent_harness.md
@@ -1,0 +1,37 @@
+# Boileroom agent harness
+
+The Boileroom harness turns repo conventions into objective checks that an agent can run before opening a PR. It is intentionally narrow: Bagel docs remain the source for public narrative documentation, while this repo owns implementation contracts that must stay true for code changes.
+
+## Local command
+
+Run the harness before a model-family PR:
+
+```bash
+uv run python scripts/harness/check_repo.py
+```
+
+For machine-readable output:
+
+```bash
+uv run python scripts/harness/check_repo.py --json-output /tmp/boileroom-harness.json
+```
+
+## What it checks
+
+- Every model family directory has the required runtime files declared in `harness/model_family_contract.yaml`.
+- `types.py` files stay lightweight and do not import heavy model/runtime libraries at runtime.
+- `ModelSpec` entries, `RuntimeImageSpec` entries, wrapper exports, and image smoke target enumeration agree.
+- Apptainer core class paths resolve statically, without importing model core modules.
+
+## Adding a model family
+
+An agent adding a model family should update the family files, registry metadata, image metadata, public exports, contract tests, and user-facing docs. The harness catches missing structural links, but it does not replace model behavior tests or Docker/Modal/Apptainer smoke validation.
+
+Use the normal verification path after the harness passes:
+
+```bash
+uv run pytest -q -m contract
+uv run pytest -n 4 -m "not integration"
+```
+
+Public-facing development pages live in the separate `bagel-docs` repo. If a code change affects public docs, update that repo in a separate docs PR.

--- a/harness/model_family_contract.yaml
+++ b/harness/model_family_contract.yaml
@@ -1,0 +1,39 @@
+version: 1
+
+model_family:
+  required_files:
+    - __init__.py
+    - core.py
+    - types.py
+    - image.py
+    - Dockerfile
+    - environment.yml
+    - requirements.txt
+    - config.yaml
+
+  lightweight_types:
+    allowed_import_roots:
+      - __future__
+      - collections
+      - dataclasses
+      - enum
+      - numpy
+      - pathlib
+      - typing
+    allowed_import_modules:
+      - boileroom.base
+    forbidden_import_roots:
+      - biotite
+      - boltz
+      - chai_lab
+      - esm
+      - fastapi
+      - modal
+      - pydantic
+      - torch
+      - transformers
+
+registry:
+  required_backends:
+    - modal
+    - apptainer

--- a/scripts/harness/check_repo.py
+++ b/scripts/harness/check_repo.py
@@ -1,0 +1,642 @@
+#!/usr/bin/env python3
+"""Validate Boileroom's repo-local implementation harness."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib
+import json
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from boileroom.images.import_checks import iter_image_targets  # noqa: E402
+from boileroom.images.metadata import MODEL_IMAGE_SPECS, RuntimeImageSpec  # noqa: E402
+from boileroom.models.registry import MODEL_SPECS, ModelSpec, resolve_object  # noqa: E402
+
+DEFAULT_CONTRACT_PATH = REPO_ROOT / "harness/model_family_contract.yaml"
+
+
+@dataclass(frozen=True)
+class CheckIssue:
+    """Actionable harness validation failure."""
+
+    code: str
+    subject: str
+    message: str
+    fix: str
+    path: str | None = None
+
+
+@dataclass(frozen=True)
+class ImportReference:
+    """Import found in a lightweight types module."""
+
+    module: str
+    line_no: int
+
+    @property
+    def root(self) -> str:
+        """Return the top-level import root."""
+
+        return self.module.split(".", 1)[0]
+
+
+def _issue(code: str, subject: str, message: str, fix: str, path: Path | str | None = None) -> CheckIssue:
+    """Create a normalized issue."""
+
+    return CheckIssue(code=code, subject=subject, message=message, fix=fix, path=str(path) if path else None)
+
+
+def load_contract(path: Path = DEFAULT_CONTRACT_PATH) -> dict[str, Any]:
+    """Load the harness YAML contract."""
+
+    with path.open(encoding="utf-8") as handle:
+        contract = yaml.safe_load(handle) or {}
+    if not isinstance(contract, dict):
+        raise ValueError(f"Harness contract must be a mapping: {path}")
+    return contract
+
+
+def _family_dirs(repo_root: Path) -> set[str]:
+    """Return model family directories present in the repository."""
+
+    models_root = repo_root / "boileroom/models"
+    return {
+        path.name
+        for path in models_root.iterdir()
+        if path.is_dir() and not path.name.startswith("_") and path.name != "__pycache__"
+    }
+
+
+def _required_files(contract: dict[str, Any]) -> list[str]:
+    """Return required model-family files from the contract."""
+
+    raw_files = contract.get("model_family", {}).get("required_files", [])
+    return [str(path) for path in raw_files]
+
+
+def _type_import_rules(contract: dict[str, Any]) -> tuple[set[str], set[str], set[str]]:
+    """Return allowed and forbidden import rules for lightweight types modules."""
+
+    raw_rules = contract.get("model_family", {}).get("lightweight_types", {})
+    allowed_roots = {str(value) for value in raw_rules.get("allowed_import_roots", [])}
+    allowed_modules = {str(value) for value in raw_rules.get("allowed_import_modules", [])}
+    forbidden = {str(value) for value in raw_rules.get("forbidden_import_roots", [])}
+    return allowed_roots, allowed_modules, forbidden
+
+
+def _required_backends(contract: dict[str, Any]) -> set[str]:
+    """Return required model backends from the contract."""
+
+    return {str(value) for value in contract.get("registry", {}).get("required_backends", [])}
+
+
+def check_required_family_files(repo_root: Path, contract: dict[str, Any], family_names: Iterable[str]) -> list[CheckIssue]:
+    """Validate required files for every model family."""
+
+    issues: list[CheckIssue] = []
+    required_files = _required_files(contract)
+    for family in sorted(family_names):
+        family_dir = repo_root / "boileroom/models" / family
+        if not family_dir.exists():
+            issues.append(
+                _issue(
+                    "missing-family-dir",
+                    family,
+                    f"Model family directory does not exist: {family_dir}",
+                    f"Create boileroom/models/{family}/ or remove the stale registry/image reference.",
+                    family_dir,
+                )
+            )
+            continue
+        for relative_path in required_files:
+            expected = family_dir / relative_path
+            if not expected.exists():
+                issues.append(
+                    _issue(
+                        "missing-family-file",
+                        family,
+                        f"Missing required model-family file: {expected}",
+                        f"Add {relative_path} for family {family}, or update harness/model_family_contract.yaml if the contract changed.",
+                        expected,
+                    )
+                )
+    return issues
+
+
+def _is_type_checking_test(node: ast.AST) -> bool:
+    """Return whether an if-test is a TYPE_CHECKING guard."""
+
+    if isinstance(node, ast.Name):
+        return node.id == "TYPE_CHECKING"
+    if isinstance(node, ast.Attribute):
+        return node.attr == "TYPE_CHECKING"
+    return False
+
+
+def _module_name_for_path(repo_root: Path, path: Path) -> str:
+    """Return the dotted module name for a Python source path under the repo root."""
+
+    relative_path = path.relative_to(repo_root).with_suffix("")
+    return ".".join(relative_path.parts)
+
+
+def _resolve_import_from_module(repo_root: Path, path: Path, node: ast.ImportFrom) -> list[str]:
+    """Resolve an ImportFrom node to fully qualified module names."""
+
+    if node.level == 0:
+        return [node.module] if node.module else []
+
+    package_parts = _module_name_for_path(repo_root, path).split(".")[:-1]
+    keep_count = len(package_parts) - node.level + 1
+    if keep_count < 0:
+        return []
+
+    base_parts = package_parts[:keep_count]
+    if node.module:
+        return [".".join([*base_parts, *node.module.split(".")])]
+
+    return [".".join([*base_parts, alias.name]) for alias in node.names if alias.name != "*"]
+
+
+class _ImportVisitor(ast.NodeVisitor):
+    """Collect imports outside TYPE_CHECKING guards."""
+
+    def __init__(self, repo_root: Path) -> None:
+        self.repo_root = repo_root
+        self.imports: list[ImportReference] = []
+        self.path: Path | None = None
+        self._type_checking_depth = 0
+
+    def visit_If(self, node: ast.If) -> None:
+        if _is_type_checking_test(node.test):
+            self._type_checking_depth += 1
+            for child in node.body:
+                self.visit(child)
+            self._type_checking_depth -= 1
+            for child in node.orelse:
+                self.visit(child)
+            return
+        self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import) -> None:
+        if self._type_checking_depth:
+            return
+        for alias in node.names:
+            self.imports.append(ImportReference(alias.name, node.lineno))
+
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        if self._type_checking_depth:
+            return
+        if self.path is None:
+            raise RuntimeError("Import visitor path was not initialized.")
+        for module in _resolve_import_from_module(self.repo_root, self.path, node):
+            if module:
+                self.imports.append(ImportReference(module, node.lineno))
+
+    def collect(self, path: Path) -> list[ImportReference]:
+        """Collect imports from a Python source file."""
+
+        self.path = path
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        self.visit(tree)
+        return self.imports
+
+
+def _imports(repo_root: Path, path: Path) -> list[ImportReference]:
+    """Return imports used outside TYPE_CHECKING guards."""
+
+    return _ImportVisitor(repo_root).collect(path)
+
+
+def check_lightweight_types_imports(
+    repo_root: Path,
+    contract: dict[str, Any],
+    family_names: Iterable[str],
+) -> list[CheckIssue]:
+    """Validate that model-family types modules stay lightweight."""
+
+    allowed_roots, allowed_modules, forbidden = _type_import_rules(contract)
+    issues: list[CheckIssue] = []
+    for family in sorted(family_names):
+        types_path = repo_root / "boileroom/models" / family / "types.py"
+        if not types_path.exists():
+            continue
+        for import_ref in _imports(repo_root, types_path):
+            if import_ref.root in forbidden:
+                issues.append(
+                    _issue(
+                        "forbidden-types-import",
+                        family,
+                        f"{types_path}:{import_ref.line_no} imports heavyweight module {import_ref.module!r}.",
+                        "Move heavyweight imports into core.py or behind a TYPE_CHECKING guard if only needed for annotations.",
+                        types_path,
+                    )
+                )
+                continue
+            if import_ref.root in allowed_roots or import_ref.module in allowed_modules:
+                continue
+            if allowed_roots or allowed_modules:
+                issues.append(
+                    _issue(
+                        "unexpected-types-import",
+                        family,
+                        f"{types_path}:{import_ref.line_no} imports module {import_ref.module!r}, which is not allowed by the lightweight types contract.",
+                        f"Remove the import, move it behind TYPE_CHECKING, or add {import_ref.module!r} to allowed_import_modules after review.",
+                        types_path,
+                    )
+                )
+    return issues
+
+
+def _class_exists_in_module(repo_root: Path, dotted_path: str) -> bool:
+    """Return whether a dotted class path exists without importing the module."""
+
+    module_path, separator, class_name = dotted_path.rpartition(".")
+    if not separator:
+        return False
+    candidate = repo_root / f"{module_path.replace('.', '/')}.py"
+    if not candidate.exists():
+        candidate = repo_root / module_path.replace(".", "/") / "__init__.py"
+    if not candidate.exists():
+        return False
+    tree = ast.parse(candidate.read_text(encoding="utf-8"), filename=str(candidate))
+    return any(isinstance(node, ast.ClassDef) and node.name == class_name for node in tree.body)
+
+
+def _image_specs_by_key(image_specs: Sequence[RuntimeImageSpec]) -> dict[str, RuntimeImageSpec]:
+    """Return image specs keyed by family key."""
+
+    return {spec.key: spec for spec in image_specs}
+
+
+def check_registry_image_consistency(
+    repo_root: Path,
+    model_specs: Sequence[ModelSpec],
+    image_specs: Sequence[RuntimeImageSpec],
+    contract: dict[str, Any] | None = None,
+) -> list[CheckIssue]:
+    """Validate registry/image metadata links without importing model cores."""
+
+    issues: list[CheckIssue] = []
+    image_by_key = _image_specs_by_key(image_specs)
+    families_with_models = {spec.family for spec in model_specs}
+    family_dirs = _family_dirs(repo_root)
+    image_keys = set(image_by_key)
+    required_backends = _required_backends(contract or {})
+
+    for family in sorted(family_dirs - image_keys):
+        issues.append(
+            _issue(
+                "unregistered-family-image",
+                family,
+                f"Model family {family!r} has a directory but no RuntimeImageSpec.",
+                "Add a RuntimeImageSpec to boileroom/images/metadata.py or remove the unused family directory.",
+                repo_root / "boileroom/models" / family,
+            )
+        )
+
+    for family in sorted(families_with_models - image_keys):
+        issues.append(
+            _issue(
+                "missing-image-spec",
+                family,
+                f"Model family {family!r} is used by a ModelSpec but has no RuntimeImageSpec.",
+                "Add matching image metadata to MODEL_IMAGE_SPECS in boileroom/images/metadata.py.",
+            )
+        )
+
+    for image_key in sorted(image_keys - families_with_models):
+        issues.append(
+            _issue(
+                "image-without-model",
+                image_key,
+                f"RuntimeImageSpec {image_key!r} has no registered ModelSpec family.",
+                "Register a ModelSpec for this family or remove the unused image metadata.",
+            )
+        )
+
+    for image_spec in image_specs:
+        for label, path in (
+            ("context path", image_spec.context_path),
+            ("Dockerfile", image_spec.dockerfile_path),
+        ):
+            if not path.exists():
+                issues.append(
+                    _issue(
+                        "missing-image-path",
+                        image_spec.key,
+                        f"{label} does not exist for image spec {image_spec.key!r}: {path}",
+                        "Fix the RuntimeImageSpec path or add the missing file.",
+                        path,
+                    )
+                )
+        if image_spec.config_relative_path is not None:
+            config_path = repo_root / image_spec.config_relative_path
+            if not config_path.exists():
+                issues.append(
+                    _issue(
+                        "missing-image-config",
+                        image_spec.key,
+                        f"Image config does not exist for image spec {image_spec.key!r}: {config_path}",
+                        "Fix config_relative_path or add the missing config.yaml.",
+                        config_path,
+                    )
+                )
+
+    seen_keys: set[str] = set()
+    seen_public_names: set[str] = set()
+    for spec in model_specs:
+        if spec.key in seen_keys:
+            issues.append(
+                _issue("duplicate-model-key", spec.key, f"Duplicate ModelSpec key: {spec.key}", "Use unique model keys.")
+            )
+        seen_keys.add(spec.key)
+        if spec.public_name in seen_public_names:
+            issues.append(
+                _issue(
+                    "duplicate-public-name",
+                    spec.public_name,
+                    f"Duplicate ModelSpec public name: {spec.public_name}",
+                    "Use unique public wrapper names.",
+                )
+            )
+        seen_public_names.add(spec.public_name)
+
+        missing_backends = required_backends - set(spec.supported_backends)
+        if missing_backends:
+            issues.append(
+                _issue(
+                    "missing-required-backend",
+                    spec.key,
+                    f"{spec.public_name} is missing required backend(s): {', '.join(sorted(missing_backends))}.",
+                    "Add backend support metadata or update harness/model_family_contract.yaml if the policy changed.",
+                )
+            )
+
+        linked_image_spec = image_by_key.get(spec.family)
+        if linked_image_spec is not None and spec.apptainer_image_name != linked_image_spec.image_name:
+            issues.append(
+                _issue(
+                    "apptainer-image-mismatch",
+                    spec.key,
+                    f"{spec.public_name} uses apptainer image {spec.apptainer_image_name!r}, expected {linked_image_spec.image_name!r}.",
+                    "Set ModelSpec.apptainer_image_name from get_model_image_spec(<family>).image_name.",
+                )
+            )
+        if "modal" in spec.supported_backends and spec.modal_class_path is None:
+            issues.append(
+                _issue(
+                    "missing-modal-class",
+                    spec.key,
+                    f"{spec.public_name} declares Modal support but has no modal_class_path.",
+                    "Add a Modal wrapper class path or remove modal from supported_backends.",
+                )
+            )
+        if "apptainer" in spec.supported_backends:
+            if spec.apptainer_core_class_path is None:
+                issues.append(
+                    _issue(
+                        "missing-apptainer-core",
+                        spec.key,
+                        f"{spec.public_name} declares Apptainer support but has no apptainer_core_class_path.",
+                        "Add an Apptainer core class path or remove apptainer from supported_backends.",
+                    )
+                )
+            elif not _class_exists_in_module(repo_root, spec.apptainer_core_class_path):
+                issues.append(
+                    _issue(
+                        "missing-apptainer-core-class",
+                        spec.key,
+                        f"Apptainer core class path does not resolve statically: {spec.apptainer_core_class_path}",
+                        "Create the core class or fix ModelSpec.apptainer_core_class_path.",
+                    )
+                )
+            if spec.apptainer_image_name is None:
+                issues.append(
+                    _issue(
+                        "missing-apptainer-image",
+                        spec.key,
+                        f"{spec.public_name} declares Apptainer support but has no apptainer_image_name.",
+                        "Set apptainer_image_name to the family RuntimeImageSpec image_name.",
+                    )
+                )
+    return issues
+
+
+def check_wrapper_exposure(model_specs: Sequence[ModelSpec]) -> list[CheckIssue]:
+    """Validate public wrapper exposure and registry identity."""
+
+    issues: list[CheckIssue] = []
+    boileroom_module = importlib.import_module("boileroom")
+    models_module = importlib.import_module("boileroom.models")
+    top_level_all = set(getattr(boileroom_module, "__all__", []))
+    models_all = set(getattr(models_module, "__all__", []))
+
+    for spec in model_specs:
+        try:
+            wrapper_cls = resolve_object(spec.wrapper_class_path)
+        except Exception as exc:
+            issues.append(
+                _issue(
+                    "unresolved-wrapper-class",
+                    spec.key,
+                    f"Could not import wrapper class {spec.wrapper_class_path}: {exc}",
+                    "Fix ModelSpec.wrapper_class_path or the wrapper module import error.",
+                )
+            )
+            continue
+
+        if getattr(wrapper_cls, "MODEL_SPEC", None) is not spec:
+            issues.append(
+                _issue(
+                    "wrapper-model-spec-mismatch",
+                    spec.key,
+                    f"{spec.wrapper_class_path}.MODEL_SPEC is not the registered ModelSpec object.",
+                    "Set the wrapper class MODEL_SPEC attribute to the registry constant used in MODEL_SPECS.",
+                )
+            )
+
+        if spec.modal_class_path is not None:
+            try:
+                resolve_object(spec.modal_class_path)
+            except Exception as exc:
+                issues.append(
+                    _issue(
+                        "unresolved-modal-class",
+                        spec.key,
+                        f"Could not import Modal class {spec.modal_class_path}: {exc}",
+                        "Fix ModelSpec.modal_class_path or the Modal wrapper module import error.",
+                    )
+                )
+
+        if spec.public_name not in top_level_all:
+            issues.append(
+                _issue(
+                    "missing-top-level-export",
+                    spec.key,
+                    f"{spec.public_name} is missing from boileroom.__all__.",
+                    "Add the public wrapper name to boileroom/__init__.py.",
+                    "boileroom/__init__.py",
+                )
+            )
+        elif getattr(boileroom_module, spec.public_name, None) is not wrapper_cls:
+            issues.append(
+                _issue(
+                    "broken-top-level-export",
+                    spec.key,
+                    f"boileroom.{spec.public_name} does not resolve to {spec.wrapper_class_path}.",
+                    "Fix boileroom/__init__.py lazy export wiring.",
+                    "boileroom/__init__.py",
+                )
+            )
+        if spec.public_name not in models_all:
+            issues.append(
+                _issue(
+                    "missing-models-export",
+                    spec.key,
+                    f"{spec.public_name} is missing from boileroom.models.__all__.",
+                    "Add the public wrapper name to boileroom/models/__init__.py.",
+                    "boileroom/models/__init__.py",
+                )
+            )
+        elif getattr(models_module, spec.public_name, None) is not wrapper_cls:
+            issues.append(
+                _issue(
+                    "broken-models-export",
+                    spec.key,
+                    f"boileroom.models.{spec.public_name} does not resolve to {spec.wrapper_class_path}.",
+                    "Fix boileroom/models/__init__.py lazy export wiring.",
+                    "boileroom/models/__init__.py",
+                )
+            )
+
+        family_module = importlib.import_module(f"boileroom.models.{spec.family}")
+        family_all = set(getattr(family_module, "__all__", []))
+        if spec.public_name not in family_all:
+            issues.append(
+                _issue(
+                    "missing-family-export",
+                    spec.key,
+                    f"{spec.public_name} is missing from boileroom.models.{spec.family}.__all__.",
+                    f"Add the public wrapper name to boileroom/models/{spec.family}/__init__.py.",
+                    f"boileroom/models/{spec.family}/__init__.py",
+                )
+            )
+        elif getattr(family_module, spec.public_name, None) is not wrapper_cls:
+            issues.append(
+                _issue(
+                    "broken-family-export",
+                    spec.key,
+                    f"boileroom.models.{spec.family}.{spec.public_name} does not resolve to {spec.wrapper_class_path}.",
+                    f"Fix boileroom/models/{spec.family}/__init__.py lazy export wiring.",
+                    f"boileroom/models/{spec.family}/__init__.py",
+                )
+            )
+    return issues
+
+
+def check_smoke_targets(image_specs: Sequence[RuntimeImageSpec]) -> list[CheckIssue]:
+    """Validate image smoke target enumeration."""
+
+    issues: list[CheckIssue] = []
+    expected_keys = {spec.key for spec in image_specs}
+    actual_keys = {image_key for image_key, *_rest in iter_image_targets(None, [])}
+    missing = expected_keys - actual_keys
+    extra = actual_keys - expected_keys
+    if missing:
+        issues.append(
+            _issue(
+                "missing-smoke-target",
+                "image-smoke",
+                f"Image smoke target enumeration is missing: {', '.join(sorted(missing))}",
+                "Update boileroom/images/import_checks.py so every RuntimeImageSpec is included.",
+            )
+        )
+    if extra:
+        issues.append(
+            _issue(
+                "extra-smoke-target",
+                "image-smoke",
+                f"Image smoke target enumeration has unexpected targets: {', '.join(sorted(extra))}",
+                "Update boileroom/images/import_checks.py or MODEL_IMAGE_SPECS so they agree.",
+            )
+        )
+    return issues
+
+
+def run_checks(repo_root: Path = REPO_ROOT, contract: dict[str, Any] | None = None) -> list[CheckIssue]:
+    """Run all objective harness checks."""
+
+    loaded_contract = contract or load_contract()
+    family_names = _family_dirs(repo_root) | {spec.family for spec in MODEL_SPECS} | {spec.key for spec in MODEL_IMAGE_SPECS}
+    issues: list[CheckIssue] = []
+    issues.extend(check_required_family_files(repo_root, loaded_contract, family_names))
+    issues.extend(check_lightweight_types_imports(repo_root, loaded_contract, family_names))
+    issues.extend(check_registry_image_consistency(repo_root, MODEL_SPECS, MODEL_IMAGE_SPECS, loaded_contract))
+    issues.extend(check_wrapper_exposure(MODEL_SPECS))
+    issues.extend(check_smoke_targets(MODEL_IMAGE_SPECS))
+    return issues
+
+
+def _write_json_report(path: Path, issues: Sequence[CheckIssue]) -> None:
+    """Write a machine-readable harness report."""
+
+    payload = {"ok": not issues, "issue_count": len(issues), "issues": [asdict(issue) for issue in issues]}
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _print_report(issues: Sequence[CheckIssue]) -> None:
+    """Print a human-readable harness report."""
+
+    if not issues:
+        print("Boileroom harness checks passed.")
+        return
+
+    print(f"Boileroom harness found {len(issues)} issue(s):", file=sys.stderr)
+    for index, issue in enumerate(issues, start=1):
+        location = f" ({issue.path})" if issue.path else ""
+        print(f"{index}. [{issue.code}] {issue.subject}{location}", file=sys.stderr)
+        print(f"   Problem: {issue.message}", file=sys.stderr)
+        print(f"   Fix: {issue.fix}", file=sys.stderr)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description="Run objective Boileroom harness checks.")
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=DEFAULT_CONTRACT_PATH,
+        help="Path to the YAML harness contract.",
+    )
+    parser.add_argument("--json-output", type=Path, default=None, help="Optional path for a JSON report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the harness CLI."""
+
+    args = parse_args(argv)
+    contract = load_contract(args.contract)
+    issues = run_checks(REPO_ROOT, contract)
+    if args.json_output is not None:
+        _write_json_report(args.json_output, issues)
+    _print_report(issues)
+    return 1 if issues else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/harness/check_repo.py
+++ b/scripts/harness/check_repo.py
@@ -152,6 +152,20 @@ def _module_name_for_path(repo_root: Path, path: Path) -> str:
     return ".".join(relative_path.parts)
 
 
+def _module_path_for_name(repo_root: Path, module_path: str) -> tuple[Path, bool] | None:
+    """Return the source file for a dotted module and whether it is a package."""
+
+    module_file = repo_root / f"{module_path.replace('.', '/')}.py"
+    if module_file.exists():
+        return module_file, False
+
+    package_file = repo_root / module_path.replace(".", "/") / "__init__.py"
+    if package_file.exists():
+        return package_file, True
+
+    return None
+
+
 def _resolve_import_from_module(repo_root: Path, path: Path, node: ast.ImportFrom) -> list[str]:
     """Resolve an ImportFrom node to fully qualified module names."""
 
@@ -260,19 +274,74 @@ def check_lightweight_types_imports(
     return issues
 
 
-def _class_exists_in_module(repo_root: Path, dotted_path: str) -> bool:
+def _resolve_reexported_class_path(
+    repo_root: Path,
+    current_module_path: str,
+    current_path: Path,
+    is_package: bool,
+    node: ast.ImportFrom,
+    class_name: str,
+) -> str | None:
+    """Return the original dotted class path for a matching re-export."""
+
+    if node.level == 0:
+        import_module_path = node.module
+    else:
+        package_parts = current_module_path.split(".") if is_package else current_module_path.split(".")[:-1]
+        keep_count = len(package_parts) - node.level + 1
+        if keep_count < 0:
+            return None
+        base_parts = package_parts[:keep_count]
+        import_module_path = ".".join([*base_parts, *(node.module.split(".") if node.module else [])])
+
+    for alias in node.names:
+        if alias.name == "*":
+            continue
+        exported_name = alias.asname or alias.name
+        if exported_name != class_name:
+            continue
+        if import_module_path:
+            return f"{import_module_path}.{alias.name}"
+
+        resolved_modules = _resolve_import_from_module(repo_root, current_path, node)
+        matching_module = next((module for module in resolved_modules if module.rsplit(".", 1)[-1] == alias.name), None)
+        if matching_module is not None:
+            return matching_module
+
+    return None
+
+
+def _class_exists_in_module(repo_root: Path, dotted_path: str, seen: set[str] | None = None) -> bool:
     """Return whether a dotted class path exists without importing the module."""
+
+    seen = set() if seen is None else seen
+    if dotted_path in seen:
+        return False
+    seen.add(dotted_path)
 
     module_path, separator, class_name = dotted_path.rpartition(".")
     if not separator:
         return False
-    candidate = repo_root / f"{module_path.replace('.', '/')}.py"
-    if not candidate.exists():
-        candidate = repo_root / module_path.replace(".", "/") / "__init__.py"
-    if not candidate.exists():
+    module_source = _module_path_for_name(repo_root, module_path)
+    if module_source is None:
         return False
+    candidate, is_package = module_source
     tree = ast.parse(candidate.read_text(encoding="utf-8"), filename=str(candidate))
-    return any(isinstance(node, ast.ClassDef) and node.name == class_name for node in tree.body)
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            return True
+        if isinstance(node, ast.ImportFrom):
+            reexported_path = _resolve_reexported_class_path(
+                repo_root,
+                module_path,
+                candidate,
+                is_package,
+                node,
+                class_name,
+            )
+            if reexported_path is not None and _class_exists_in_module(repo_root, reexported_path, seen):
+                return True
+    return False
 
 
 def _image_specs_by_key(image_specs: Sequence[RuntimeImageSpec]) -> dict[str, RuntimeImageSpec]:
@@ -447,7 +516,8 @@ def check_wrapper_exposure(model_specs: Sequence[ModelSpec]) -> list[CheckIssue]
     for spec in model_specs:
         try:
             wrapper_cls = resolve_object(spec.wrapper_class_path)
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
+            # Wrapper modules can fail through third-party import-time errors; report them as harness issues.
             issues.append(
                 _issue(
                     "unresolved-wrapper-class",
@@ -471,7 +541,8 @@ def check_wrapper_exposure(model_specs: Sequence[ModelSpec]) -> list[CheckIssue]
         if spec.modal_class_path is not None:
             try:
                 resolve_object(spec.modal_class_path)
-            except Exception as exc:
+            except Exception as exc:  # noqa: BLE001
+                # Modal wrapper imports can fail before the class is reached; report the import failure.
                 issues.append(
                     _issue(
                         "unresolved-modal-class",
@@ -552,7 +623,7 @@ def check_smoke_targets(image_specs: Sequence[RuntimeImageSpec]) -> list[CheckIs
 
     issues: list[CheckIssue] = []
     expected_keys = {spec.key for spec in image_specs}
-    actual_keys = {image_key for image_key, *_rest in iter_image_targets(None, [])}
+    actual_keys = {image_key for image_key, *_rest in iter_image_targets(None, [], image_specs=image_specs)}
     missing = expected_keys - actual_keys
     extra = actual_keys - expected_keys
     if missing:
@@ -580,7 +651,8 @@ def run_checks(repo_root: Path = REPO_ROOT, contract: dict[str, Any] | None = No
     """Run all objective harness checks."""
 
     loaded_contract = contract or load_contract()
-    family_names = _family_dirs(repo_root) | {spec.family for spec in MODEL_SPECS} | {spec.key for spec in MODEL_IMAGE_SPECS}
+    # Image-only keys are reported by check_registry_image_consistency, not treated as family directories.
+    family_names = _family_dirs(repo_root) | {spec.family for spec in MODEL_SPECS}
     issues: list[CheckIssue] = []
     issues.extend(check_required_family_files(repo_root, loaded_contract, family_names))
     issues.extend(check_lightweight_types_imports(repo_root, loaded_contract, family_names))

--- a/tests/contracts/test_harness.py
+++ b/tests/contracts/test_harness.py
@@ -1,0 +1,169 @@
+"""Fast contract tests for the repo-local harness."""
+
+from pathlib import Path
+
+import pytest
+
+from boileroom.images.metadata import RuntimeImageSpec
+from boileroom.models.registry import ModelContract, ModelSpec
+from scripts.harness import check_repo
+
+pytestmark = pytest.mark.contract
+
+
+def test_current_repo_harness_passes() -> None:
+    """The checked-in repository should satisfy the harness contract."""
+    issues = check_repo.run_checks(check_repo.REPO_ROOT, check_repo.load_contract())
+    assert issues == []
+
+
+def test_required_family_files_reports_missing_files(tmp_path: Path) -> None:
+    """Missing model-family files should produce actionable harness issues."""
+    family_dir = tmp_path / "boileroom/models/fake"
+    family_dir.mkdir(parents=True)
+    (family_dir / "types.py").write_text("from dataclasses import dataclass\n", encoding="utf-8")
+
+    contract = {
+        "model_family": {
+            "required_files": ["types.py", "core.py"],
+        }
+    }
+
+    issues = check_repo.check_required_family_files(tmp_path, contract, ["fake"])
+
+    assert [issue.code for issue in issues] == ["missing-family-file"]
+    assert "core.py" in issues[0].message
+    assert "Add core.py" in issues[0].fix
+
+
+def test_lightweight_types_rejects_forbidden_import(tmp_path: Path) -> None:
+    """types.py must not import heavyweight runtime modules."""
+    family_dir = tmp_path / "boileroom/models/fake"
+    family_dir.mkdir(parents=True)
+    (family_dir / "types.py").write_text("import torch\n", encoding="utf-8")
+    contract = check_repo.load_contract()
+
+    issues = check_repo.check_lightweight_types_imports(tmp_path, contract, ["fake"])
+
+    assert [issue.code for issue in issues] == ["forbidden-types-import"]
+    assert "torch" in issues[0].message
+
+
+def test_lightweight_types_allows_type_checking_import(tmp_path: Path) -> None:
+    """TYPE_CHECKING-only imports should not make output types heavyweight at runtime."""
+    family_dir = tmp_path / "boileroom/models/fake"
+    family_dir.mkdir(parents=True)
+    (family_dir / "types.py").write_text(
+        "from typing import TYPE_CHECKING\n\nif TYPE_CHECKING:\n    from biotite.structure import AtomArray\n",
+        encoding="utf-8",
+    )
+    contract = check_repo.load_contract()
+
+    issues = check_repo.check_lightweight_types_imports(tmp_path, contract, ["fake"])
+
+    assert issues == []
+
+
+def test_lightweight_types_allows_base_protocol_import(tmp_path: Path) -> None:
+    """types.py may import the lightweight Boileroom base protocols."""
+    family_dir = tmp_path / "boileroom/models/fake"
+    family_dir.mkdir(parents=True)
+    (family_dir / "types.py").write_text("from ...base import PredictionMetadata\n", encoding="utf-8")
+    contract = check_repo.load_contract()
+
+    issues = check_repo.check_lightweight_types_imports(tmp_path, contract, ["fake"])
+
+    assert issues == []
+
+
+def test_lightweight_types_rejects_absolute_in_repo_core_import(tmp_path: Path) -> None:
+    """Allowing boileroom.base must not allow arbitrary in-repo runtime modules."""
+    family_dir = tmp_path / "boileroom/models/fake"
+    family_dir.mkdir(parents=True)
+    (family_dir / "types.py").write_text("from boileroom.models.fake.core import FakeCore\n", encoding="utf-8")
+    contract = check_repo.load_contract()
+
+    issues = check_repo.check_lightweight_types_imports(tmp_path, contract, ["fake"])
+
+    assert [issue.code for issue in issues] == ["unexpected-types-import"]
+    assert "boileroom.models.fake.core" in issues[0].message
+
+
+def test_lightweight_types_rejects_relative_core_import(tmp_path: Path) -> None:
+    """Relative imports should be resolved before enforcing lightweight import rules."""
+    family_dir = tmp_path / "boileroom/models/fake"
+    family_dir.mkdir(parents=True)
+    (family_dir / "types.py").write_text("from .core import FakeCore\n", encoding="utf-8")
+    contract = check_repo.load_contract()
+
+    issues = check_repo.check_lightweight_types_imports(tmp_path, contract, ["fake"])
+
+    assert [issue.code for issue in issues] == ["unexpected-types-import"]
+    assert "boileroom.models.fake.core" in issues[0].message
+
+
+def test_registry_check_reports_missing_core_class(tmp_path: Path) -> None:
+    """Apptainer core paths should point at a real class without importing the core module."""
+    core_dir = tmp_path / "boileroom/models/fake"
+    core_dir.mkdir(parents=True)
+    (core_dir / "core.py").write_text("class OtherCore:\n    pass\n", encoding="utf-8")
+    model_spec = ModelSpec(
+        key="fake",
+        public_name="Fake",
+        family="fake",
+        wrapper_class_path="boileroom.models.fake.fake.Fake",
+        modal_class_path="boileroom.models.fake.fake.ModalFake",
+        apptainer_core_class_path="boileroom.models.fake.core.FakeCore",
+        apptainer_image_name="boileroom-fake",
+        supported_backends=("modal", "apptainer"),
+        contract=ModelContract(
+            task_method="fold",
+            task_kind="structure",
+            static_config_keys=frozenset(),
+            minimal_output_fields=("metadata", "atom_array"),
+        ),
+    )
+    image_spec = RuntimeImageSpec(
+        key="fake",
+        image_name="boileroom-fake",
+        dockerfile_relative_path="pyproject.toml",
+        context_relative_path=".",
+    )
+
+    issues = check_repo.check_registry_image_consistency(tmp_path, [model_spec], [image_spec])
+
+    assert any(issue.code == "missing-apptainer-core-class" for issue in issues)
+
+
+def test_registry_check_enforces_required_backends(tmp_path: Path) -> None:
+    """The YAML contract should drive required backend policy."""
+    family_dir = tmp_path / "boileroom/models/fake"
+    family_dir.mkdir(parents=True)
+    (family_dir / "core.py").write_text("class FakeCore:\n    pass\n", encoding="utf-8")
+    model_spec = ModelSpec(
+        key="fake",
+        public_name="Fake",
+        family="fake",
+        wrapper_class_path="boileroom.models.fake.fake.Fake",
+        modal_class_path="boileroom.models.fake.fake.ModalFake",
+        apptainer_core_class_path=None,
+        apptainer_image_name="boileroom-fake",
+        supported_backends=("modal",),
+        contract=ModelContract(
+            task_method="fold",
+            task_kind="structure",
+            static_config_keys=frozenset(),
+            minimal_output_fields=("metadata", "atom_array"),
+        ),
+    )
+    image_spec = RuntimeImageSpec(
+        key="fake",
+        image_name="boileroom-fake",
+        dockerfile_relative_path="pyproject.toml",
+        context_relative_path=".",
+    )
+    contract = {"registry": {"required_backends": ["modal", "apptainer"]}}
+
+    issues = check_repo.check_registry_image_consistency(tmp_path, [model_spec], [image_spec], contract)
+
+    assert any(issue.code == "missing-required-backend" for issue in issues)

--- a/tests/contracts/test_harness.py
+++ b/tests/contracts/test_harness.py
@@ -1,5 +1,7 @@
 """Fast contract tests for the repo-local harness."""
 
+from collections.abc import Sequence
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -135,6 +137,40 @@ def test_registry_check_reports_missing_core_class(tmp_path: Path) -> None:
     assert any(issue.code == "missing-apptainer-core-class" for issue in issues)
 
 
+def test_registry_check_accepts_reexported_core_class(tmp_path: Path) -> None:
+    """Apptainer core paths may point at package-level re-exports."""
+    core_dir = tmp_path / "boileroom/models/fake"
+    core_dir.mkdir(parents=True)
+    (core_dir / "__init__.py").write_text("from .core import FakeCore\n", encoding="utf-8")
+    (core_dir / "core.py").write_text("class FakeCore:\n    pass\n", encoding="utf-8")
+    model_spec = ModelSpec(
+        key="fake",
+        public_name="Fake",
+        family="fake",
+        wrapper_class_path="boileroom.models.fake.fake.Fake",
+        modal_class_path="boileroom.models.fake.fake.ModalFake",
+        apptainer_core_class_path="boileroom.models.fake.FakeCore",
+        apptainer_image_name="boileroom-fake",
+        supported_backends=("modal", "apptainer"),
+        contract=ModelContract(
+            task_method="fold",
+            task_kind="structure",
+            static_config_keys=frozenset(),
+            minimal_output_fields=("metadata", "atom_array"),
+        ),
+    )
+    image_spec = RuntimeImageSpec(
+        key="fake",
+        image_name="boileroom-fake",
+        dockerfile_relative_path="pyproject.toml",
+        context_relative_path=".",
+    )
+
+    issues = check_repo.check_registry_image_consistency(tmp_path, [model_spec], [image_spec])
+
+    assert not any(issue.code == "missing-apptainer-core-class" for issue in issues)
+
+
 def test_registry_check_enforces_required_backends(tmp_path: Path) -> None:
     """The YAML contract should drive required backend policy."""
     family_dir = tmp_path / "boileroom/models/fake"
@@ -167,3 +203,37 @@ def test_registry_check_enforces_required_backends(tmp_path: Path) -> None:
     issues = check_repo.check_registry_image_consistency(tmp_path, [model_spec], [image_spec], contract)
 
     assert any(issue.code == "missing-required-backend" for issue in issues)
+
+
+def test_wrapper_exposure_reports_model_spec_mismatch() -> None:
+    """Wrapper MODEL_SPEC attributes should point at the exact registry object."""
+    mismatched_spec = replace(check_repo.MODEL_SPECS[0], key="mismatched-esmfold")
+
+    issues = check_repo.check_wrapper_exposure([mismatched_spec])
+
+    assert any(issue.code == "wrapper-model-spec-mismatch" for issue in issues)
+
+
+def test_smoke_targets_reports_missing_target(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The harness should report image specs missing from smoke target enumeration."""
+    image_spec = RuntimeImageSpec(
+        key="fake",
+        image_name="boileroom-fake",
+        dockerfile_relative_path="pyproject.toml",
+        context_relative_path=".",
+    )
+
+    def fake_iter_image_targets(
+        tag: str | None,
+        cuda_versions: list[str],
+        *,
+        image_specs: Sequence[RuntimeImageSpec] | None = None,
+    ) -> list[tuple[str, str, str, Path, Path]]:
+        return []
+
+    monkeypatch.setattr(check_repo, "iter_image_targets", fake_iter_image_targets)
+
+    issues = check_repo.check_smoke_targets([image_spec])
+
+    assert [issue.code for issue in issues] == ["missing-smoke-target"]
+    assert "fake" in issues[0].message


### PR DESCRIPTION
## Summary

Adds a repo-local, machine-checkable harness for Boileroom model-family conventions so agents and CI can validate objective implementation contracts before PRs land.

## Changes

- Add `harness/model_family_contract.yaml` for required model-family files, lightweight `types.py` import rules, and backend policy.
- Add `scripts/harness/check_repo.py` as the main local harness entrypoint with human-readable failures and optional JSON output.
- Add contract tests for current repo success and key failure paths, including forbidden heavy imports, relative import resolution, missing files, missing core classes, and backend policy.
- Add a blocking `harness-checks` job to Python CI.
- Document the harness in `docs/agent_harness.md`, `CONTRIBUTING.md`, and `CLAUDE.md`.
- Adjust `iter_image_targets` typing to reflect its existing `None` default-tag behavior.

## Validation

- `uv run python scripts/harness/check_repo.py --json-output /tmp/boileroom-harness.json`
- `uv run pytest -q tests/contracts/test_harness.py`
- `uv run pytest -q -m contract`
- `uv run pytest -n 4 -m "not integration"`
- `uv run --extra dev pre-commit run --files harness/model_family_contract.yaml scripts/harness/check_repo.py tests/contracts/test_harness.py`
- `uv run --extra dev pre-commit run --all-files`

## Notes

This PR intentionally does not modify the separate `bagel-docs` repository. Public-facing development docs should be handled in a separate docs PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced repository harness validation tool to check model family contracts, import compliance, registry consistency, and wrapper exports before submitting PRs.

* **Documentation**
  * Added harness documentation and contributing guide updates with pre-PR validation instructions.

* **Tests**
  * Added contract tests to verify repository compliance with model family requirements.

* **Chores**
  * Updated GitHub Actions workflow to include automated harness checks on pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->