### PR TITLE
chore: consolidate image selection flags

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -33,7 +33,7 @@ permissions:
 concurrency: dockerhub-builds-${{ github.ref }}
 
 env:
-  BOILEROOM_DOCKER_REPOSITORY: ${{ github.event.inputs.docker_repository || 'docker.io/jakublala' }}
+  DOCKER_REPOSITORY_FOR_RUN: ${{ github.event.inputs.docker_repository || 'docker.io/jakublala' }}
   DOCKERHUB_USERNAME_FOR_RUN: ${{ github.event.inputs.dockerhub_username || secrets.DOCKERHUB_USERNAME }}
   DOCKERHUB_TOKEN_SECRET_FOR_RUN: ${{ github.event.inputs.dockerhub_token_secret || 'DOCKERHUB_TOKEN' }}
   IMAGE_BUILD_MAX_WORKERS: "3"
@@ -146,6 +146,7 @@ jobs:
           uv run python ./scripts/images/build_model_images.py \
             --cuda-version=${{ matrix.cuda_version }} \
             --tag=${{ needs.prepare-release.outputs.validation_tag }} \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --platform=${{ matrix.platform }} \
             "${build_args[@]}" \
             --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
@@ -155,24 +156,28 @@ jobs:
         run: |
           uv run python ./scripts/images/check_model_imports.py \
             --cuda-version=${{ matrix.cuda_version }} \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
       - name: Verify local canonical validation image server health
         run: |
           uv run python ./scripts/images/check_model_server_health.py \
             --cuda-version=${{ matrix.cuda_version }} \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
       - name: Verify local validation alias image imports
         if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
           uv run python ./scripts/images/check_model_imports.py \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
       - name: Verify local validation alias image server health
         if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
           uv run python ./scripts/images/check_model_server_health.py \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
       - name: Free disk space after build
@@ -215,5 +220,6 @@ jobs:
         run: |
           uv run python ./scripts/images/promote_image_tags.py \
             --all-cuda \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --source-tag=${{ needs.prepare-release.outputs.validation_tag }} \
             --target-tag=${{ needs.prepare-release.outputs.release_version }}

--- a/boileroom/images/import_checks.py
+++ b/boileroom/images/import_checks.py
@@ -9,6 +9,7 @@ from typing import Final
 
 from .metadata import (
     CUDA_MICROMAMBA_BASE,
+    DEFAULT_DOCKER_REPOSITORY,
     MODEL_IMAGE_SPECS,
     RuntimeImageSpec,
     format_image_reference,
@@ -51,6 +52,7 @@ def iter_image_targets(
     tag: str | None,
     cuda_versions: list[str],
     *,
+    docker_repository: str = DEFAULT_DOCKER_REPOSITORY,
     image_specs: Sequence[RuntimeImageSpec] | None = None,
 ) -> list[tuple[str, str, str, Path, Path]]:
     """Return model-image targets for smoke checks.
@@ -70,11 +72,13 @@ def iter_image_targets(
             for cuda_version in cuda_versions:
                 if cuda_version not in get_supported_cuda(spec):
                     continue
-                canonical_ref = published_image_references(spec.image_name, cuda_version, normalized_tag)[0]
+                canonical_ref = published_image_references(
+                    spec.image_name, cuda_version, normalized_tag, docker_repository
+                )[0]
                 display_tag = canonical_ref.rsplit(":", 1)[1]
                 targets.append((spec.key, canonical_ref, display_tag, env_path, core_path))
             continue
 
-        image_reference = format_image_reference(spec.image_name, normalized_tag)
+        image_reference = format_image_reference(spec.image_name, normalized_tag, docker_repository)
         targets.append((spec.key, image_reference, normalized_tag, env_path, core_path))
     return targets

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -12,12 +12,10 @@ from pathlib import Path
 from typing import Final
 
 DEFAULT_DOCKER_REPOSITORY: Final = "docker.io/jakublala"
-DOCKER_REGISTRY: Final = DEFAULT_DOCKER_REPOSITORY
 PACKAGE_NAME: Final = "boileroom"
 DEFAULT_CUDA_VERSION: Final = "12.6"
 DOCKER_REPOSITORY_ENV: Final = "BOILEROOM_DOCKER_REPOSITORY"
 MODAL_IMAGE_TAG_ENV: Final = "BOILEROOM_MODAL_IMAGE_TAG"
-MODAL_BASE_IMAGE_REF_ENV: Final = "BOILEROOM_MODAL_BASE_IMAGE"
 
 CUDA_MICROMAMBA_BASE: Final[dict[str, str]] = {
     "11.8": "mambaorg/micromamba:2.5-cuda11.8.0-ubuntu22.04",
@@ -174,29 +172,51 @@ def get_docker_repository() -> str:
     if override is None or not override.strip():
         return DEFAULT_DOCKER_REPOSITORY
 
-    repository = override.strip()
+    return normalize_docker_repository(override)
+
+
+def normalize_docker_repository(repository: str) -> str:
+    """Return a normalized Docker Hub repository namespace."""
+    normalized = repository.strip().removesuffix("/")
+    if not normalized:
+        raise ValueError("Docker repository must not be empty.")
+    if normalized == "docker.io" or ("." in normalized and "/" not in normalized):
+        raise ValueError("Docker repository must use the form 'docker.io/<repository>'.")
+    if "/" in normalized and "." in normalized.split("/", 1)[0] and not normalized.startswith("docker.io/"):
+        raise ValueError("Docker repository must use the form 'docker.io/<repository>'.")
+    if not normalized.startswith("docker.io/"):
+        normalized = f"docker.io/{normalized}"
     if (
         re.fullmatch(
             r"docker\.io/(?:[a-z0-9]+(?:[._-][a-z0-9]+)*)(?:/(?:[a-z0-9]+(?:[._-][a-z0-9]+)*))*",
-            repository,
+            normalized,
         )
         is None
     ):
-        raise ValueError(f"{DOCKER_REPOSITORY_ENV} must use the form 'docker.io/<repository>'.")
-    return repository
+        raise ValueError("Docker repository must use the form 'docker.io/<repository>'.")
+    return normalized
 
 
-def format_image_reference(image_name: str, tag: str | None = None) -> str:
+def format_image_reference(image_name: str, tag: str | None = None, docker_repository: str | None = None) -> str:
     """Return a fully qualified Docker image reference."""
     resolved_tag = resolve_registry_tag(tag)
-    return f"{get_docker_repository()}/{image_name}:{resolved_tag}"
-
-
-def published_image_references(image_name: str, cuda_version: str, tag: str | None) -> tuple[str, ...]:
-    """Return all published references for a built image."""
-    return tuple(
-        f"{get_docker_repository()}/{image_name}:{published_tag}" for published_tag in published_tags(cuda_version, tag)
+    repository = (
+        get_docker_repository() if docker_repository is None else normalize_docker_repository(docker_repository)
     )
+    return f"{repository}/{image_name}:{resolved_tag}"
+
+
+def published_image_references(
+    image_name: str,
+    cuda_version: str,
+    tag: str | None,
+    docker_repository: str | None = None,
+) -> tuple[str, ...]:
+    """Return all published references for a built image."""
+    repository = (
+        get_docker_repository() if docker_repository is None else normalize_docker_repository(docker_repository)
+    )
+    return tuple(f"{repository}/{image_name}:{published_tag}" for published_tag in published_tags(cuda_version, tag))
 
 
 def get_modal_image_tag() -> str:
@@ -206,11 +226,6 @@ def get_modal_image_tag() -> str:
 
 def get_modal_base_image_reference() -> str:
     """Return the base image Modal should use for the shared runtime layer."""
-    override = os.environ.get(MODAL_BASE_IMAGE_REF_ENV)
-    if override:
-        normalized = override.strip()
-        if normalized:
-            return normalized
     return format_image_reference(BASE_IMAGE_SPEC.image_name, get_modal_image_tag())
 
 
@@ -256,8 +271,6 @@ def render_modal_runtime_env(spec: RuntimeImageSpec, model_dir: str) -> dict[str
         DOCKER_REPOSITORY_ENV: get_docker_repository(),
         MODAL_IMAGE_TAG_ENV: get_modal_image_tag(),
     }
-    if (override := os.environ.get(MODAL_BASE_IMAGE_REF_ENV)) and (normalized := override.strip()):
-        env[MODAL_BASE_IMAGE_REF_ENV] = normalized
     for key, value in spec.modal_runtime_env:
         env[key] = value.replace("{MODEL_DIR}", model_dir)
     return env

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -28,19 +28,18 @@ uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=0.3
 uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=sha-$(git rev-parse --short HEAD) --push ...
 ```
 
-Images publish to `docker.io/jakublala` by default. Set `BOILEROOM_DOCKER_REPOSITORY` to build and run against another namespace:
+Images publish to `docker.io/jakublala` by default. If `--tag` is omitted, image helpers use the current boileroom package version from `pyproject.toml`. Pass `--docker-user` and `--tag` to build or publish a specific tag under another Docker Hub namespace:
 
 ```bash
-export BOILEROOM_DOCKER_REPOSITORY=docker.io/my-dockerhub-user
+uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=0.3.0 --docker-user=my-dockerhub-user --push
 ```
 
-The same variable is used by Modal and Apptainer image lookups, so pytest runs that import Modal wrappers will pull from the same repository override. `BOILEROOM_MODAL_IMAGE_TAG` still controls only the tag.
+The image build, smoke check, and promotion helpers all accept the same `--docker-user` flag.
 
-For Modal pytest runs against images in a custom namespace, set both values:
+Modal pytest uses `docker.io/jakublala` plus the current package version by default. To run against manually published images, pass the same user and tag:
 
 ```bash
-export BOILEROOM_DOCKER_REPOSITORY=docker.io/my-dockerhub-user
-export BOILEROOM_MODAL_IMAGE_TAG=0.3.0
+uv run pytest --backend=modal --docker-user=my-dockerhub-user --image-tag=0.3.0
 ```
 
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
@@ -73,11 +72,6 @@ For example, a temporary validation push on the default CUDA line:
 ```bash
 TAG=sha-$(git rev-parse --short HEAD)
 uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag="$TAG" --platform=linux/amd64 --push
-```
-
-Modal can then be pointed at that published validation tag with:
-```bash
-export BOILEROOM_MODAL_IMAGE_TAG="$TAG"
 ```
 
 Because `12.6` is the default CUDA line, publishing `--tag="$TAG"` also creates the explicit `cuda12.6-$TAG` tag alongside the unqualified alias.

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -19,10 +19,11 @@ from boileroom.images.metadata import (  # noqa: E402
     BASE_IMAGE_SPEC,
     CUDA_MICROMAMBA_BASE,
     CUDA_TORCH_WHEEL_INDEX,
+    DEFAULT_DOCKER_REPOSITORY,
     MODEL_IMAGE_SPECS,
     RuntimeImageSpec,
-    get_docker_repository,
     get_supported_cuda,
+    normalize_docker_repository,
     normalize_cuda_version,
     normalize_requested_tag,
     published_image_references,
@@ -38,6 +39,7 @@ class BuildTask:
     cuda_version: str
     image_spec: RuntimeImageSpec
     base_image_reference: str
+    docker_repository: str
     tag: str
 
 
@@ -74,9 +76,10 @@ def log_error(message: str) -> None:
     print(Colors.wrap(message, Colors.red), file=sys.stderr)
 
 
-def build_cache_reference(image_name: str, cuda_version: str) -> str:
+def build_cache_reference(docker_repository: str, image_name: str, cuda_version: str) -> str:
     """Return the stable registry cache reference for a build output."""
-    return f"{get_docker_repository()}/{image_name}:buildcache-cuda{cuda_version}"
+    docker_repository = normalize_docker_repository(docker_repository)
+    return f"{docker_repository}/{image_name}:buildcache-cuda{cuda_version}"
 
 
 def append_registry_cache_args(
@@ -84,6 +87,7 @@ def append_registry_cache_args(
     image_name: str,
     cuda_version: str,
     *,
+    docker_repository: str,
     push: bool,
     no_cache: bool,
 ) -> None:
@@ -91,7 +95,7 @@ def append_registry_cache_args(
     if not push or no_cache:
         return
 
-    cache_reference = build_cache_reference(image_name, cuda_version)
+    cache_reference = build_cache_reference(docker_repository, image_name, cuda_version)
     cmd.extend(
         [
             "--cache-from",
@@ -225,6 +229,14 @@ def parse_args() -> argparse.Namespace:
         help="Unqualified tag to publish. Defaults to the current boileroom package version; explicit examples include 0.3.0 or sha-<commit>.",
     )
     parser.add_argument(
+        "--docker-user",
+        default=DEFAULT_DOCKER_REPOSITORY,
+        help=(
+            "Docker Hub user or namespace to publish under. "
+            "Accepts either a user such as my-dockerhub-user or a full namespace such as docker.io/my-dockerhub-user."
+        ),
+    )
+    parser.add_argument(
         "--cuda-version",
         action="append",
         dest="cuda_versions",
@@ -325,6 +337,7 @@ def should_use_local_docker_build(push: bool, platform: str) -> bool:
 def build_base(
     cuda_version: str,
     tag: str,
+    docker_repository: str,
     platform: str,
     output_flag: str | None,
     no_cache: bool,
@@ -333,14 +346,14 @@ def build_base(
     push_after_build: bool = False,
 ) -> str:
     """Build the shared base image and return its canonical reference."""
-    image_references = published_image_references(BASE_IMAGE_SPEC.image_name, cuda_version, tag)
-    canonical_reference = image_references[0]
+    references = published_image_references(BASE_IMAGE_SPEC.image_name, cuda_version, tag, docker_repository)
+    canonical_reference = references[0]
     micromamba_base = CUDA_MICROMAMBA_BASE[cuda_version]
 
     log_info("")
     log_info(Colors.wrap(f"=== Building base image for CUDA {cuda_version}: {canonical_reference}", Colors.bold))
     log_info(f"Using micromamba base: {micromamba_base}")
-    log_info(f"Publishing tags: {', '.join(image_references)}")
+    log_info(f"Publishing tags: {', '.join(references)}")
 
     log_file = Path.cwd() / f"{canonical_reference.replace('/', '_').replace(':', '_')}.log"
     effective_output_flag = "--load" if push_after_build else output_flag
@@ -367,12 +380,13 @@ def build_base(
             cmd,
             BASE_IMAGE_SPEC.image_name,
             cuda_version,
+            docker_repository=docker_repository,
             push=output_flag == "--push" or push_after_build,
             no_cache=no_cache,
         )
     if verbose:
         cmd.extend(["--progress", "plain"])
-    for image_reference in image_references:
+    for image_reference in references:
         cmd.extend(["-t", image_reference])
     cmd.extend(["-f", str(BASE_IMAGE_SPEC.dockerfile_path), str(BASE_IMAGE_SPEC.context_path)])
     if no_cache:
@@ -383,7 +397,7 @@ def build_base(
     log_info(f"Build log: {log_file}")
     run(cmd, log_file=log_file, echo=verbose)
     if push_after_build:
-        push_image_references(image_references)
+        push_image_references(references)
     return canonical_reference
 
 
@@ -397,11 +411,16 @@ def build_model(
     push_after_build: bool = False,
 ) -> tuple[str, ...]:
     """Build a single model image and return all published references."""
-    image_references = published_image_references(task.image_spec.image_name, task.cuda_version, task.tag)
-    canonical_reference = image_references[0]
+    references = published_image_references(
+        task.image_spec.image_name,
+        task.cuda_version,
+        task.tag,
+        task.docker_repository,
+    )
+    canonical_reference = references[0]
 
     log_info(Colors.wrap(f"--- Building {task.image_spec.key} for CUDA {task.cuda_version}: {canonical_reference}", Colors.bold))
-    log_info(f"Publishing tags: {', '.join(image_references)}")
+    log_info(f"Publishing tags: {', '.join(references)}")
 
     log_file = Path.cwd() / f"{canonical_reference.replace('/', '_').replace(':', '_')}.log"
     effective_output_flag = "--load" if push_after_build else output_flag
@@ -432,6 +451,7 @@ def build_model(
             cmd,
             task.image_spec.image_name,
             task.cuda_version,
+            docker_repository=task.docker_repository,
             push=output_flag == "--push" or push_after_build,
             no_cache=no_cache,
         )
@@ -439,7 +459,7 @@ def build_model(
             append_local_image_context_args(cmd, task.base_image_reference)
     if verbose:
         cmd.extend(["--progress", "plain"])
-    for image_reference in image_references:
+    for image_reference in references:
         cmd.extend(["-t", image_reference])
     cmd.extend(["-f", str(task.image_spec.dockerfile_path), str(task.image_spec.context_path)])
     if no_cache:
@@ -450,8 +470,8 @@ def build_model(
     log_info(f"Build log: {log_file}")
     run(cmd, log_file=log_file, echo=verbose)
     if push_after_build:
-        push_image_references(image_references)
-    return image_references
+        push_image_references(references)
+    return references
 
 
 def main() -> None:
@@ -461,6 +481,7 @@ def main() -> None:
     try:
         ensure_docker()
         tag = resolve_publish_tag(args.tag)
+        docker_repository = normalize_docker_repository(args.docker_user)
         cuda_versions = compute_cuda_versions(args.cuda_versions, args.all_cuda)
         output_flag = resolve_output_flag(args.push, args.load, args.platform)
         use_local_docker_build = should_use_local_docker_build(args.push, args.platform)
@@ -490,7 +511,7 @@ def main() -> None:
         )
 
     log_info(Colors.wrap(f"Boileroom repo root: {REPO_ROOT}", Colors.magenta))
-    log_info(f"Docker repository: {get_docker_repository()}")
+    log_info(f"Docker repository: {docker_repository}")
     log_info(f"Model images: {', '.join(spec.image_name for spec in MODEL_IMAGE_SPECS)}")
     log_info(f"CUDA versions: {', '.join(cuda_versions)}")
     log_info(f"Platforms: {args.platform}")
@@ -509,7 +530,12 @@ def main() -> None:
 
     for cuda_version in cuda_versions:
         try:
-            target_base_reference = published_image_references(BASE_IMAGE_SPEC.image_name, cuda_version, tag)[0]
+            target_base_reference = published_image_references(
+                BASE_IMAGE_SPEC.image_name,
+                cuda_version,
+                tag,
+                docker_repository,
+            )[0]
             if args.skip_existing and not args.force_rebuild and image_reference_exists(target_base_reference):
                 log_info(
                     f"Skipping base build for CUDA {cuda_version}; existing tag already present: "
@@ -520,6 +546,7 @@ def main() -> None:
                 base_reference = build_base(
                     cuda_version,
                     tag,
+                    docker_repository,
                     args.platform,
                     output_flag,
                     args.no_cache,
@@ -541,7 +568,7 @@ def main() -> None:
                     f"(supported CUDA variants: {', '.join(supported_cuda)})"
                 )
                 continue
-            target_reference = published_image_references(image_spec.image_name, cuda_version, tag)[0]
+            target_reference = published_image_references(image_spec.image_name, cuda_version, tag, docker_repository)[0]
             if args.skip_existing and not args.force_rebuild and image_reference_exists(target_reference):
                 log_info(
                     f"Skipping {image_spec.image_name} for CUDA {cuda_version}; existing tag already present: "
@@ -554,6 +581,7 @@ def main() -> None:
                     cuda_version=cuda_version,
                     image_spec=image_spec,
                     base_image_reference=base_reference,
+                    docker_repository=docker_repository,
                     tag=tag,
                 )
             )

--- a/scripts/images/check_model_imports.py
+++ b/scripts/images/check_model_imports.py
@@ -17,6 +17,8 @@ from boileroom.images.import_checks import (  # noqa: E402
     iter_image_targets,
 )
 from boileroom.images.metadata import (  # noqa: E402
+    DEFAULT_DOCKER_REPOSITORY,
+    normalize_docker_repository,
     normalize_requested_tag,
 )
 
@@ -29,6 +31,7 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Tag to check. Defaults to the installed boileroom version; explicit examples include 0.3.0 or cuda12.6-0.3.0.",
     )
+    parser.add_argument("--docker-user", default=DEFAULT_DOCKER_REPOSITORY, help="Docker Hub user or namespace to check.")
     parser.add_argument(
         "--cuda-version",
         action="append",
@@ -184,8 +187,9 @@ def main() -> None:
     """Run the import smoke workflow."""
     args = parse_args()
     ensure_docker()
+    docker_repository = normalize_docker_repository(args.docker_user)
     cuda_versions = compute_cuda_versions(args.cuda_versions, args.all_cuda)
-    targets = iter_image_targets(args.tag, cuda_versions)
+    targets = iter_image_targets(args.tag, cuda_versions, docker_repository=docker_repository)
     if not targets:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 

--- a/scripts/images/check_model_server_health.py
+++ b/scripts/images/check_model_server_health.py
@@ -16,7 +16,11 @@ if str(REPO_ROOT) not in sys.path:
 
 from boileroom.backend.transport import TRANSPORT_HMAC_KEY_ENV  # noqa: E402
 from boileroom.images.import_checks import compute_cuda_versions, iter_image_targets  # noqa: E402
-from boileroom.images.metadata import normalize_requested_tag  # noqa: E402
+from boileroom.images.metadata import (  # noqa: E402
+    DEFAULT_DOCKER_REPOSITORY,
+    normalize_docker_repository,
+    normalize_requested_tag,
+)
 
 SERVER_PATH = REPO_ROOT / "boileroom/backend/server.py"
 FAKE_MODEL_CLASS = "boileroom.testing.fake_core.HealthcheckCore"
@@ -30,6 +34,7 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Tag to check. Defaults to the installed boileroom version; explicit examples include 0.3.0 or cuda12.6-0.3.0.",
     )
+    parser.add_argument("--docker-user", default=DEFAULT_DOCKER_REPOSITORY, help="Docker Hub user or namespace to check.")
     parser.add_argument(
         "--cuda-version",
         action="append",
@@ -175,8 +180,9 @@ def main() -> None:
     """Run the server health-smoke workflow."""
     args = parse_args()
     ensure_docker()
+    docker_repository = normalize_docker_repository(args.docker_user)
     cuda_versions = compute_cuda_versions(args.cuda_versions, args.all_cuda)
-    targets = iter_image_targets(args.tag, cuda_versions)
+    targets = iter_image_targets(args.tag, cuda_versions, docker_repository=docker_repository)
     if not targets:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 

--- a/scripts/images/promote_image_tags.py
+++ b/scripts/images/promote_image_tags.py
@@ -14,9 +14,11 @@ if str(REPO_ROOT) not in sys.path:
 from boileroom.images.metadata import (  # noqa: E402
     BASE_IMAGE_SPEC,
     CUDA_MICROMAMBA_BASE,
+    DEFAULT_DOCKER_REPOSITORY,
     MODEL_IMAGE_SPECS,
     RuntimeImageSpec,
     get_supported_cuda,
+    normalize_docker_repository,
     normalize_cuda_version,
     normalize_requested_tag,
     published_image_references,
@@ -28,6 +30,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Promote validated boileroom image tags without rebuilding.")
     parser.add_argument("--source-tag", required=True, help="Validated source tag, for example sha-abcd1234.")
     parser.add_argument("--target-tag", required=True, help="Public target tag, for example 0.3.0.")
+    parser.add_argument("--docker-user", default=DEFAULT_DOCKER_REPOSITORY, help="Docker Hub user or namespace to promote.")
     parser.add_argument(
         "--cuda-version",
         action="append",
@@ -60,10 +63,16 @@ def compute_cuda_versions(requested: list[str] | None, all_cuda: bool) -> list[s
     return [normalize_cuda_version(cuda_version) for cuda_version in requested]
 
 
-def promote_one(spec: RuntimeImageSpec, cuda_version: str, source_tag: str, target_tag: str) -> None:
+def promote_one(
+    spec: RuntimeImageSpec,
+    cuda_version: str,
+    source_tag: str,
+    target_tag: str,
+    docker_repository: str,
+) -> None:
     """Promote one canonical image manifest to its public target tags."""
-    source_reference = published_image_references(spec.image_name, cuda_version, source_tag)[0]
-    target_references = published_image_references(spec.image_name, cuda_version, target_tag)
+    source_reference = published_image_references(spec.image_name, cuda_version, source_tag, docker_repository)[0]
+    target_references = published_image_references(spec.image_name, cuda_version, target_tag, docker_repository)
     cmd = ["docker", "buildx", "imagetools", "create"]
     for target_reference in target_references:
         cmd.extend(["-t", target_reference])
@@ -76,6 +85,7 @@ def main() -> None:
     """Promote validated runtime images to public tags."""
     args = parse_args()
     ensure_buildx()
+    docker_repository = normalize_docker_repository(args.docker_user)
     source_tag = normalize_requested_tag(args.source_tag)
     target_tag = normalize_requested_tag(args.target_tag)
     cuda_versions = compute_cuda_versions(args.cuda_versions, args.all_cuda)
@@ -85,7 +95,7 @@ def main() -> None:
         for spec in image_specs:
             if cuda_version not in get_supported_cuda(spec):
                 continue
-            promote_one(spec, cuda_version, source_tag, target_tag)
+            promote_one(spec, cuda_version, source_tag, target_tag, docker_repository)
 
 
 if __name__ == "__main__":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import pathlib
 
 import pytest
 
+from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, MODAL_IMAGE_TAG_ENV, normalize_docker_repository
+
 
 def pytest_addoption(parser):
     """Register pytest CLI options used by the test suite.
@@ -12,6 +14,8 @@ def pytest_addoption(parser):
     Adds two command-line options:
     - --backend: selects the execution backend for tests; allowed values are "modal" and "apptainer", defaults to "modal".
     - --gpu: specifies the GPU type for Modal backend tests (examples: "A100-40GB", "A100-80GB", "T4"); defaults to None which uses the test-suite default.
+    - --docker-user: overrides the default Docker Hub user or namespace for Modal image lookup; defaults to None, which uses the package default.
+    - --image-tag: selects the runtime image tag for Modal image lookup; defaults to None, which uses the current package version.
 
     Parameters
     ----------
@@ -31,6 +35,26 @@ def pytest_addoption(parser):
         default=None,
         help="GPU type for Modal backend tests (e.g., A100-40GB, A100-80GB, T4). Defaults to None (uses default T4).",
     )
+    parser.addoption(
+        "--docker-user",
+        action="store",
+        default=None,
+        help="Docker Hub user or namespace for Modal image lookup.",
+    )
+    parser.addoption(
+        "--image-tag",
+        action="store",
+        default=None,
+        help="Runtime image tag for Modal image lookup.",
+    )
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Apply image lookup options before test modules import Modal wrappers."""
+    if docker_user := config.getoption("--docker-user"):
+        os.environ[DOCKER_REPOSITORY_ENV] = normalize_docker_repository(docker_user)
+    if image_tag := config.getoption("--image-tag"):
+        os.environ[MODAL_IMAGE_TAG_ENV] = image_tag
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -21,6 +21,7 @@ def test_build_base_push_uses_registry_cache(monkeypatch, tmp_path) -> None:
     build_model_images.build_base(
         DEFAULT_CUDA_VERSION,
         "sha-test",
+        "docker.io/jakublala",
         "linux/amd64",
         "--push",
         no_cache=False,
@@ -47,6 +48,7 @@ def test_build_base_no_cache_disables_registry_cache(monkeypatch, tmp_path) -> N
     build_model_images.build_base(
         DEFAULT_CUDA_VERSION,
         "sha-test",
+        "docker.io/jakublala",
         "linux/amd64",
         "--push",
         no_cache=True,
@@ -59,10 +61,9 @@ def test_build_base_no_cache_disables_registry_cache(monkeypatch, tmp_path) -> N
     assert "--cache-to" not in cmd
 
 
-def test_build_cache_reference_uses_repository_env(monkeypatch) -> None:
-    """Build cache tags should follow the same repository override as image tags."""
-    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
-    assert build_model_images.build_cache_reference("boileroom-base", DEFAULT_CUDA_VERSION) == (
+def test_build_cache_reference_uses_explicit_repository() -> None:
+    """Build cache tags should follow the requested repository."""
+    assert build_model_images.build_cache_reference("example", "boileroom-base", DEFAULT_CUDA_VERSION) == (
         f"docker.io/example/boileroom-base:buildcache-cuda{DEFAULT_CUDA_VERSION}"
     )
 
@@ -78,6 +79,7 @@ def test_parse_args_exposes_documented_flags(monkeypatch) -> None:
             "--force-rebuild",
             "--verbose",
             "--local-base",
+            "--docker-user=example",
         ],
     )
 
@@ -86,6 +88,7 @@ def test_parse_args_exposes_documented_flags(monkeypatch) -> None:
     assert args.force_rebuild is True
     assert args.verbose is True
     assert args.local_base is True
+    assert args.docker_user == "example"
 
 
 def test_build_base_verbose_echoes_plain_progress(monkeypatch, tmp_path) -> None:
@@ -101,6 +104,7 @@ def test_build_base_verbose_echoes_plain_progress(monkeypatch, tmp_path) -> None
     build_model_images.build_base(
         DEFAULT_CUDA_VERSION,
         "sha-test",
+        "docker.io/jakublala",
         "linux/amd64",
         "--load",
         no_cache=False,
@@ -127,6 +131,7 @@ def test_build_base_local_base_uses_buildx_cache_load_then_push(monkeypatch, tmp
     build_model_images.build_base(
         DEFAULT_CUDA_VERSION,
         "sha-test",
+        "docker.io/jakublala",
         "linux/amd64",
         "--push",
         no_cache=False,
@@ -164,6 +169,7 @@ def test_build_model_local_base_uses_buildx_cache_context_then_push(monkeypatch,
             cuda_version=DEFAULT_CUDA_VERSION,
             image_spec=model_spec,
             base_image_reference=base_image_reference,
+            docker_repository="docker.io/jakublala",
             tag="sha-test",
         ),
         "linux/amd64",
@@ -203,6 +209,7 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
         force_rebuild=False,
         max_workers=1,
         local_base=False,
+        docker_user="docker.io/jakublala",
     )
 
     built_tasks: list[tuple[str, str]] = []
@@ -223,9 +230,9 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
         )
         return image_reference.endswith(existing_refs)
 
-    def fake_build_base(cuda_version: str, tag: str, *_args, **_kwargs) -> str:
+    def fake_build_base(cuda_version: str, tag: str, docker_repository: str, *_args, **_kwargs) -> str:
         built_bases.append(f"{cuda_version}:{tag}")
-        return f"docker.io/jakublala/boileroom-base:cuda{cuda_version}-{tag}"
+        return f"{docker_repository}/boileroom-base:cuda{cuda_version}-{tag}"
 
     def fake_build_model(task, *_args, **_kwargs):
         built_tasks.append((task.image_spec.image_name, task.base_image_reference))
@@ -272,6 +279,7 @@ def test_local_base_push_builds_locally_then_pushes(monkeypatch, tmp_path) -> No
         force_rebuild=False,
         max_workers=1,
         local_base=True,
+        docker_user="docker.io/jakublala",
     )
 
     base_calls: list[tuple[bool, bool]] = []
@@ -288,6 +296,7 @@ def test_local_base_push_builds_locally_then_pushes(monkeypatch, tmp_path) -> No
     def fake_build_base(
         cuda_version: str,
         tag: str,
+        docker_repository: str,
         _platform: str,
         _output_flag: str,
         _no_cache: bool,
@@ -296,7 +305,7 @@ def test_local_base_push_builds_locally_then_pushes(monkeypatch, tmp_path) -> No
         push_after_build: bool = False,
     ) -> str:
         base_calls.append((use_local_docker_build, push_after_build))
-        return f"docker.io/jakublala/boileroom-base:cuda{cuda_version}-{tag}"
+        return f"{docker_repository}/boileroom-base:cuda{cuda_version}-{tag}"
 
     def fake_build_model(
         task,

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -13,6 +13,7 @@ from boileroom.images.metadata import (
     get_modal_image_tag,
     get_model_image_spec,
     get_supported_cuda,
+    normalize_docker_repository,
     published_tags,
     render_modal_runtime_env,
     resolve_registry_tag,
@@ -60,40 +61,51 @@ def test_modal_tag_uses_env_override(monkeypatch) -> None:
     assert get_modal_image_tag() == f"cuda12.6-{get_default_image_tag()}"
 
 
-def test_modal_base_image_reference_uses_env_override(monkeypatch) -> None:
-    """Modal base image lookups should respect an optional image reference override."""
-    monkeypatch.setenv("BOILEROOM_MODAL_BASE_IMAGE", "docker.io/example/custom-base:1.2.3")
-    assert get_modal_base_image_reference() == "docker.io/example/custom-base:1.2.3"
+def test_modal_base_image_reference_uses_repository_and_tag(monkeypatch) -> None:
+    """Modal base image lookups should use the same repository and tag as model images."""
+    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
+    monkeypatch.setenv("BOILEROOM_MODAL_IMAGE_TAG", "0.3.0.1")
+
+    assert get_modal_base_image_reference() == "docker.io/example/boileroom-base:0.3.0.1"
 
 
 def test_modal_runtime_env_carries_image_lookup_overrides(monkeypatch) -> None:
     """Modal containers should re-import wrappers with the same resolved image lookup settings."""
     monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
     monkeypatch.setenv("BOILEROOM_MODAL_IMAGE_TAG", "0.3.0.1")
-    monkeypatch.setenv("BOILEROOM_MODAL_BASE_IMAGE", "docker.io/example/boileroom-base:0.3.0.1")
 
     env = render_modal_runtime_env(get_model_image_spec("boltz"), "/mnt/models")
 
     assert env["BOILEROOM_DOCKER_REPOSITORY"] == "docker.io/example"
     assert env["BOILEROOM_MODAL_IMAGE_TAG"] == "0.3.0.1"
-    assert env["BOILEROOM_MODAL_BASE_IMAGE"] == "docker.io/example/boileroom-base:0.3.0.1"
+    assert set(env) == {"MODEL_DIR", "BOILEROOM_DOCKER_REPOSITORY", "BOILEROOM_MODAL_IMAGE_TAG"}
 
 
 def test_docker_repository_uses_env_override(monkeypatch) -> None:
     """Image references should support a shared Docker repository override."""
-    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
+    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "example")
     assert get_docker_repository() == "docker.io/example"
     assert format_image_reference("boileroom-boltz", "0.3.0") == "docker.io/example/boileroom-boltz:0.3.0"
 
 
-def test_docker_repository_rejects_partial_or_non_docker_io_override(monkeypatch) -> None:
-    """Repository overrides should use the same full Docker Hub namespace format as the default."""
-    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "example")
-    with pytest.raises(ValueError, match="BOILEROOM_DOCKER_REPOSITORY"):
-        get_docker_repository()
+def test_normalize_docker_repository_accepts_user_or_full_namespace() -> None:
+    """Docker repository normalization should match CLI shorthand behavior."""
+    assert normalize_docker_repository("example") == "docker.io/example"
+    assert normalize_docker_repository("docker.io/example/team") == "docker.io/example/team"
+    assert normalize_docker_repository("docker.io/example/") == "docker.io/example"
 
+
+@pytest.mark.parametrize("repository", ["docker.io", "docker.io/", "ghcr.io"])
+def test_normalize_docker_repository_rejects_bare_registries(repository: str) -> None:
+    """Bare registry hosts should not be treated as Docker Hub users."""
+    with pytest.raises(ValueError, match="Docker repository"):
+        normalize_docker_repository(repository)
+
+
+def test_docker_repository_rejects_non_docker_io_override(monkeypatch) -> None:
+    """Repository overrides should remain Docker Hub namespaces."""
     monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "ghcr.io/example")
-    with pytest.raises(ValueError, match="BOILEROOM_DOCKER_REPOSITORY"):
+    with pytest.raises(ValueError, match="Docker repository"):
         get_docker_repository()
 
 
@@ -103,13 +115,12 @@ def test_docker_repository_rejects_partial_or_non_docker_io_override(monkeypatch
         ("docker.io/Example", "uppercase"),
         ("docker.io/example repo", "spaces"),
         ("docker.io/example//repo", "double slash"),
-        ("docker.io/example/", "trailing slash"),
     ],
 )
 def test_docker_repository_rejects_malformed_docker_io_override(monkeypatch, override: str, label: str) -> None:
     """Repository overrides should reject malformed Docker Hub namespaces."""
     monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", override)
-    with pytest.raises(ValueError, match="BOILEROOM_DOCKER_REPOSITORY"):
+    with pytest.raises(ValueError, match="Docker repository"):
         get_docker_repository()
 
 
@@ -135,8 +146,11 @@ def test_package_name_to_import_name_handles_overrides_and_hyphens() -> None:
 
 def test_iter_image_targets_uses_canonical_cuda_tags() -> None:
     """Image smoke targets should honor CUDA-qualified tag selection."""
-    targets = iter_image_targets("0.3.0", ["12.6"])
+    targets = iter_image_targets("0.3.0", ["12.6"], docker_repository="example")
     references = {image_key: image_reference for image_key, image_reference, *_ in targets}
+    assert references["boltz"].startswith("docker.io/example/")
+    assert references["chai"].startswith("docker.io/example/")
+    assert references["esm"].startswith("docker.io/example/")
     assert references["boltz"].endswith(":cuda12.6-0.3.0")
     assert references["chai"].endswith(":cuda12.6-0.3.0")
     assert references["esm"].endswith(":cuda12.6-0.3.0")

--- a/tests/contracts/test_pytest_image_options.py
+++ b/tests/contracts/test_pytest_image_options.py
@@ -1,0 +1,73 @@
+"""Contract tests for pytest image lookup options."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any
+
+from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, MODAL_IMAGE_TAG_ENV
+
+
+def _load_test_conftest() -> Any:
+    path = Path(__file__).parents[1] / "conftest.py"
+    spec = importlib.util.spec_from_file_location("boileroom_test_conftest", path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FakeConfig:
+    def __init__(self, options: dict[str, str | None]) -> None:
+        self.options = options
+
+    def getoption(self, name: str) -> str | None:
+        return self.options.get(name)
+
+
+def test_pytest_image_options_set_modal_lookup_env(monkeypatch) -> None:
+    monkeypatch.delenv(DOCKER_REPOSITORY_ENV, raising=False)
+    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
+    conftest = _load_test_conftest()
+
+    try:
+        conftest.pytest_configure(FakeConfig({"--docker-user": "phauglin", "--image-tag": "sha-test"}))
+
+        assert os.environ[DOCKER_REPOSITORY_ENV] == "docker.io/phauglin"
+        assert os.environ[MODAL_IMAGE_TAG_ENV] == "sha-test"
+    finally:
+        os.environ.pop(DOCKER_REPOSITORY_ENV, None)
+        os.environ.pop(MODAL_IMAGE_TAG_ENV, None)
+
+
+def test_pytest_image_options_leave_env_unset_when_absent(monkeypatch) -> None:
+    monkeypatch.delenv(DOCKER_REPOSITORY_ENV, raising=False)
+    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
+    conftest = _load_test_conftest()
+
+    conftest.pytest_configure(FakeConfig({"--docker-user": None, "--image-tag": None}))
+
+    assert DOCKER_REPOSITORY_ENV not in os.environ
+    assert MODAL_IMAGE_TAG_ENV not in os.environ
+
+
+def test_pytest_image_options_can_set_only_one_env(monkeypatch) -> None:
+    monkeypatch.delenv(DOCKER_REPOSITORY_ENV, raising=False)
+    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
+    conftest = _load_test_conftest()
+
+    try:
+        conftest.pytest_configure(FakeConfig({"--docker-user": "phauglin", "--image-tag": None}))
+        assert os.environ[DOCKER_REPOSITORY_ENV] == "docker.io/phauglin"
+        assert MODAL_IMAGE_TAG_ENV not in os.environ
+
+        os.environ.pop(DOCKER_REPOSITORY_ENV, None)
+        conftest.pytest_configure(FakeConfig({"--docker-user": None, "--image-tag": "sha-test"}))
+        assert DOCKER_REPOSITORY_ENV not in os.environ
+        assert os.environ[MODAL_IMAGE_TAG_ENV] == "sha-test"
+    finally:
+        os.environ.pop(DOCKER_REPOSITORY_ENV, None)
+        os.environ.pop(MODAL_IMAGE_TAG_ENV, None)


### PR DESCRIPTION
## Summary
- consolidate Docker image repository selection behind `--docker-user` for build, smoke-check, health-check, and promotion helpers
- add pytest `--docker-user` and `--image-tag` options for Modal image lookup without environment variables
- remove the separate Modal base-image override so base and model images always use the same selected namespace and tag
- document the default namespace/tag behavior and the manual image test workflow

Closes #79.

## Validation
- `uv run pre-commit run --all-files`
- `uv run pytest tests/contracts/test_pytest_image_options.py --docker-user=phauglin --image-tag=sha-test`
- `uv run pytest tests/contracts/test_harness.py tests/contracts/test_image_metadata.py tests/contracts/test_build_model_images.py tests/contracts/test_pytest_image_options.py`
- `uv run python scripts/harness/check_repo.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Added --docker-user and --image-tag CLI options across build, validation, promotion, and test tooling; repository input is normalized.
  - Test harness supports image lookup via these CLI options.

* **Refactor**
  - Replaced several environment-variable overrides with flag-based configuration for Docker/Modal image selection.
  - Modal base-image override via env removed; base image now comes from package/runtime resolution.

* **Documentation**
  - Updated docs to document the new CLI flags and workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->