### PR TITLE
ci: use prerelease image tags for main builds

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -4,10 +4,12 @@ on:
   push:
     branches:
       - main
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       promote:
-        description: Promote validated images to the derived release version. Only allowed from main.
+        description: Promote validated images to the derived prerelease version. Only allowed from main.
         required: true
         type: boolean
         default: false
@@ -37,13 +39,13 @@ env:
   DOCKERHUB_USERNAME_FOR_RUN: ${{ github.event.inputs.dockerhub_username || secrets.DOCKERHUB_USERNAME }}
   DOCKERHUB_TOKEN_SECRET_FOR_RUN: ${{ github.event.inputs.dockerhub_token_secret || 'DOCKERHUB_TOKEN' }}
   IMAGE_BUILD_MAX_WORKERS: "3"
-  SHOULD_PROMOTE: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.promote }}
+  SHOULD_PROMOTE: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release' || inputs.promote }}
 
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
     outputs:
-      release_version: ${{ steps.release_version.outputs.pep440 }}
+      release_version: ${{ steps.version.outputs.docker_tag }}
       validation_tag: ${{ steps.validation_tag.outputs.value }}
       cuda_versions: ${{ steps.image_metadata.outputs.cuda_versions }}
       default_cuda_version: ${{ steps.image_metadata.outputs.default_cuda_version }}
@@ -55,8 +57,8 @@ jobs:
 
       - name: Validate release ref
         run: |
-          if [ "$SHOULD_PROMOTE" = "true" ] && [ "$GITHUB_REF" != "refs/heads/main" ]; then
-            echo "Publishing release tags is only allowed from main."
+          if [ "$SHOULD_PROMOTE" = "true" ] && [ "$GITHUB_REF" != "refs/heads/main" ] && [ "$GITHUB_EVENT_NAME" != "release" ]; then
+            echo "Publishing prerelease tags is only allowed from main."
             exit 1
           fi
           if [ "$SHOULD_PROMOTE" != "true" ]; then
@@ -76,10 +78,15 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra dev
 
-      - name: Determine Boileroom release version
-        id: release_version
+      - name: Determine Boileroom version
+        id: version
         run: |
-          uv run python ./scripts/ci/derive_version.py --github-output "$GITHUB_OUTPUT"
+          version_args=()
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            version_args+=(--release-tag "$GITHUB_REF_NAME")
+          fi
+
+          uv run python ./scripts/ci/derive_version.py "${version_args[@]}" --github-output "$GITHUB_OUTPUT"
 
       - name: Determine validation tag
         id: validation_tag
@@ -188,7 +195,7 @@ jobs:
   promote-validated-images:
     needs: [ prepare-release, build-validation-images ]
     runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || inputs.promote }}
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release' || inputs.promote }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -216,7 +223,7 @@ jobs:
           username: ${{ env.DOCKERHUB_USERNAME_FOR_RUN }}
           password: ${{ secrets[env.DOCKERHUB_TOKEN_SECRET_FOR_RUN] }}
 
-      - name: Promote validated images to version tag
+      - name: Promote validated images to target tag
         run: |
           uv run python ./scripts/images/promote_image_tags.py \
             --all-cuda \

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -39,10 +39,11 @@ env:
   DOCKERHUB_USERNAME_FOR_RUN: ${{ github.event.inputs.dockerhub_username || secrets.DOCKERHUB_USERNAME }}
   DOCKERHUB_TOKEN_SECRET_FOR_RUN: ${{ github.event.inputs.dockerhub_token_secret || 'DOCKERHUB_TOKEN' }}
   IMAGE_BUILD_MAX_WORKERS: "3"
-  SHOULD_PROMOTE: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release' || inputs.promote }}
+  SHOULD_PROMOTE: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && github.event.release.prerelease == false) || inputs.promote }}
 
 jobs:
   prepare-release:
+    if: ${{ github.event_name != 'release' || github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
     outputs:
       release_version: ${{ steps.version.outputs.docker_tag }}

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   build-and-publish:
+    if: ${{ github.event.release.prerelease == false }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,16 +43,17 @@
 - Explicit image-tag overrides still work:
   - Modal via `BOILEROOM_MODAL_IMAGE_TAG`
   - Apptainer via `backend="apptainer:<tag>"`
-- Canonical published tags are CUDA-qualified, for example `cuda12.6-0.3.0`.
-- The default CUDA line `12.6` also gets an unqualified alias for the same version, for example `0.3.0`.
+- Canonical published tags are CUDA-qualified, for example `cuda12.6-0.3.0` or `cuda12.6-0.3.1-alpha.1`.
+- The default CUDA line `12.6` also gets an unqualified alias for the same version, for example `0.3.0` or `0.3.1-alpha.1`.
 - Temporary validation tags such as `sha-<commit>` are allowed and should be deleted after use.
 
 ## Release Flow
-- Merging to `main` publishes Docker Hub images for an automatically derived `0.3.x` version.
-- The workflow first publishes a temporary `sha-<commit>` tag, verifies it, then promotes it to `0.3.x` tags.
-- The `0.3.x` patch component is derived from commits after the configured CI baseline and grows with each main-branch commit.
-- PyPI publication is separate and happens from the GitHub release workflow, which injects the `0.3.x` release tag into `pyproject.toml` before building.
-- Changing `project.version` changes package release semantics, but Docker image tags are derived by CI.
+- Merging to `main` publishes Docker Hub images for an automatically derived alpha prerelease tag such as `0.3.1-alpha.1`.
+- The workflow first publishes a temporary `sha-<commit>` tag, verifies it, then promotes it to the derived alpha tag.
+- Alpha numbers are counted from the latest reachable stable release tag; before the first stable release tag, they use the configured CI baseline.
+- Publishing a GitHub release from a `vX.Y.Z` tag promotes verified Docker images to the stable `X.Y.Z` tag.
+- PyPI publication is separate and happens from the GitHub release workflow, which injects the stable release tag into `pyproject.toml` before building.
+- Changing `project.version` changes the stable target for subsequent alpha image tags and package release semantics.
 
 ## Apptainer Notes
 - Apptainer images are pulled from Docker Hub and cached as `.sif` files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,8 @@
 - Merging to `main` publishes Docker Hub images for an automatically derived alpha prerelease tag such as `0.3.1-alpha.1`.
 - The workflow first publishes a temporary `sha-<commit>` tag, verifies it, then promotes it to the derived alpha tag.
 - Alpha numbers are counted from the latest reachable stable release tag; before the first stable release tag, they use the configured CI baseline.
-- Publishing a GitHub release from a `vX.Y.Z` tag promotes verified Docker images to the stable `X.Y.Z` tag.
+- Publishing a full GitHub release from a `vX.Y.Z` tag promotes verified Docker images to the stable `X.Y.Z` tag.
+- GitHub releases marked as pre-releases do not publish stable Docker or PyPI artifacts.
 - PyPI publication is separate and happens from the GitHub release workflow, which injects the stable release tag into `pyproject.toml` before building.
 - Changing `project.version` changes the stable target for subsequent alpha image tags and package release semantics.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,8 @@ smoke target coverage. See [docs/agent_harness.md](docs/agent_harness.md).
 - Docker image version tags on `main` are prereleases for `project.version` in `pyproject.toml`, for example `0.3.1-alpha.1`.
 - Runtime defaults also follow the installed boileroom package version unless you explicitly override the image tag.
 - Merging to `main` triggers `.github/workflows/build-docker-images.yml`, which publishes Docker Hub tags for the current alpha prerelease.
-- Stable Docker tags and PyPI publication are separate manual release steps and happen from GitHub release tags such as `v0.3.1`.
+- Stable Docker tags and PyPI publication are separate manual release steps and happen from full GitHub release tags such as `v0.3.1`.
+- GitHub releases marked as pre-releases do not publish stable Docker or PyPI artifacts.
 - In practice, Docker Hub can act as the earlier staging/public channel while PyPI remains the later package release step.
 - After a stable release, bump `project.version` to the next intended stable version so subsequent `main` builds become the next alpha series.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,12 +49,12 @@ smoke target coverage. See [docs/agent_harness.md](docs/agent_harness.md).
 
 ## Release and versioning
 
-- Docker image version tags follow `project.version` in `pyproject.toml`.
+- Docker image version tags on `main` are prereleases for `project.version` in `pyproject.toml`, for example `0.3.1-alpha.1`.
 - Runtime defaults also follow the installed boileroom package version unless you explicitly override the image tag.
-- Merging to `main` triggers `.github/workflows/build-docker-images.yml`, which publishes Docker Hub tags for the current package version.
-- PyPI publication is a separate step and only happens when a GitHub release is published.
+- Merging to `main` triggers `.github/workflows/build-docker-images.yml`, which publishes Docker Hub tags for the current alpha prerelease.
+- Stable Docker tags and PyPI publication are separate manual release steps and happen from GitHub release tags such as `v0.3.1`.
 - In practice, Docker Hub can act as the earlier staging/public channel while PyPI remains the later package release step.
-- If you change `project.version`, you are also changing the versioned Docker tags that will be published from `main`.
+- After a stable release, bump `project.version` to the next intended stable version so subsequent `main` builds become the next alpha series.
 
 ## Further reading
 

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -116,7 +116,8 @@ def normalize_requested_tag(tag: str | None) -> str:
     if normalized == "latest":
         raise ValueError(
             "The 'latest' image tag is no longer published. "
-            "Use a concrete package version such as '0.3.0' or a temporary validation tag such as 'sha-<commit>'."
+            "Use a concrete package version such as '0.3.0', an alpha tag such as "
+            "'0.3.1-alpha.1', or a temporary validation tag such as 'sha-<commit>'."
         )
     return normalized
 
@@ -140,9 +141,9 @@ def canonical_image_tag(cuda_version: str, tag: str | None) -> str:
 def resolve_registry_tag(tag: str | None) -> str:
     """Resolve a tag for runtime image lookup.
 
-    Unqualified tags such as ``0.3.0`` or ``sha-<commit>`` are preserved so they resolve
-    through the published default-CUDA aliases. Explicit CUDA-qualified tags are normalized
-    to the canonical ``cuda<version>-<tag>`` form.
+    Unqualified tags such as ``0.3.0``, ``0.3.1-alpha.1``, or ``sha-<commit>`` are
+    preserved so they resolve through the published default-CUDA aliases. Explicit
+    CUDA-qualified tags are normalized to the canonical ``cuda<version>-<tag>`` form.
     """
     normalized_tag = normalize_requested_tag(tag)
     if match := _CUDA_TAG_PATTERN.fullmatch(normalized_tag):
@@ -155,8 +156,8 @@ def resolve_registry_tag(tag: str | None) -> str:
 def published_tags(cuda_version: str, tag: str | None) -> tuple[str, ...]:
     """Return the canonical published tags for a build output.
 
-    The default CUDA line also gets an unqualified alias such as ``0.3.0`` or
-    ``sha-<commit>`` for convenience.
+    The default CUDA line also gets an unqualified alias such as ``0.3.0``,
+    ``0.3.1-alpha.1``, or ``sha-<commit>`` for convenience.
     """
     normalized_cuda = normalize_cuda_version(cuda_version)
     normalized_tag = normalize_requested_tag(tag)

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -140,7 +140,7 @@ This publishes:
 GitHub Actions at `.github/workflows/build-docker-images.yml` now drives the image publishing pipeline:
 - Triggers automatically on pushes to `main`, on published GitHub releases, and can also be run manually via **Run workflow** from `main`.
 - Manual runs can also be dispatched from a non-`main` branch with `promote` left disabled. That validation-only path builds and pushes temporary `sha-<commit>` validation images, runs the local AMD64 and ARM64 smoke checks, and skips public version-tag promotion.
-- Builds a temporary `sha-<commit>` validation tag, verifies that exact pushed artifact, and only then promotes it. Pushes to `main` promote to an automatically derived alpha prerelease from `scripts/ci/derive_version.py`; published GitHub releases promote to the stable release tag.
+- Builds a temporary `sha-<commit>` validation tag, verifies that exact pushed artifact, and only then promotes it. Pushes to `main` promote to an automatically derived alpha prerelease from `scripts/ci/derive_version.py`; full GitHub releases promote to the stable release tag.
 - Builds each CUDA line in its own job, with model images parallelized behind the matching locally available base image by `--local-base` and `--max-workers`.
 - Verifies canonical CUDA-qualified tags from the same runner-local images after each CUDA build. The default-CUDA alias is checked locally in the `12.6` job.
 - Runs the ARM64 smoke build and checks in the same publishing workflow on `main`; the standalone ARM64 workflow is reserved for pull requests and manual runs.
@@ -148,7 +148,8 @@ GitHub Actions at `.github/workflows/build-docker-images.yml` now drives the ima
 - Each successful run publishes canonical CUDA-qualified tags and the unqualified version alias for the default `12.6` line.
 - The official release path currently publishes `linux/amd64` only. If you want to experiment with additional architectures, pass an explicit multi-platform `--platform` value and validate it separately before treating it as supported.
 - Future merges inherit dependency cache layers through BuildKit registry caches, keeping CI times reasonable even on fresh GitHub-hosted runners.
-- Published GitHub releases from `vX.Y.Z` tags promote the same validated images to the stable `X.Y.Z` Docker tag.
+- Published full GitHub releases from `vX.Y.Z` tags promote the same validated images to the stable `X.Y.Z` Docker tag.
+- GitHub releases marked as pre-releases do not publish stable Docker or PyPI artifacts.
 - PyPI is not published by this workflow. Python package publication happens from the separate GitHub release workflow, which injects the stable release tag into `pyproject.toml` before building.
 
 To test the publishing workflow before merging:

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -9,8 +9,8 @@
 Dockerfiles are the canonical image definition for all runtimes. Docker/Apptainer images are built from these Dockerfiles, and Modal pulls the corresponding published model image from Docker Hub instead of maintaining a separate handwritten dependency stack.
 
 ### Tag scheme
-- Canonical published tags are CUDA-qualified, for example `cuda12.6-0.3.0`, `cuda11.8-0.3.0`, or `cuda12.6-sha-abc1234`.
-- The default CUDA line is `12.6`. That line also gets an unqualified alias for the exact package version or temporary validation tag, for example `0.3.0` or `sha-abc1234`.
+- Canonical published tags are CUDA-qualified, for example `cuda12.6-0.3.0`, `cuda11.8-0.3.0`, `cuda12.6-0.3.1-alpha.1`, or `cuda12.6-sha-abc1234`.
+- The default CUDA line is `12.6`. That line also gets an unqualified alias for the exact package version, alpha prerelease, or temporary validation tag, for example `0.3.0`, `0.3.1-alpha.1`, or `sha-abc1234`.
 - `latest` is not published.
 - Runtime shorthands such as `backend="apptainer"` resolve to the installed boileroom package version on the default `12.6` CUDA line.
 
@@ -64,7 +64,7 @@ uv run python scripts/images/check_model_server_health.py --cuda-version=12.6 --
 The build helper also supports `--skip-existing` and `--force-rebuild` for registry-aware rebuilds.
 
 ### 🔖 Tag policy
-- Docker Hub is kept clean for users. The long-lived public tags are version tags such as `0.3.0` and the corresponding CUDA-qualified tags such as `cuda12.6-0.3.0` and `cuda11.8-0.3.0`.
+- Docker Hub is kept clean for users. The long-lived public tags are stable version tags such as `0.3.0`, alpha prerelease tags such as `0.3.1-alpha.1`, and the corresponding CUDA-qualified tags such as `cuda12.6-0.3.0` and `cuda11.8-0.3.0`.
 - Short-lived validation tags such as `sha-<shortsha>` are fine when you need to test a branch through Docker Hub or Modal before promoting a version tag.
 - Validation tags should be deleted once the validation pass is complete.
 
@@ -137,18 +137,19 @@ This publishes:
 - the unqualified version alias such as `0.3.0` for the `12.6` line
 
 ### 📦 CI publishing (production)
-GitHub Actions at `.github/workflows/build-docker-images.yml` now drives the release pipeline:
-- Triggers automatically on pushes to `main` and can also be run manually via **Run workflow** from `main`.
+GitHub Actions at `.github/workflows/build-docker-images.yml` now drives the image publishing pipeline:
+- Triggers automatically on pushes to `main`, on published GitHub releases, and can also be run manually via **Run workflow** from `main`.
 - Manual runs can also be dispatched from a non-`main` branch with `promote` left disabled. That validation-only path builds and pushes temporary `sha-<commit>` validation images, runs the local AMD64 and ARM64 smoke checks, and skips public version-tag promotion.
-- Builds a temporary `sha-<commit>` validation tag, verifies that exact pushed artifact, and only then promotes it to an automatically derived `0.3.x` version from `scripts/ci/derive_version.py`.
+- Builds a temporary `sha-<commit>` validation tag, verifies that exact pushed artifact, and only then promotes it. Pushes to `main` promote to an automatically derived alpha prerelease from `scripts/ci/derive_version.py`; published GitHub releases promote to the stable release tag.
 - Builds each CUDA line in its own job, with model images parallelized behind the matching locally available base image by `--local-base` and `--max-workers`.
 - Verifies canonical CUDA-qualified tags from the same runner-local images after each CUDA build. The default-CUDA alias is checked locally in the `12.6` job.
 - Runs the ARM64 smoke build and checks in the same publishing workflow on `main`; the standalone ARM64 workflow is reserved for pull requests and manual runs.
-- The `0.3.x` patch component is the number of commits after the configured main-line baseline, so it increases with every new commit on `main`.
+- The alpha suffix counts commits since the latest reachable stable release tag, for example `0.3.1-alpha.1`, `0.3.1-alpha.2`, and so on. Before the first stable release tag, the count falls back to the configured CI baseline.
 - Each successful run publishes canonical CUDA-qualified tags and the unqualified version alias for the default `12.6` line.
 - The official release path currently publishes `linux/amd64` only. If you want to experiment with additional architectures, pass an explicit multi-platform `--platform` value and validate it separately before treating it as supported.
 - Future merges inherit dependency cache layers through BuildKit registry caches, keeping CI times reasonable even on fresh GitHub-hosted runners.
-- PyPI is not published by this workflow. Python package publication happens later from the GitHub release workflow, which injects the `0.3.x` release tag into `pyproject.toml` before building.
+- Published GitHub releases from `vX.Y.Z` tags promote the same validated images to the stable `X.Y.Z` Docker tag.
+- PyPI is not published by this workflow. Python package publication happens from the separate GitHub release workflow, which injects the stable release tag into `pyproject.toml` before building.
 
 To test the publishing workflow before merging:
 1. Push your branch.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "boileroom"
-# Release automation treats this as the base release line. Change it only
-# when starting a new minor line; CI derives patch versions automatically.
+# Release automation treats this as the current stable target. Main-branch
+# image builds publish prerelease tags such as 0.3.0-alpha.1 from it.
 version = "0.3.0"
 authors = [
     { name="Jakub Lála", email="jakublala@gmail.com" },

--- a/scripts/ci/derive_version.py
+++ b/scripts/ci/derive_version.py
@@ -1,4 +1,4 @@
-"""Derive CI/CD release versions from the main-branch commit count."""
+"""Derive CI/CD release and prerelease versions."""
 
 from __future__ import annotations
 
@@ -11,6 +11,9 @@ from pathlib import Path
 MAIN_VERSION_BASE_SHA = "48e8a23fbde63e95a0e39fe0d5748c3f338b30b3"
 DEFAULT_PYPROJECT_PATH = Path(__file__).resolve().parents[2] / "pyproject.toml"
 VERSION_PATTERN = re.compile(r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$")
+RELEASE_TAG_PATTERN = re.compile(
+    r"^(?:refs/tags/)?v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$"
+)
 
 
 def run_git(args: list[str]) -> str:
@@ -32,29 +35,81 @@ def parse_version(version: str) -> tuple[int, int, int]:
     return int(match.group("major")), int(match.group("minor")), int(match.group("patch"))
 
 
-def main_patch_for_head(head_ref: str = "HEAD", base_patch: int | None = None) -> int:
-    """Return the patch version offset for ``head_ref`` on the main release line."""
-    commit_count = run_git(["rev-list", "--count", f"{MAIN_VERSION_BASE_SHA}..{head_ref}"])
-    if base_patch is None:
-        base_patch = parse_version(pyproject_version())[2]
-    return base_patch + int(commit_count)
+def normalize_release_tag(tag: str) -> str:
+    """Return a stable version from a release tag such as ``v0.3.7``."""
+    match = RELEASE_TAG_PATTERN.fullmatch(tag)
+    if match is None:
+        raise ValueError(f"Expected a release tag like v0.3.0, got {tag!r}.")
+    return f"{match.group('major')}.{match.group('minor')}.{match.group('patch')}"
+
+
+def reachable_release_tags(head_ref: str = "HEAD") -> list[tuple[int, int, int, str]]:
+    """Return reachable stable release tags."""
+    raw_tags = run_git(["tag", "--merged", head_ref, "--list"])
+    release_tags: list[tuple[int, int, int, str]] = []
+    for tag in raw_tags.splitlines():
+        try:
+            normalized = normalize_release_tag(tag)
+        except ValueError:
+            continue
+        version_parts = parse_version(normalized)
+        release_tags.append((*version_parts, tag))
+    return sorted(release_tags)
+
+
+def release_tags_before(base_version: str, head_ref: str = "HEAD") -> list[tuple[int, int, int, str]]:
+    """Return reachable stable release tags older than ``base_version``."""
+    base_parts = parse_version(base_version)
+    return [tag_parts for tag_parts in reachable_release_tags(head_ref) if tag_parts[:3] < base_parts]
+
+
+def prerelease_base_ref(head_ref: str = "HEAD", base_version: str | None = None) -> str:
+    """Return the ref that starts the current prerelease sequence."""
+    version = base_version or pyproject_version()
+    version_parts = parse_version(version)
+    stable_tags = reachable_release_tags(head_ref)
+    matching_tags = [tag for *tag_version, tag in stable_tags if tuple(tag_version) == version_parts]
+    if matching_tags:
+        raise ValueError(
+            f"Stable release tag {matching_tags[-1]!r} already matches pyproject.version {version!r}. "
+            "Bump pyproject.version to the next release target or adjust the release process."
+        )
+
+    release_tags = [tag_parts for tag_parts in stable_tags if tag_parts[:3] < version_parts]
+    if release_tags:
+        return release_tags[-1][3]
+    return MAIN_VERSION_BASE_SHA
+
+
+def main_prerelease_number(head_ref: str = "HEAD", base_version: str | None = None) -> int:
+    """Return the alpha prerelease number for ``head_ref``."""
+    base_ref = prerelease_base_ref(head_ref, base_version)
+    commit_count = int(run_git(["rev-list", "--count", f"{base_ref}..{head_ref}"]))
+    return max(1, commit_count)
 
 
 def main_version(head_ref: str = "HEAD", base_version: str | None = None) -> str:
-    """Return the PEP 440 version for ``head_ref`` on the main release line."""
-    major, minor, base_patch = parse_version(base_version or pyproject_version())
-    patch = main_patch_for_head(head_ref, base_patch)
-    return f"{major}.{minor}.{patch}"
+    """Return the Docker tag for ``head_ref`` on the main prerelease line."""
+    major, minor, patch = parse_version(base_version or pyproject_version())
+    alpha = main_prerelease_number(head_ref, base_version)
+    return f"{major}.{minor}.{patch}-alpha.{alpha}"
 
 
 def version_from_release_tag(tag: str, base_version: str | None = None) -> str:
-    """Return a PEP 440 version from a release tag such as ``0.3.7``."""
-    normalized = tag.removeprefix("refs/tags/")
+    """Return a stable version from a release tag such as ``v0.3.7``."""
+    normalized = normalize_release_tag(tag)
     base_major, base_minor, _ = parse_version(base_version or pyproject_version())
     release_major, release_minor, _ = parse_version(normalized)
     if (release_major, release_minor) != (base_major, base_minor):
-        raise ValueError(f"Expected a release tag like {base_major}.{base_minor}.x, got {tag!r}.")
+        raise ValueError(f"Expected a release tag like v{base_major}.{base_minor}.x, got {tag!r}.")
     return normalized
+
+
+def pep440_version(version: str) -> str:
+    """Return the PEP 440 spelling for a stable or alpha Docker tag."""
+    if "-alpha." in version:
+        return version.replace("-alpha.", "a", 1)
+    return version
 
 
 def write_pyproject_version(path: Path, version: str) -> None:
@@ -69,14 +124,15 @@ def write_pyproject_version(path: Path, version: str) -> None:
 def write_github_output(path: Path, version: str) -> None:
     """Append version outputs for GitHub Actions."""
     with path.open("a", encoding="utf-8") as output:
-        output.write(f"pep440={version}\n")
+        output.write(f"pep440={pep440_version(version)}\n")
+        output.write(f"docker_tag={version}\n")
 
 
 def parse_args() -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--head-ref", default="HEAD", help="Git ref to version. Defaults to HEAD.")
-    parser.add_argument("--release-tag", help="Release tag to normalize, for example 0.3.7.")
+    parser.add_argument("--release-tag", help="Release tag to normalize, for example v0.3.7.")
     parser.add_argument(
         "--base-pyproject",
         type=Path,
@@ -87,7 +143,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--github-output",
         type=Path,
-        help="Optional GitHub Actions output file that receives the pep440 value.",
+        help="Optional GitHub Actions output file that receives pep440 and docker_tag values.",
     )
     return parser.parse_args()
 

--- a/scripts/ci/derive_version.py
+++ b/scripts/ci/derive_version.py
@@ -57,12 +57,6 @@ def reachable_release_tags(head_ref: str = "HEAD") -> list[tuple[int, int, int, 
     return sorted(release_tags)
 
 
-def release_tags_before(base_version: str, head_ref: str = "HEAD") -> list[tuple[int, int, int, str]]:
-    """Return reachable stable release tags older than ``base_version``."""
-    base_parts = parse_version(base_version)
-    return [tag_parts for tag_parts in reachable_release_tags(head_ref) if tag_parts[:3] < base_parts]
-
-
 def prerelease_base_ref(head_ref: str = "HEAD", base_version: str | None = None) -> str:
     """Return the ref that starts the current prerelease sequence."""
     version = base_version or pyproject_version()
@@ -72,6 +66,12 @@ def prerelease_base_ref(head_ref: str = "HEAD", base_version: str | None = None)
     if matching_tags:
         raise ValueError(
             f"Stable release tag {matching_tags[-1]!r} already matches pyproject.version {version!r}. "
+            "Bump pyproject.version to the next release target or adjust the release process."
+        )
+    newer_tags = [tag for *tag_version, tag in stable_tags if tuple(tag_version) > version_parts]
+    if newer_tags:
+        raise ValueError(
+            f"Stable release tag {newer_tags[-1]!r} is newer than pyproject.version {version!r}. "
             "Bump pyproject.version to the next release target or adjust the release process."
         )
 

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -226,7 +226,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--tag",
         default=None,
-        help="Unqualified tag to publish. Defaults to the current boileroom package version; explicit examples include 0.3.0 or sha-<commit>.",
+        help="Unqualified tag to publish. Defaults to the current boileroom package version; explicit examples include 0.3.0, 0.3.1-alpha.1, or sha-<commit>.",
     )
     parser.add_argument(
         "--docker-user",
@@ -288,7 +288,7 @@ def resolve_publish_tag(tag: str | None) -> str:
     if _CUDA_TAG_PATTERN.fullmatch(normalized):
         raise ValueError(
             f"Publish tag {tag!r} is already CUDA-qualified. "
-            "Pass an unqualified tag such as 0.3.0 or sha-<commit> and select CUDA variants with --cuda-version."
+            "Pass an unqualified tag such as 0.3.0, 0.3.1-alpha.1, or sha-<commit> and select CUDA variants with --cuda-version."
         )
     return normalized
 

--- a/tests/contracts/test_derive_version.py
+++ b/tests/contracts/test_derive_version.py
@@ -44,7 +44,20 @@ def test_main_version_rejects_already_released_base_version(monkeypatch) -> None
 
     monkeypatch.setattr(derive_version, "run_git", fake_run_git)
 
-    with pytest.raises(ValueError, match="Bump pyproject.version to the next release target"):
+    with pytest.raises(ValueError, match=r"Bump pyproject\.version to the next release target"):
+        derive_version.main_version(base_version="0.3.1")
+
+
+def test_main_version_rejects_newer_reachable_stable_release(monkeypatch) -> None:
+    """Main prereleases should not derive from behind a newer stable release."""
+
+    def fake_run_git(args: list[str]) -> str:
+        assert args == ["tag", "--merged", "HEAD", "--list"]
+        return "\n".join(["v0.3.0", "v0.3.2"])
+
+    monkeypatch.setattr(derive_version, "run_git", fake_run_git)
+
+    with pytest.raises(ValueError, match=r"Bump pyproject\.version to the next release target"):
         derive_version.main_version(base_version="0.3.1")
 
 
@@ -74,7 +87,7 @@ def test_version_from_release_tag_accepts_plain_version_tag() -> None:
 @pytest.mark.parametrize("tag", ["v0.2.1", "v0.4.1"])
 def test_version_from_release_tag_rejects_invalid_inputs(tag: str) -> None:
     """Invalid release tags should fail fast."""
-    with pytest.raises(ValueError, match="Expected a release tag like v0.3.x"):
+    with pytest.raises(ValueError, match=r"Expected a release tag like v0\.3\.x"):
         derive_version.version_from_release_tag(tag, "0.3.0")
 
 
@@ -84,7 +97,7 @@ def test_version_from_release_tag_rejects_invalid_inputs(tag: str) -> None:
 )
 def test_version_from_release_tag_rejects_malformed_inputs(tag: str) -> None:
     """Malformed release tags should fail fast."""
-    with pytest.raises(ValueError, match="Expected a release tag like v0.3.0"):
+    with pytest.raises(ValueError, match=r"Expected a release tag like v0\.3\.0"):
         derive_version.version_from_release_tag(tag, "0.3.0")
 
 

--- a/tests/contracts/test_derive_version.py
+++ b/tests/contracts/test_derive_version.py
@@ -8,27 +8,44 @@ from scripts.ci import derive_version
 
 
 def test_main_version_uses_commit_count_after_baseline(monkeypatch) -> None:
-    """Main releases should advance one patch version per commit after the baseline."""
+    """Main builds should publish alpha prerelease tags for the target version."""
 
     def fake_run_git(args: list[str]) -> str:
+        if args == ["tag", "--merged", "HEAD", "--list"]:
+            return ""
         assert args == ["rev-list", "--count", f"{derive_version.MAIN_VERSION_BASE_SHA}..HEAD"]
         return "7"
 
     monkeypatch.setattr(derive_version, "run_git", fake_run_git)
 
-    assert derive_version.main_version() == "0.3.7"
+    assert derive_version.main_version() == "0.3.0-alpha.7"
 
 
-def test_main_version_uses_pyproject_version_as_release_line(monkeypatch) -> None:
-    """The pyproject version should be the only maintained release-line version."""
+def test_main_version_counts_from_latest_stable_release_tag(monkeypatch) -> None:
+    """Alpha numbers should restart after the previous stable release."""
 
     def fake_run_git(args: list[str]) -> str:
-        assert args == ["rev-list", "--count", f"{derive_version.MAIN_VERSION_BASE_SHA}..HEAD"]
-        return "7"
+        if args == ["tag", "--merged", "HEAD", "--list"]:
+            return "\n".join(["v0.2.2", "v0.3.0", "0.3.1", "notes"])
+        assert args == ["rev-list", "--count", "v0.3.0..HEAD"]
+        return "2"
 
     monkeypatch.setattr(derive_version, "run_git", fake_run_git)
 
-    assert derive_version.main_version(base_version="0.4.2") == "0.4.9"
+    assert derive_version.main_version(base_version="0.3.1") == "0.3.1-alpha.2"
+
+
+def test_main_version_rejects_already_released_base_version(monkeypatch) -> None:
+    """Main prereleases should not continue after the target version has shipped."""
+
+    def fake_run_git(args: list[str]) -> str:
+        assert args == ["tag", "--merged", "HEAD", "--list"]
+        return "\n".join(["v0.2.2", "v0.3.0", "v0.3.1"])
+
+    monkeypatch.setattr(derive_version, "run_git", fake_run_git)
+
+    with pytest.raises(ValueError, match="Bump pyproject.version to the next release target"):
+        derive_version.main_version(base_version="0.3.1")
 
 
 def test_pyproject_version_reads_project_version(tmp_path) -> None:
@@ -43,28 +60,31 @@ def test_github_output_includes_pep440_version(tmp_path) -> None:
     """GitHub Actions should receive the package-compatible version."""
     output_path = tmp_path / "github-output.txt"
 
-    derive_version.write_github_output(output_path, "0.3.2")
+    derive_version.write_github_output(output_path, "0.3.1-alpha.2")
 
-    assert output_path.read_text(encoding="utf-8") == "pep440=0.3.2\n"
+    assert output_path.read_text(encoding="utf-8") == "pep440=0.3.1a2\ndocker_tag=0.3.1-alpha.2\n"
 
 
 def test_version_from_release_tag_accepts_plain_version_tag() -> None:
     """Release tags should become package-compatible versions."""
-    assert derive_version.version_from_release_tag("0.3.9", "0.3.0") == "0.3.9"
-    assert derive_version.version_from_release_tag("refs/tags/0.3.10", "0.3.0") == "0.3.10"
+    assert derive_version.version_from_release_tag("v0.3.9", "0.3.0") == "0.3.9"
+    assert derive_version.version_from_release_tag("refs/tags/v0.3.10", "0.3.0") == "0.3.10"
 
 
-@pytest.mark.parametrize("tag", ["0.2.1", "0.4.1"])
+@pytest.mark.parametrize("tag", ["v0.2.1", "v0.4.1"])
 def test_version_from_release_tag_rejects_invalid_inputs(tag: str) -> None:
     """Invalid release tags should fail fast."""
-    with pytest.raises(ValueError, match="Expected a release tag like 0.3.x"):
+    with pytest.raises(ValueError, match="Expected a release tag like v0.3.x"):
         derive_version.version_from_release_tag(tag, "0.3.0")
 
 
-@pytest.mark.parametrize("tag", ["", "main", "refs/heads/main", "v0.3.1", "0.3", "0.3.x"])
+@pytest.mark.parametrize(
+    "tag",
+    ["", "main", "refs/heads/main", "0.3.1", "refs/tags/0.3.1", "0.3", "0.3.x", "0.3.1-alpha.1"],
+)
 def test_version_from_release_tag_rejects_malformed_inputs(tag: str) -> None:
     """Malformed release tags should fail fast."""
-    with pytest.raises(ValueError, match="Expected a version like 0.3.0"):
+    with pytest.raises(ValueError, match="Expected a release tag like v0.3.0"):
         derive_version.version_from_release_tag(tag, "0.3.0")
 
 
@@ -91,9 +111,9 @@ def test_write_github_output_writes_pep440_value(tmp_path) -> None:
     """GitHub Actions output should receive the pep440 value verbatim."""
     output_path = tmp_path / "github-output.txt"
 
-    derive_version.write_github_output(output_path, "not-a-version")
+    derive_version.write_github_output(output_path, "0.3.2")
 
-    assert output_path.read_text(encoding="utf-8") == "pep440=not-a-version\n"
+    assert output_path.read_text(encoding="utf-8") == "pep440=0.3.2\ndocker_tag=0.3.2\n"
 
 
 def test_write_github_output_propagates_write_errors(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Publish main-branch image builds as alpha prerelease tags for the current target version instead of incrementing stable patch versions per commit.
- Require `vX.Y.Z` GitHub release tags and normalize them to `X.Y.Z` for Docker and PyPI publication.
- Update the image publishing workflow, docs, CLI help, and contract tests for the new release flow.

Closes #77

## Validation
- `uv run pytest tests/contracts/test_derive_version.py`
- `uv run pytest tests/contracts -n 4`
- `uv run python scripts/harness/check_repo.py`
- `uv run pre-commit run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Main branch builds now publish Docker images with alpha prerelease tags (e.g., 0.3.1-alpha.1).
  * GitHub releases promote verified images to stable X.Y.Z tags; workflow now accepts release events for stable promotions and version derivation.

* **Behavior Changes**
  * Pre-release GitHub releases no longer trigger stable Docker or PyPI publication; prepare/publish steps are skipped for prereleases.

* **Documentation**
  * Updated release, image-tagging, and versioning guidance to describe alpha prereleases, promotion behavior, and stable-release flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->