### PR TITLE
refactor: migrate maintenance scripts to click

### DIFF
--- a/.github/workflows/arm64-image-smoke.yml
+++ b/.github/workflows/arm64-image-smoke.yml
@@ -31,7 +31,7 @@ jobs:
           cache-suffix: arm64-image-smoke
 
       - name: Prepare image smoke script dependencies
-        run: uv run --no-project --with pyyaml python -c "import yaml"
+        run: uv run --no-project --with click --with pyyaml python -c "import click, yaml"
 
       - name: Determine default CUDA version
         id: image_metadata
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build ARM64 image set
         run: |
-          uv run --no-project --with pyyaml python scripts/images/build_model_images.py \
+          uv run --no-project --with click --with pyyaml python scripts/images/build_model_images.py \
             --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
             --tag=arm64-ci \
             --platform=linux/arm64 \
@@ -53,12 +53,12 @@ jobs:
 
       - name: Run ARM64 import smoke
         run: |
-          uv run --no-project --with pyyaml python scripts/images/check_model_imports.py \
+          uv run --no-project --with click --with pyyaml python scripts/images/check_model_imports.py \
             --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
             --tag=arm64-ci
 
       - name: Run ARM64 server health smoke
         run: |
-          uv run --no-project --with pyyaml python scripts/images/check_model_server_health.py \
+          uv run --no-project --with click --with pyyaml python scripts/images/check_model_server_health.py \
             --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
             --tag=arm64-ci

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -85,7 +85,7 @@ jobs:
             version_args+=(--release-tag "$GITHUB_REF_NAME")
           fi
 
-          uv run --no-project --with pyyaml python ./scripts/ci/derive_version.py "${version_args[@]}" --github-output "$GITHUB_OUTPUT"
+          uv run --no-project --with click --with pyyaml python ./scripts/ci/derive_version.py "${version_args[@]}" --github-output "$GITHUB_OUTPUT"
 
       - name: Determine validation tag
         id: validation_tag
@@ -132,7 +132,7 @@ jobs:
           cache-suffix: image-build-${{ matrix.platform }}-${{ matrix.cuda_version }}
 
       - name: Prepare image script dependencies
-        run: uv run --no-project --with pyyaml python -c "import yaml"
+        run: uv run --no-project --with click --with pyyaml python -c "import click, yaml"
 
       - name: Log in to Docker Hub
         if: matrix.platform == 'linux/amd64'
@@ -150,7 +150,7 @@ jobs:
             build_args+=(--push --local-base)
           fi
 
-          uv run --no-project --with pyyaml python ./scripts/images/build_model_images.py \
+          uv run --no-project --with click --with pyyaml python ./scripts/images/build_model_images.py \
             --cuda-version=${{ matrix.cuda_version }} \
             --tag=${{ needs.prepare-release.outputs.validation_tag }} \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
@@ -161,14 +161,14 @@ jobs:
 
       - name: Verify local canonical validation image imports
         run: |
-          uv run --no-project --with pyyaml python ./scripts/images/check_model_imports.py \
+          uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
             --cuda-version=${{ matrix.cuda_version }} \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
       - name: Verify local canonical validation image server health
         run: |
-          uv run --no-project --with pyyaml python ./scripts/images/check_model_server_health.py \
+          uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
             --cuda-version=${{ matrix.cuda_version }} \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
@@ -176,14 +176,14 @@ jobs:
       - name: Verify local validation alias image imports
         if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
-          uv run --no-project --with pyyaml python ./scripts/images/check_model_imports.py \
+          uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
       - name: Verify local validation alias image server health
         if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
-          uv run --no-project --with pyyaml python ./scripts/images/check_model_server_health.py \
+          uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
@@ -223,7 +223,7 @@ jobs:
 
       - name: Promote validated images to target tag
         run: |
-          uv run --no-project --with pyyaml python ./scripts/images/promote_image_tags.py \
+          uv run --no-project --with click --with pyyaml python ./scripts/images/promote_image_tags.py \
             --all-cuda \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --source-tag=${{ needs.prepare-release.outputs.validation_tag }} \

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Apply release version
         run: |
-          uv run --no-project python ./scripts/ci/derive_version.py --release-tag "${GITHUB_REF_NAME}" --write-pyproject pyproject.toml
+          uv run --no-project --with click python ./scripts/ci/derive_version.py --release-tag "${GITHUB_REF_NAME}" --write-pyproject pyproject.toml
 
       - name: Build and publish to PyPI
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
+    "click>=8.1",
     "httpx>=0.27.0",
     "modal>=1.1.0",
     "numpy>=2.2.2",
@@ -36,7 +37,6 @@ dev = [
     "pytest>=8.3.4",
     "pytest-xdist>=3.6.1",
     "pytest-mock>=3.14.0",
-    "fire>=0.7.0",
 ]
 
 [project.urls]

--- a/scripts/ci/derive_version.py
+++ b/scripts/ci/derive_version.py
@@ -2,18 +2,39 @@
 
 from __future__ import annotations
 
-import argparse
 import re
 import subprocess
+import sys
 import tomllib
+from dataclasses import dataclass
 from pathlib import Path
 
+import click
+
+SCRIPT_PATH = Path(__file__).resolve()
+REPO_ROOT = SCRIPT_PATH.parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.cli_utils import CONTEXT_SETTINGS  # noqa: E402
+
 MAIN_VERSION_BASE_SHA = "48e8a23fbde63e95a0e39fe0d5748c3f338b30b3"
-DEFAULT_PYPROJECT_PATH = Path(__file__).resolve().parents[2] / "pyproject.toml"
+DEFAULT_PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
 VERSION_PATTERN = re.compile(r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$")
 RELEASE_TAG_PATTERN = re.compile(
     r"^(?:refs/tags/)?v(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)$"
 )
+
+
+@dataclass(frozen=True)
+class VersionOptions:
+    """CLI options for release version derivation."""
+
+    head_ref: str
+    release_tag: str | None
+    base_pyproject: Path
+    write_pyproject: Path | None
+    github_output: Path | None
 
 
 def run_git(args: list[str]) -> str:
@@ -128,41 +149,62 @@ def write_github_output(path: Path, version: str) -> None:
         output.write(f"docker_tag={version}\n")
 
 
-def parse_args() -> argparse.Namespace:
-    """Parse command-line arguments."""
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--head-ref", default="HEAD", help="Git ref to version. Defaults to HEAD.")
-    parser.add_argument("--release-tag", help="Release tag to normalize, for example v0.3.7.")
-    parser.add_argument(
-        "--base-pyproject",
-        type=Path,
-        default=DEFAULT_PYPROJECT_PATH,
-        help="Path to the pyproject.toml version anchor. Defaults to the repository pyproject.toml.",
-    )
-    parser.add_argument("--write-pyproject", type=Path, help="Optional pyproject.toml path to update.")
-    parser.add_argument(
-        "--github-output",
-        type=Path,
-        help="Optional GitHub Actions output file that receives pep440 and docker_tag values.",
-    )
-    return parser.parse_args()
-
-
-def main() -> None:
+def run_derive_version(options: VersionOptions) -> None:
     """CLI entrypoint."""
-    args = parse_args()
-    base_version = pyproject_version(args.base_pyproject)
+
+    base_version = pyproject_version(options.base_pyproject)
     version = (
-        version_from_release_tag(args.release_tag, base_version)
-        if args.release_tag
-        else main_version(args.head_ref, base_version)
+        version_from_release_tag(options.release_tag, base_version)
+        if options.release_tag
+        else main_version(options.head_ref, base_version)
     )
-    if args.write_pyproject is not None:
-        write_pyproject_version(args.write_pyproject, version)
-    if args.github_output is not None:
-        write_github_output(args.github_output, version)
+    if options.write_pyproject is not None:
+        write_pyproject_version(options.write_pyproject, version)
+    if options.github_output is not None:
+        write_github_output(options.github_output, version)
     print(version)
 
 
+@click.command(context_settings=CONTEXT_SETTINGS, help=__doc__)
+@click.option("--head-ref", default="HEAD", help="Git ref to version. Defaults to HEAD.")
+@click.option("--release-tag", default=None, help="Release tag to normalize, for example 0.3.7.")
+@click.option(
+    "--base-pyproject",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_PYPROJECT_PATH,
+    help="Path to the pyproject.toml version anchor. Defaults to the repository pyproject.toml.",
+)
+@click.option(
+    "--write-pyproject",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional pyproject.toml path to update.",
+)
+@click.option(
+    "--github-output",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional GitHub Actions output file that receives the pep440 value.",
+)
+def cli(
+    head_ref: str,
+    release_tag: str | None,
+    base_pyproject: Path,
+    write_pyproject: Path | None,
+    github_output: Path | None,
+) -> None:
+    """Run the version derivation Click command."""
+
+    run_derive_version(
+        VersionOptions(
+            head_ref=head_ref,
+            release_tag=release_tag,
+            base_pyproject=base_pyproject,
+            write_pyproject=write_pyproject,
+            github_output=github_output,
+        )
+    )
+
+
 if __name__ == "__main__":
-    main()
+    cli()

--- a/scripts/cli_utils.py
+++ b/scripts/cli_utils.py
@@ -1,0 +1,75 @@
+"""Shared Click helpers for repo-local maintenance scripts."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any, TypeVar, cast
+
+import click
+
+CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+
+def none_if_empty(values: Sequence[str]) -> list[str] | None:
+    """Return a list for repeated Click options, or None when omitted."""
+
+    return list(values) if values else None
+
+
+def tag_option(function: F) -> F:
+    """Add the shared image tag option."""
+
+    return cast(
+        F,
+        click.option(
+            "--tag",
+            default=None,
+            help=(
+                "Tag to check. Defaults to the installed boileroom version; explicit examples include "
+                "0.3.0 or cuda12.6-0.3.0."
+            ),
+        )(function),
+    )
+
+
+def cuda_version_option(help_text: str) -> Callable[[F], F]:
+    """Return a reusable repeatable CUDA-version Click option decorator."""
+
+    def decorator(function: F) -> F:
+        return cast(
+            F,
+            click.option(
+                "--cuda-version",
+                "cuda_versions",
+                multiple=True,
+                help=help_text,
+            )(function),
+        )
+
+    return decorator
+
+
+def all_cuda_option(help_text: str) -> Callable[[F], F]:
+    """Return the shared all-CUDA flag decorator."""
+
+    def decorator(function: F) -> F:
+        return cast(F, click.option("--all-cuda", is_flag=True, help=help_text)(function))
+
+    return decorator
+
+
+def pull_option(function: F) -> F:
+    """Add the shared Docker pull flag."""
+
+    return cast(F, click.option("--pull", is_flag=True, help="Pull images before running checks.")(function))
+
+
+def cleanup_option(function: F) -> F:
+    """Add the shared Docker image cleanup flag."""
+
+    return cast(
+        F,
+        click.option("--cleanup", is_flag=True, help="Remove each image after checking to free disk space.")(function),
+    )

--- a/scripts/harness/check_repo.py
+++ b/scripts/harness/check_repo.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import argparse
 import ast
 import importlib
 import json
@@ -13,6 +12,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any
 
+import click
 import yaml
 
 SCRIPT_PATH = Path(__file__).resolve()
@@ -23,6 +23,7 @@ if str(REPO_ROOT) not in sys.path:
 from boileroom.images.import_checks import iter_image_targets  # noqa: E402
 from boileroom.images.metadata import MODEL_IMAGE_SPECS, RuntimeImageSpec  # noqa: E402
 from boileroom.models.registry import MODEL_SPECS, ModelSpec, resolve_object  # noqa: E402
+from scripts.cli_utils import CONTEXT_SETTINGS  # noqa: E402
 
 DEFAULT_CONTRACT_PATH = REPO_ROOT / "harness/model_family_contract.yaml"
 
@@ -684,31 +685,36 @@ def _print_report(issues: Sequence[CheckIssue]) -> None:
         print(f"   Fix: {issue.fix}", file=sys.stderr)
 
 
-def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
-    """Parse CLI arguments."""
-
-    parser = argparse.ArgumentParser(description="Run objective Boileroom harness checks.")
-    parser.add_argument(
-        "--contract",
-        type=Path,
-        default=DEFAULT_CONTRACT_PATH,
-        help="Path to the YAML harness contract.",
-    )
-    parser.add_argument("--json-output", type=Path, default=None, help="Optional path for a JSON report.")
-    return parser.parse_args(argv)
-
-
-def main(argv: Sequence[str] | None = None) -> int:
+def run_harness(contract_path: Path = DEFAULT_CONTRACT_PATH, json_output: Path | None = None) -> int:
     """Run the harness CLI."""
 
-    args = parse_args(argv)
-    contract = load_contract(args.contract)
+    contract = load_contract(contract_path)
     issues = run_checks(REPO_ROOT, contract)
-    if args.json_output is not None:
-        _write_json_report(args.json_output, issues)
+    if json_output is not None:
+        _write_json_report(json_output, issues)
     _print_report(issues)
     return 1 if issues else 0
 
 
+@click.command(context_settings=CONTEXT_SETTINGS, help="Run objective Boileroom harness checks.")
+@click.option(
+    "--contract",
+    "contract_path",
+    type=click.Path(path_type=Path),
+    default=DEFAULT_CONTRACT_PATH,
+    help="Path to the YAML harness contract.",
+)
+@click.option(
+    "--json-output",
+    type=click.Path(path_type=Path),
+    default=None,
+    help="Optional path for a JSON report.",
+)
+def cli(contract_path: Path, json_output: Path | None) -> None:
+    """Run the harness Click command."""
+
+    raise click.exceptions.Exit(run_harness(contract_path, json_output))
+
+
 if __name__ == "__main__":
-    raise SystemExit(main())
+    cli()

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -435,7 +435,6 @@ def run_build(options: BuildOptions) -> None:
     """Run the Docker image build workflow."""
 
     try:
-        ensure_docker()
         tag = resolve_publish_tag(options.tag)
         docker_repository = normalize_docker_repository(options.docker_user)
         cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
@@ -447,6 +446,7 @@ def run_build(options: BuildOptions) -> None:
             if "," in options.platform:
                 raise ValueError("--local-base requires a single --platform value.")
             use_local_docker_build = False
+        ensure_docker()
         if not use_local_docker_build:
             ensure_buildx_builder()
     except Exception as exc:

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import argparse
 import re
 import shlex
 import subprocess
@@ -9,6 +8,8 @@ import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
+
+import click
 
 SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[2]
@@ -28,6 +29,7 @@ from boileroom.images.metadata import (  # noqa: E402
     normalize_requested_tag,
     published_image_references,
 )
+from scripts.cli_utils import CONTEXT_SETTINGS, all_cuda_option, cuda_version_option, none_if_empty  # noqa: E402
 
 _CUDA_TAG_PATTERN = re.compile(r"^cuda\d+\.\d+(?:-.+)?$")
 
@@ -41,6 +43,25 @@ class BuildTask:
     base_image_reference: str
     docker_repository: str
     tag: str
+
+
+@dataclass(frozen=True)
+class BuildOptions:
+    """CLI options for the Docker image build workflow."""
+
+    tag: str | None
+    docker_user: str
+    cuda_versions: list[str] | None
+    all_cuda: bool
+    platform: str
+    push: bool
+    load: bool
+    no_cache: bool
+    verbose: bool
+    skip_existing: bool
+    force_rebuild: bool
+    max_workers: int
+    local_base: bool
 
 
 class Colors:
@@ -216,70 +237,6 @@ def ensure_buildx_builder() -> None:
 
     subprocess.run(["docker", "buildx", "use", "boileroom-builder"], check=True)
     log_info("Using existing buildx builder 'boileroom-builder'.")
-
-
-def parse_args() -> argparse.Namespace:
-    """Parse CLI arguments."""
-    parser = argparse.ArgumentParser(
-        description="Build base and per-model Docker images using shared boileroom image metadata."
-    )
-    parser.add_argument(
-        "--tag",
-        default=None,
-        help="Unqualified tag to publish. Defaults to the current boileroom package version; explicit examples include 0.3.0, 0.3.1-alpha.1, or sha-<commit>.",
-    )
-    parser.add_argument(
-        "--docker-user",
-        default=DEFAULT_DOCKER_REPOSITORY,
-        help=(
-            "Docker Hub user or namespace to publish under. "
-            "Accepts either a user such as my-dockerhub-user or a full namespace such as docker.io/my-dockerhub-user."
-        ),
-    )
-    parser.add_argument(
-        "--cuda-version",
-        action="append",
-        dest="cuda_versions",
-        help=f"CUDA version to build (repeatable). Supported values: {', '.join(sorted(CUDA_MICROMAMBA_BASE))}.",
-    )
-    parser.add_argument("--all-cuda", action="store_true", help="Build all supported CUDA variants.")
-    parser.add_argument(
-        "--platform",
-        default="linux/amd64",
-        help="Comma-separated buildx platforms. The default release path publishes linux/amd64 only.",
-    )
-    parser.add_argument("--push", action="store_true", help="Push built images to Docker Hub.")
-    parser.add_argument(
-        "--load",
-        action="store_true",
-        help="Load single-platform builds into the local Docker daemon. Incompatible with --push and multi-platform builds.",
-    )
-    parser.add_argument("--no-cache", action="store_true", help="Disable Docker build cache.")
-    parser.add_argument(
-        "--verbose",
-        action="store_true",
-        help="Print Docker build output and plain BuildKit progress while still writing per-image log files.",
-    )
-    parser.add_argument(
-        "--skip-existing",
-        action="store_true",
-        help="Skip a build when the canonical image tag already exists in Docker Hub.",
-    )
-    parser.add_argument(
-        "--force-rebuild",
-        action="store_true",
-        help="Ignore --skip-existing and rebuild even when matching tags already exist.",
-    )
-    parser.add_argument("--max-workers", type=int, default=1, help="Maximum concurrent model-image builds.")
-    parser.add_argument(
-        "--local-base",
-        action="store_true",
-        help=(
-            "For single-platform pushed builds, load the base into the local Docker daemon and build model images "
-            "from that local base before pushing their tags."
-        ),
-    )
-    return parser.parse_args()
 
 
 def resolve_publish_tag(tag: str | None) -> str:
@@ -474,21 +431,20 @@ def build_model(
     return references
 
 
-def main() -> None:
+def run_build(options: BuildOptions) -> None:
     """Run the Docker image build workflow."""
-    args = parse_args()
 
     try:
         ensure_docker()
-        tag = resolve_publish_tag(args.tag)
-        docker_repository = normalize_docker_repository(args.docker_user)
-        cuda_versions = compute_cuda_versions(args.cuda_versions, args.all_cuda)
-        output_flag = resolve_output_flag(args.push, args.load, args.platform)
-        use_local_docker_build = should_use_local_docker_build(args.push, args.platform)
-        if args.local_base:
-            if not args.push:
+        tag = resolve_publish_tag(options.tag)
+        docker_repository = normalize_docker_repository(options.docker_user)
+        cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
+        output_flag = resolve_output_flag(options.push, options.load, options.platform)
+        use_local_docker_build = should_use_local_docker_build(options.push, options.platform)
+        if options.local_base:
+            if not options.push:
                 raise ValueError("--local-base only applies to pushed builds.")
-            if "," in args.platform:
+            if "," in options.platform:
                 raise ValueError("--local-base requires a single --platform value.")
             use_local_docker_build = False
         if not use_local_docker_build:
@@ -497,7 +453,7 @@ def main() -> None:
         log_error(str(exc))
         raise SystemExit(1) from exc
 
-    if args.local_base:
+    if options.local_base:
         log_info(
             "Using buildx --load and named image contexts for single-platform pushed images so model builds "
             "inherit the local base image."
@@ -514,15 +470,15 @@ def main() -> None:
     log_info(f"Docker repository: {docker_repository}")
     log_info(f"Model images: {', '.join(spec.image_name for spec in MODEL_IMAGE_SPECS)}")
     log_info(f"CUDA versions: {', '.join(cuda_versions)}")
-    log_info(f"Platforms: {args.platform}")
-    if args.verbose:
+    log_info(f"Platforms: {options.platform}")
+    if options.verbose:
         output_mode = {
             "--push": "push to registry",
             "--load": "load into local Docker",
             None: "buildx cache only",
         }[output_flag]
         log_info(f"Verbose build logs enabled; output mode: {output_mode}")
-    if args.force_rebuild and args.skip_existing:
+    if options.force_rebuild and options.skip_existing:
         log_info("Ignoring --skip-existing because --force-rebuild was set.")
 
     published_references: list[str] = []
@@ -536,7 +492,7 @@ def main() -> None:
                 tag,
                 docker_repository,
             )[0]
-            if args.skip_existing and not args.force_rebuild and image_reference_exists(target_base_reference):
+            if options.skip_existing and not options.force_rebuild and image_reference_exists(target_base_reference):
                 log_info(
                     f"Skipping base build for CUDA {cuda_version}; existing tag already present: "
                     f"{target_base_reference}"
@@ -547,12 +503,12 @@ def main() -> None:
                     cuda_version,
                     tag,
                     docker_repository,
-                    args.platform,
+                    options.platform,
                     output_flag,
-                    args.no_cache,
+                    options.no_cache,
                     use_local_docker_build,
-                    args.verbose,
-                    push_after_build=args.local_base,
+                    options.verbose,
+                    push_after_build=options.local_base,
                 )
         except Exception as exc:
             log_error(f"Failed to build base image for CUDA {cuda_version}: {exc}")
@@ -569,7 +525,7 @@ def main() -> None:
                 )
                 continue
             target_reference = published_image_references(image_spec.image_name, cuda_version, tag, docker_repository)[0]
-            if args.skip_existing and not args.force_rebuild and image_reference_exists(target_reference):
+            if options.skip_existing and not options.force_rebuild and image_reference_exists(target_reference):
                 log_info(
                     f"Skipping {image_spec.image_name} for CUDA {cuda_version}; existing tag already present: "
                     f"{target_reference}"
@@ -588,36 +544,36 @@ def main() -> None:
 
     if not tasks:
         log_warn("No model images matched the requested CUDA selection.")
-    elif args.max_workers <= 1 or len(tasks) == 1:
+    elif options.max_workers <= 1 or len(tasks) == 1:
         for task in tasks:
             try:
                 published_references.extend(
                     build_model(
                         task,
-                        args.platform,
+                        options.platform,
                         output_flag,
-                        args.no_cache,
+                        options.no_cache,
                         use_local_docker_build,
-                        args.verbose,
-                        push_after_build=args.local_base,
+                        options.verbose,
+                        push_after_build=options.local_base,
                     )
                 )
             except Exception as exc:
                 log_error(f"Failed to build {task.image_spec.image_name} for CUDA {task.cuda_version}: {exc}")
                 raise SystemExit(1) from exc
     else:
-        executor = ThreadPoolExecutor(max_workers=max(1, args.max_workers))
+        executor = ThreadPoolExecutor(max_workers=max(1, options.max_workers))
         try:
             future_map = {
                 executor.submit(
                     build_model,
                     task,
-                    args.platform,
+                    options.platform,
                     output_flag,
-                    args.no_cache,
+                    options.no_cache,
                     use_local_docker_build,
-                    args.verbose,
-                    push_after_build=args.local_base,
+                    options.verbose,
+                    push_after_build=options.local_base,
                 ): task
                 for task in tasks
             }
@@ -638,5 +594,99 @@ def main() -> None:
         print(f"  {image_reference}")
 
 
+@click.command(
+    context_settings=CONTEXT_SETTINGS,
+    help="Build base and per-model Docker images using shared boileroom image metadata.",
+)
+@click.option(
+    "--tag",
+    default=None,
+    help=(
+        "Unqualified tag to publish. Defaults to the current boileroom package version; explicit examples include "
+        "0.3.0 or sha-<commit>."
+    ),
+)
+@cuda_version_option("CUDA version to build (repeatable). Supported values: 11.8, 12.6.")
+@all_cuda_option("Build all supported CUDA variants.")
+@click.option(
+    "--docker-user",
+    default=DEFAULT_DOCKER_REPOSITORY,
+    help=(
+        "Docker Hub user or namespace to publish under. Accepts either a user such as my-dockerhub-user "
+        "or a full namespace such as docker.io/my-dockerhub-user."
+    ),
+)
+@click.option(
+    "--platform",
+    default="linux/amd64",
+    help="Comma-separated buildx platforms. The default release path publishes linux/amd64 only.",
+)
+@click.option("--push", is_flag=True, help="Push built images to Docker Hub.")
+@click.option(
+    "--load",
+    is_flag=True,
+    help="Load single-platform builds into the local Docker daemon. Incompatible with --push and multi-platform builds.",
+)
+@click.option("--no-cache", is_flag=True, help="Disable Docker build cache.")
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Print Docker build output and plain BuildKit progress while still writing per-image log files.",
+)
+@click.option(
+    "--skip-existing",
+    is_flag=True,
+    help="Skip a build when the canonical image tag already exists in Docker Hub.",
+)
+@click.option(
+    "--force-rebuild",
+    is_flag=True,
+    help="Ignore --skip-existing and rebuild even when matching tags already exist.",
+)
+@click.option("--max-workers", type=int, default=1, help="Maximum concurrent model-image builds.")
+@click.option(
+    "--local-base",
+    is_flag=True,
+    help=(
+        "For single-platform pushed builds, load the base into the local Docker daemon and build model images "
+        "from that local base before pushing their tags."
+    ),
+)
+def cli(
+    tag: str | None,
+    cuda_versions: tuple[str, ...],
+    all_cuda: bool,
+    docker_user: str,
+    platform: str,
+    push: bool,
+    load: bool,
+    no_cache: bool,
+    verbose: bool,
+    skip_existing: bool,
+    force_rebuild: bool,
+    max_workers: int,
+    local_base: bool,
+) -> None:
+    """Run the Docker image build Click command."""
+
+    run_build(
+        BuildOptions(
+            tag=tag,
+            docker_user=docker_user,
+            cuda_versions=none_if_empty(cuda_versions),
+            all_cuda=all_cuda,
+            platform=platform,
+            push=push,
+            load=load,
+            no_cache=no_cache,
+            verbose=verbose,
+            skip_existing=skip_existing,
+            force_rebuild=force_rebuild,
+            max_workers=max_workers,
+            local_base=local_base,
+        )
+    )
+
+
 if __name__ == "__main__":
-    main()
+    cli()

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -472,11 +472,14 @@ def run_build(options: BuildOptions) -> None:
     log_info(f"CUDA versions: {', '.join(cuda_versions)}")
     log_info(f"Platforms: {options.platform}")
     if options.verbose:
-        output_mode = {
-            "--push": "push to registry",
-            "--load": "load into local Docker",
-            None: "buildx cache only",
-        }[output_flag]
+        if options.local_base:
+            output_mode = "load into local Docker then push"
+        else:
+            output_mode = {
+                "--push": "push to registry",
+                "--load": "load into local Docker",
+                None: "buildx cache only",
+            }[output_flag]
         log_info(f"Verbose build logs enabled; output mode: {output_mode}")
     if options.force_rebuild and options.skip_existing:
         log_info("Ignoring --skip-existing because --force-rebuild was set.")

--- a/scripts/images/check_model_imports.py
+++ b/scripts/images/check_model_imports.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import argparse
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+
+import click
 
 SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[2]
@@ -21,27 +23,27 @@ from boileroom.images.metadata import (  # noqa: E402
     normalize_docker_repository,
     normalize_requested_tag,
 )
+from scripts.cli_utils import (  # noqa: E402
+    CONTEXT_SETTINGS,
+    all_cuda_option,
+    cleanup_option,
+    cuda_version_option,
+    none_if_empty,
+    pull_option,
+    tag_option,
+)
 
 
-def parse_args() -> argparse.Namespace:
-    """Parse CLI arguments."""
-    parser = argparse.ArgumentParser(description="Run import smoke checks inside boileroom model images.")
-    parser.add_argument(
-        "--tag",
-        default=None,
-        help="Tag to check. Defaults to the installed boileroom version; explicit examples include 0.3.0 or cuda12.6-0.3.0.",
-    )
-    parser.add_argument("--docker-user", default=DEFAULT_DOCKER_REPOSITORY, help="Docker Hub user or namespace to check.")
-    parser.add_argument(
-        "--cuda-version",
-        action="append",
-        dest="cuda_versions",
-        help="CUDA version to validate canonically (repeatable).",
-    )
-    parser.add_argument("--all-cuda", action="store_true", help="Validate all supported CUDA variants canonically.")
-    parser.add_argument("--pull", action="store_true", help="Pull images before running checks.")
-    parser.add_argument("--cleanup", action="store_true", help="Remove each image after checking to free disk space.")
-    return parser.parse_args()
+@dataclass(frozen=True)
+class ImportCheckOptions:
+    """CLI options for image import smoke checks."""
+
+    tag: str | None
+    docker_user: str
+    cuda_versions: list[str] | None
+    all_cuda: bool
+    pull: bool
+    cleanup: bool
 
 
 def ensure_docker() -> None:
@@ -183,21 +185,50 @@ for dep in deps:
         _remove_image(image_reference)
 
 
-def main() -> None:
+def run_import_checks(options: ImportCheckOptions) -> None:
     """Run the import smoke workflow."""
-    args = parse_args()
+
     ensure_docker()
-    docker_repository = normalize_docker_repository(args.docker_user)
-    cuda_versions = compute_cuda_versions(args.cuda_versions, args.all_cuda)
-    targets = iter_image_targets(args.tag, cuda_versions, docker_repository=docker_repository)
+    docker_repository = normalize_docker_repository(options.docker_user)
+    cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
+    targets = iter_image_targets(options.tag, cuda_versions, docker_repository=docker_repository)
     if not targets:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 
     for image_key, image_reference, _display_tag, env_path, core_path in targets:
-        check_image(image_key, image_reference, env_path, core_path, args.pull, args.cleanup)
+        check_image(image_key, image_reference, env_path, core_path, options.pull, options.cleanup)
 
-    print(f"All module imports succeeded for tag selection: {normalize_requested_tag(args.tag)}")
+    print(f"All module imports succeeded for tag selection: {normalize_requested_tag(options.tag)}")
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, help="Run import smoke checks inside boileroom model images.")
+@tag_option
+@click.option("--docker-user", default=DEFAULT_DOCKER_REPOSITORY, help="Docker Hub user or namespace to check.")
+@cuda_version_option("CUDA version to validate canonically (repeatable).")
+@all_cuda_option("Validate all supported CUDA variants canonically.")
+@pull_option
+@cleanup_option
+def cli(
+    tag: str | None,
+    docker_user: str,
+    cuda_versions: tuple[str, ...],
+    all_cuda: bool,
+    pull: bool,
+    cleanup: bool,
+) -> None:
+    """Run the image import-check Click command."""
+
+    run_import_checks(
+        ImportCheckOptions(
+            tag=tag,
+            docker_user=docker_user,
+            cuda_versions=none_if_empty(cuda_versions),
+            all_cuda=all_cuda,
+            pull=pull,
+            cleanup=cleanup,
+        )
+    )
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/scripts/images/check_model_server_health.py
+++ b/scripts/images/check_model_server_health.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import argparse
 import socket
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from urllib import error, request
+
+import click
 
 SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[2]
@@ -21,31 +23,31 @@ from boileroom.images.metadata import (  # noqa: E402
     normalize_docker_repository,
     normalize_requested_tag,
 )
+from scripts.cli_utils import (  # noqa: E402
+    CONTEXT_SETTINGS,
+    all_cuda_option,
+    cleanup_option,
+    cuda_version_option,
+    none_if_empty,
+    pull_option,
+    tag_option,
+)
 
 SERVER_PATH = REPO_ROOT / "boileroom/backend/server.py"
 FAKE_MODEL_CLASS = "boileroom.testing.fake_core.HealthcheckCore"
 
 
-def parse_args() -> argparse.Namespace:
-    """Parse CLI arguments."""
-    parser = argparse.ArgumentParser(description="Run /health smoke checks inside boileroom model images.")
-    parser.add_argument(
-        "--tag",
-        default=None,
-        help="Tag to check. Defaults to the installed boileroom version; explicit examples include 0.3.0 or cuda12.6-0.3.0.",
-    )
-    parser.add_argument("--docker-user", default=DEFAULT_DOCKER_REPOSITORY, help="Docker Hub user or namespace to check.")
-    parser.add_argument(
-        "--cuda-version",
-        action="append",
-        dest="cuda_versions",
-        help="CUDA version to validate canonically (repeatable).",
-    )
-    parser.add_argument("--all-cuda", action="store_true", help="Validate all supported CUDA variants canonically.")
-    parser.add_argument("--pull", action="store_true", help="Pull images before running checks.")
-    parser.add_argument("--cleanup", action="store_true", help="Remove each image after checking to free disk space.")
-    parser.add_argument("--timeout", type=float, default=30.0, help="Seconds to wait for each container health check.")
-    return parser.parse_args()
+@dataclass(frozen=True)
+class HealthCheckOptions:
+    """CLI options for image server health checks."""
+
+    tag: str | None
+    docker_user: str
+    cuda_versions: list[str] | None
+    all_cuda: bool
+    pull: bool
+    cleanup: bool
+    timeout: float
 
 
 def ensure_docker() -> None:
@@ -176,21 +178,53 @@ def check_server_health(
         _remove_image(image_reference)
 
 
-def main() -> None:
+def run_server_health_checks(options: HealthCheckOptions) -> None:
     """Run the server health-smoke workflow."""
-    args = parse_args()
+
     ensure_docker()
-    docker_repository = normalize_docker_repository(args.docker_user)
-    cuda_versions = compute_cuda_versions(args.cuda_versions, args.all_cuda)
-    targets = iter_image_targets(args.tag, cuda_versions, docker_repository=docker_repository)
+    docker_repository = normalize_docker_repository(options.docker_user)
+    cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
+    targets = iter_image_targets(options.tag, cuda_versions, docker_repository=docker_repository)
     if not targets:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 
     for image_key, image_reference, _display_tag, _env_path, _core_path in targets:
-        check_server_health(image_key, image_reference, args.pull, args.timeout, args.cleanup)
+        check_server_health(image_key, image_reference, options.pull, options.timeout, options.cleanup)
 
-    print(f"All server health checks succeeded for tag selection: {normalize_requested_tag(args.tag)}")
+    print(f"All server health checks succeeded for tag selection: {normalize_requested_tag(options.tag)}")
+
+
+@click.command(context_settings=CONTEXT_SETTINGS, help="Run /health smoke checks inside boileroom model images.")
+@tag_option
+@click.option("--docker-user", default=DEFAULT_DOCKER_REPOSITORY, help="Docker Hub user or namespace to check.")
+@cuda_version_option("CUDA version to validate canonically (repeatable).")
+@all_cuda_option("Validate all supported CUDA variants canonically.")
+@pull_option
+@cleanup_option
+@click.option("--timeout", type=float, default=30.0, help="Seconds to wait for each container health check.")
+def cli(
+    tag: str | None,
+    docker_user: str,
+    cuda_versions: tuple[str, ...],
+    all_cuda: bool,
+    pull: bool,
+    cleanup: bool,
+    timeout: float,
+) -> None:
+    """Run the server-health Click command."""
+
+    run_server_health_checks(
+        HealthCheckOptions(
+            tag=tag,
+            docker_user=docker_user,
+            cuda_versions=none_if_empty(cuda_versions),
+            all_cuda=all_cuda,
+            pull=pull,
+            cleanup=cleanup,
+            timeout=timeout,
+        )
+    )
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/scripts/images/promote_image_tags.py
+++ b/scripts/images/promote_image_tags.py
@@ -82,11 +82,11 @@ def promote_one(
 def run_promote_images(options: PromoteOptions) -> None:
     """Promote validated runtime images to public tags."""
 
-    ensure_buildx()
     docker_repository = normalize_docker_repository(options.docker_user)
     source_tag = normalize_requested_tag(options.source_tag)
     target_tag = normalize_requested_tag(options.target_tag)
     cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
+    ensure_buildx()
     image_specs = (BASE_IMAGE_SPEC, *MODEL_IMAGE_SPECS)
 
     for cuda_version in cuda_versions:
@@ -105,15 +105,18 @@ def run_promote_images(options: PromoteOptions) -> None:
 def cli(source_tag: str, target_tag: str, docker_user: str, cuda_versions: tuple[str, ...], all_cuda: bool) -> None:
     """Run the image promotion Click command."""
 
-    run_promote_images(
-        PromoteOptions(
-            source_tag=source_tag,
-            target_tag=target_tag,
-            docker_user=docker_user,
-            cuda_versions=none_if_empty(cuda_versions),
-            all_cuda=all_cuda,
+    try:
+        run_promote_images(
+            PromoteOptions(
+                source_tag=source_tag,
+                target_tag=target_tag,
+                docker_user=docker_user,
+                cuda_versions=none_if_empty(cuda_versions),
+                all_cuda=all_cuda,
+            )
         )
-    )
+    except ValueError as exc:
+        raise click.UsageError(str(exc)) from exc
 
 
 if __name__ == "__main__":

--- a/scripts/images/promote_image_tags.py
+++ b/scripts/images/promote_image_tags.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
-import argparse
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+
+import click
 
 SCRIPT_PATH = Path(__file__).resolve()
 REPO_ROOT = SCRIPT_PATH.parents[2]
@@ -23,22 +25,27 @@ from boileroom.images.metadata import (  # noqa: E402
     normalize_requested_tag,
     published_image_references,
 )
+from scripts.cli_utils import CONTEXT_SETTINGS, all_cuda_option, cuda_version_option, none_if_empty  # noqa: E402
 
 
-def parse_args() -> argparse.Namespace:
-    """Parse CLI arguments."""
-    parser = argparse.ArgumentParser(description="Promote validated boileroom image tags without rebuilding.")
-    parser.add_argument("--source-tag", required=True, help="Validated source tag, for example sha-abcd1234.")
-    parser.add_argument("--target-tag", required=True, help="Public target tag, for example 0.3.0.")
-    parser.add_argument("--docker-user", default=DEFAULT_DOCKER_REPOSITORY, help="Docker Hub user or namespace to promote.")
-    parser.add_argument(
-        "--cuda-version",
-        action="append",
-        dest="cuda_versions",
-        help=f"CUDA version to promote (repeatable). Supported values: {', '.join(sorted(CUDA_MICROMAMBA_BASE))}.",
-    )
-    parser.add_argument("--all-cuda", action="store_true", help="Promote all supported CUDA variants.")
-    return parser.parse_args()
+@dataclass(frozen=True)
+class PromoteOptions:
+    """CLI options for runtime image promotion."""
+
+    source_tag: str
+    target_tag: str
+    docker_user: str
+    cuda_versions: list[str] | None
+    all_cuda: bool
+
+
+def compute_cuda_versions(requested: list[str] | None, all_cuda: bool) -> list[str]:
+    """Resolve requested CUDA versions."""
+    if all_cuda:
+        return sorted({cuda for spec in (BASE_IMAGE_SPEC, *MODEL_IMAGE_SPECS) for cuda in get_supported_cuda(spec)})
+    if not requested:
+        raise ValueError("Specify at least one --cuda-version or use --all-cuda.")
+    return [normalize_cuda_version(cuda_version) for cuda_version in requested]
 
 
 def ensure_buildx() -> None:
@@ -52,15 +59,6 @@ def ensure_buildx() -> None:
         )
     except (OSError, subprocess.CalledProcessError) as exc:
         raise RuntimeError("Docker buildx is required but was not found.") from exc
-
-
-def compute_cuda_versions(requested: list[str] | None, all_cuda: bool) -> list[str]:
-    """Resolve requested CUDA versions."""
-    if all_cuda:
-        return sorted({cuda for spec in (BASE_IMAGE_SPEC, *MODEL_IMAGE_SPECS) for cuda in get_supported_cuda(spec)})
-    if not requested:
-        raise ValueError("Specify at least one --cuda-version or use --all-cuda.")
-    return [normalize_cuda_version(cuda_version) for cuda_version in requested]
 
 
 def promote_one(
@@ -81,14 +79,14 @@ def promote_one(
     subprocess.run(cmd, check=True)
 
 
-def main() -> None:
+def run_promote_images(options: PromoteOptions) -> None:
     """Promote validated runtime images to public tags."""
-    args = parse_args()
+
     ensure_buildx()
-    docker_repository = normalize_docker_repository(args.docker_user)
-    source_tag = normalize_requested_tag(args.source_tag)
-    target_tag = normalize_requested_tag(args.target_tag)
-    cuda_versions = compute_cuda_versions(args.cuda_versions, args.all_cuda)
+    docker_repository = normalize_docker_repository(options.docker_user)
+    source_tag = normalize_requested_tag(options.source_tag)
+    target_tag = normalize_requested_tag(options.target_tag)
+    cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
     image_specs = (BASE_IMAGE_SPEC, *MODEL_IMAGE_SPECS)
 
     for cuda_version in cuda_versions:
@@ -98,5 +96,25 @@ def main() -> None:
             promote_one(spec, cuda_version, source_tag, target_tag, docker_repository)
 
 
+@click.command(context_settings=CONTEXT_SETTINGS, help="Promote validated boileroom image tags without rebuilding.")
+@click.option("--source-tag", required=True, help="Validated source tag, for example sha-abcd1234.")
+@click.option("--target-tag", required=True, help="Public target tag, for example 0.3.0.")
+@click.option("--docker-user", default=DEFAULT_DOCKER_REPOSITORY, help="Docker Hub user or namespace to promote.")
+@cuda_version_option("CUDA version to promote (repeatable). Supported values: 11.8, 12.6.")
+@all_cuda_option("Promote all supported CUDA variants.")
+def cli(source_tag: str, target_tag: str, docker_user: str, cuda_versions: tuple[str, ...], all_cuda: bool) -> None:
+    """Run the image promotion Click command."""
+
+    run_promote_images(
+        PromoteOptions(
+            source_tag=source_tag,
+            target_tag=target_tag,
+            docker_user=docker_user,
+            cuda_versions=none_if_empty(cuda_versions),
+            all_cuda=all_cuda,
+        )
+    )
+
+
 if __name__ == "__main__":
-    main()
+    cli()

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -2,10 +2,11 @@
 
 from pathlib import Path
 
-from boileroom.images.metadata import DEFAULT_CUDA_VERSION
 import pytest
 from click.testing import CliRunner
 from pytest import CaptureFixture, MonkeyPatch
+
+from boileroom.images.metadata import DEFAULT_CUDA_VERSION
 from scripts.images import build_model_images
 
 
@@ -190,7 +191,7 @@ def test_build_base_verbose_echoes_plain_progress(monkeypatch: MonkeyPatch, tmp_
     assert echo is True
 
 
-def test_build_base_local_base_uses_buildx_cache_load_then_push(monkeypatch, tmp_path) -> None:
+def test_build_base_local_base_uses_buildx_cache_load_then_push(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Local-base builds should keep BuildKit cache while loading tags locally."""
     calls: list[tuple[list[str], Path | None, bool]] = []
 
@@ -224,7 +225,7 @@ def test_build_base_local_base_uses_buildx_cache_load_then_push(monkeypatch, tmp
     ]
 
 
-def test_build_model_local_base_uses_buildx_cache_context_then_push(monkeypatch, tmp_path) -> None:
+def test_build_model_local_base_uses_buildx_cache_context_then_push(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Local-base model builds should expose the loaded base image to buildx."""
     calls: list[tuple[list[str], Path | None, bool]] = []
 
@@ -332,7 +333,7 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch: MonkeyPatch, tmp_p
     ]
 
 
-def test_local_base_push_builds_locally_then_pushes(monkeypatch, tmp_path) -> None:
+def test_local_base_push_builds_locally_then_pushes(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Local-base push mode should keep FROM dependencies in the local Docker daemon."""
     options = build_model_images.BuildOptions(
         tag="sha-test",

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -3,11 +3,13 @@
 from pathlib import Path
 
 from boileroom.images.metadata import DEFAULT_CUDA_VERSION
+import pytest
 from click.testing import CliRunner
+from pytest import CaptureFixture, MonkeyPatch
 from scripts.images import build_model_images
 
 
-def test_build_base_push_uses_registry_cache(monkeypatch, tmp_path) -> None:
+def test_build_base_push_uses_registry_cache(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Pushed buildx builds should import and export stable registry cache layers."""
     calls: list[tuple[list[str], Path | None, bool]] = []
 
@@ -34,7 +36,7 @@ def test_build_base_push_uses_registry_cache(monkeypatch, tmp_path) -> None:
     assert f"type=registry,ref=docker.io/jakublala/boileroom-base:buildcache-cuda{DEFAULT_CUDA_VERSION},mode=max" in cmd
 
 
-def test_build_base_no_cache_disables_registry_cache(monkeypatch, tmp_path) -> None:
+def test_build_base_no_cache_disables_registry_cache(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Explicit no-cache builds should not import or export BuildKit registry cache."""
     calls: list[tuple[list[str], Path | None, bool]] = []
 
@@ -67,7 +69,7 @@ def test_build_cache_reference_uses_explicit_repository() -> None:
     )
 
 
-def test_cli_exposes_documented_flags(monkeypatch) -> None:
+def test_cli_exposes_documented_flags(monkeypatch: MonkeyPatch) -> None:
     """The build helper should accept the documented flags."""
 
     captured: list[build_model_images.BuildOptions] = []
@@ -112,7 +114,56 @@ def test_cli_exposes_documented_flags(monkeypatch) -> None:
     ]
 
 
-def test_build_base_verbose_echoes_plain_progress(monkeypatch, tmp_path) -> None:
+def test_cli_rejects_unknown_flags(monkeypatch: MonkeyPatch) -> None:
+    """Invalid CLI options should fail before invoking the build workflow."""
+
+    captured: list[build_model_images.BuildOptions] = []
+    monkeypatch.setattr(build_model_images, "run_build", captured.append)
+
+    result = CliRunner().invoke(build_model_images.cli, ["--definitely-not-a-real-option"])
+
+    assert result.exit_code != 0
+    assert captured == []
+    assert "No such option" in result.output
+
+
+def test_run_build_validates_cuda_selection_before_docker(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    """Semantic option errors should not be masked by missing Docker."""
+
+    options = build_model_images.BuildOptions(
+        tag="sha-test",
+        docker_user="docker.io/jakublala",
+        cuda_versions=None,
+        all_cuda=False,
+        platform="linux/amd64",
+        push=False,
+        load=False,
+        no_cache=False,
+        verbose=False,
+        skip_existing=False,
+        force_rebuild=False,
+        max_workers=1,
+        local_base=False,
+    )
+    docker_checked = False
+
+    def fake_ensure_docker() -> None:
+        nonlocal docker_checked
+        docker_checked = True
+
+    monkeypatch.setattr(build_model_images, "ensure_docker", fake_ensure_docker)
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_model_images.run_build(options)
+
+    assert exc_info.value.code == 1
+    assert docker_checked is False
+    assert "Specify at least one --cuda-version or use --all-cuda." in capsys.readouterr().err
+
+
+def test_build_base_verbose_echoes_plain_progress(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Verbose builds should print command output and request plain BuildKit progress."""
     calls: list[tuple[list[str], Path | None, bool]] = []
 
@@ -215,7 +266,7 @@ def test_build_model_local_base_uses_buildx_cache_context_then_push(monkeypatch,
     ]
 
 
-def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
+def test_main_skips_existing_base_and_model_tags(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """The main build flow should skip existing tags when skip-existing is set."""
     options = build_model_images.BuildOptions(
         tag="sha-test",

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -1,10 +1,9 @@
 """Fast contract tests for Docker image build helpers."""
 
-import sys
-from argparse import Namespace
 from pathlib import Path
 
 from boileroom.images.metadata import DEFAULT_CUDA_VERSION
+from click.testing import CliRunner
 from scripts.images import build_model_images
 
 
@@ -68,13 +67,23 @@ def test_build_cache_reference_uses_explicit_repository() -> None:
     )
 
 
-def test_parse_args_exposes_documented_flags(monkeypatch) -> None:
+def test_cli_exposes_documented_flags(monkeypatch) -> None:
     """The build helper should accept the documented flags."""
-    monkeypatch.setattr(
-        sys,
-        "argv",
+
+    captured: list[build_model_images.BuildOptions] = []
+
+    def fake_run_build(options: build_model_images.BuildOptions) -> None:
+        captured.append(options)
+
+    monkeypatch.setattr(build_model_images, "run_build", fake_run_build)
+
+    result = CliRunner().invoke(
+        build_model_images.cli,
         [
-            "build_model_images.py",
+            "--cuda-version",
+            "12.6",
+            "--cuda-version",
+            "11.8",
             "--skip-existing",
             "--force-rebuild",
             "--verbose",
@@ -83,12 +92,24 @@ def test_parse_args_exposes_documented_flags(monkeypatch) -> None:
         ],
     )
 
-    args = build_model_images.parse_args()
-    assert args.skip_existing is True
-    assert args.force_rebuild is True
-    assert args.verbose is True
-    assert args.local_base is True
-    assert args.docker_user == "example"
+    assert result.exit_code == 0, result.output
+    assert captured == [
+        build_model_images.BuildOptions(
+            tag=None,
+            docker_user="example",
+            cuda_versions=["12.6", "11.8"],
+            all_cuda=False,
+            platform="linux/amd64",
+            push=False,
+            load=False,
+            no_cache=False,
+            verbose=True,
+            skip_existing=True,
+            force_rebuild=True,
+            max_workers=1,
+            local_base=True,
+        )
+    ]
 
 
 def test_build_base_verbose_echoes_plain_progress(monkeypatch, tmp_path) -> None:
@@ -196,8 +217,9 @@ def test_build_model_local_base_uses_buildx_cache_context_then_push(monkeypatch,
 
 def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
     """The main build flow should skip existing tags when skip-existing is set."""
-    args = Namespace(
+    options = build_model_images.BuildOptions(
         tag="sha-test",
+        docker_user="docker.io/jakublala",
         cuda_versions=[DEFAULT_CUDA_VERSION],
         all_cuda=False,
         platform="linux/amd64",
@@ -209,15 +231,11 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
         force_rebuild=False,
         max_workers=1,
         local_base=False,
-        docker_user="docker.io/jakublala",
     )
 
     built_tasks: list[tuple[str, str]] = []
     checked_refs: list[str] = []
     built_bases: list[str] = []
-
-    def fake_parse_args() -> Namespace:
-        return args
 
     def fake_ensure_docker() -> None:
         return None
@@ -239,7 +257,6 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
         return (f"{task.image_spec.image_name}:built",)
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(build_model_images, "parse_args", fake_parse_args)
     monkeypatch.setattr(build_model_images, "ensure_docker", fake_ensure_docker)
     monkeypatch.setattr(build_model_images, "ensure_buildx_builder", lambda: None)
     monkeypatch.setattr(build_model_images, "image_reference_exists", fake_image_reference_exists)
@@ -249,7 +266,7 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(build_model_images, "log_warn", lambda *args, **kwargs: None)
     monkeypatch.setattr(build_model_images, "log_success", lambda *args, **kwargs: None)
 
-    build_model_images.main()
+    build_model_images.run_build(options)
 
     assert built_bases == []
     assert built_tasks == [
@@ -266,8 +283,9 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch, tmp_path) -> None:
 
 def test_local_base_push_builds_locally_then_pushes(monkeypatch, tmp_path) -> None:
     """Local-base push mode should keep FROM dependencies in the local Docker daemon."""
-    args = Namespace(
+    options = build_model_images.BuildOptions(
         tag="sha-test",
+        docker_user="docker.io/jakublala",
         cuda_versions=[DEFAULT_CUDA_VERSION],
         all_cuda=False,
         platform="linux/amd64",
@@ -279,15 +297,11 @@ def test_local_base_push_builds_locally_then_pushes(monkeypatch, tmp_path) -> No
         force_rebuild=False,
         max_workers=1,
         local_base=True,
-        docker_user="docker.io/jakublala",
     )
 
     base_calls: list[tuple[bool, bool]] = []
     model_calls: list[tuple[bool, bool, str]] = []
     buildx_calls = 0
-
-    def fake_parse_args() -> Namespace:
-        return args
 
     def fake_ensure_buildx_builder() -> None:
         nonlocal buildx_calls
@@ -320,7 +334,6 @@ def test_local_base_push_builds_locally_then_pushes(monkeypatch, tmp_path) -> No
         return (f"{task.image_spec.image_name}:built",)
 
     monkeypatch.chdir(tmp_path)
-    monkeypatch.setattr(build_model_images, "parse_args", fake_parse_args)
     monkeypatch.setattr(build_model_images, "ensure_docker", lambda: None)
     monkeypatch.setattr(build_model_images, "ensure_buildx_builder", fake_ensure_buildx_builder)
     monkeypatch.setattr(build_model_images, "build_base", fake_build_base)
@@ -329,7 +342,7 @@ def test_local_base_push_builds_locally_then_pushes(monkeypatch, tmp_path) -> No
     monkeypatch.setattr(build_model_images, "log_warn", lambda *args, **kwargs: None)
     monkeypatch.setattr(build_model_images, "log_success", lambda *args, **kwargs: None)
 
-    build_model_images.main()
+    build_model_images.run_build(options)
 
     assert buildx_calls == 1
     assert base_calls == [(False, True)]

--- a/tests/contracts/test_cli.py
+++ b/tests/contracts/test_cli.py
@@ -1,0 +1,78 @@
+"""Contract tests for repo-local Click command boundaries."""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from scripts.ci import derive_version
+from scripts.harness import check_repo
+from scripts.images import build_model_images, check_model_imports, check_model_server_health, promote_image_tags
+
+
+def test_click_commands_support_help_aliases() -> None:
+    """Converted maintenance commands should support both long and short help flags."""
+
+    commands = (
+        check_repo.cli,
+        derive_version.cli,
+        promote_image_tags.cli,
+        check_model_imports.cli,
+        check_model_server_health.cli,
+        build_model_images.cli,
+    )
+    runner = CliRunner()
+
+    for command in commands:
+        for help_flag in ("--help", "-h"):
+            result = runner.invoke(command, [help_flag])
+            assert result.exit_code == 0, result.output
+            assert "Usage:" in result.output
+
+
+def test_promote_cli_requires_source_and_target_tags() -> None:
+    """Parser-level required options should still fail before Docker is touched."""
+
+    result = CliRunner().invoke(promote_image_tags.cli, [])
+
+    assert result.exit_code == 2
+    assert "Missing option '--source-tag'" in result.output
+
+
+def test_derive_version_cli_passes_path_options(monkeypatch, tmp_path) -> None:
+    """Path-valued Click options should reach the plain runner as Path objects."""
+
+    captured: list[derive_version.VersionOptions] = []
+
+    def fake_run_derive_version(options: derive_version.VersionOptions) -> None:
+        captured.append(options)
+
+    monkeypatch.setattr(derive_version, "run_derive_version", fake_run_derive_version)
+
+    base_pyproject = tmp_path / "pyproject.toml"
+    write_pyproject = tmp_path / "release-pyproject.toml"
+    github_output = tmp_path / "github-output.txt"
+    result = CliRunner().invoke(
+        derive_version.cli,
+        [
+            "--base-pyproject",
+            str(base_pyproject),
+            "--write-pyproject",
+            str(write_pyproject),
+            "--github-output",
+            str(github_output),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured == [
+        derive_version.VersionOptions(
+            head_ref="HEAD",
+            release_tag=None,
+            base_pyproject=base_pyproject,
+            write_pyproject=write_pyproject,
+            github_output=github_output,
+        )
+    ]
+    assert isinstance(captured[0].base_pyproject, Path)
+    assert isinstance(captured[0].write_pyproject, Path)
+    assert isinstance(captured[0].github_output, Path)

--- a/tests/contracts/test_cli.py
+++ b/tests/contracts/test_cli.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 from click.testing import CliRunner
+from pytest import MonkeyPatch
 
 from scripts.ci import derive_version
 from scripts.harness import check_repo
@@ -38,7 +39,7 @@ def test_promote_cli_requires_source_and_target_tags() -> None:
     assert "Missing option '--source-tag'" in result.output
 
 
-def test_derive_version_cli_passes_path_options(monkeypatch, tmp_path) -> None:
+def test_derive_version_cli_passes_path_options(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Path-valued Click options should reach the plain runner as Path objects."""
 
     captured: list[derive_version.VersionOptions] = []
@@ -76,3 +77,24 @@ def test_derive_version_cli_passes_path_options(monkeypatch, tmp_path) -> None:
     assert isinstance(captured[0].base_pyproject, Path)
     assert isinstance(captured[0].write_pyproject, Path)
     assert isinstance(captured[0].github_output, Path)
+
+
+def test_promote_cli_validates_cuda_selection_before_buildx(monkeypatch: MonkeyPatch) -> None:
+    """Usage errors should be reported before external Docker checks."""
+
+    buildx_checked = False
+
+    def fake_ensure_buildx() -> None:
+        nonlocal buildx_checked
+        buildx_checked = True
+
+    monkeypatch.setattr(promote_image_tags, "ensure_buildx", fake_ensure_buildx)
+
+    result = CliRunner().invoke(
+        promote_image_tags.cli,
+        ["--source-tag", "sha-test", "--target-tag", "0.3.0"],
+    )
+
+    assert result.exit_code == 2
+    assert "Specify at least one --cuda-version or use --all-cuda." in result.output
+    assert buildx_checked is False

--- a/uv.lock
+++ b/uv.lock
@@ -122,6 +122,7 @@ version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "biotite" },
+    { name = "click" },
     { name = "deprecated" },
     { name = "httpx" },
     { name = "modal" },
@@ -133,7 +134,6 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
-    { name = "fire" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -144,8 +144,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "biotite", specifier = ">=1.0.1" },
+    { name = "click", specifier = ">=8.1" },
     { name = "deprecated", specifier = ">=1.2.14" },
-    { name = "fire", marker = "extra == 'dev'", specifier = ">=0.7.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "modal", specifier = ">=1.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.15.0" },
@@ -277,18 +277,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
-]
-
-[[package]]
-name = "fire"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "termcolor" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/00/f8d10588d2019d6d6452653def1ee807353b21983db48550318424b5ff18/fire-0.7.1.tar.gz", hash = "sha256:3b208f05c736de98fb343310d090dcc4d8c78b2a89ea4f32b837c586270a9cbf", size = 88720, upload-time = "2025-08-16T20:20:24.175Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/4c/93d0f85318da65923e4b91c1c2ff03d8a458cbefebe3bc612a6693c7906d/fire-0.7.1-py3-none-any.whl", hash = "sha256:e43fd8a5033a9001e7e2973bab96070694b9f12f2e0ecf96d4683971b5ab1882", size = 115945, upload-time = "2025-08-16T20:20:22.87Z" },
 ]
 
 [[package]]
@@ -1018,15 +1006,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/26/8874d34755691994266d4a844ba8d53d10c2690ec67f246ca4d6b6f34cbb/synchronicity-0.11.1.tar.gz", hash = "sha256:3628df9ab34bd7be89b729104114841c62612c5d5ec43b76f4b7b243185ec1a8", size = 58131, upload-time = "2025-12-19T18:28:42.291Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/b9/71153db12f4ad029cfe9b7fbf9792ef3fc9ade4485d31a13470b52954e62/synchronicity-0.11.1-py3-none-any.whl", hash = "sha256:53959c7f8b9b852fb5ea4d3d290a47a04310ede483a4cf0f8452cb4b5fa09db2", size = 40399, upload-time = "2025-12-19T18:28:40.972Z" },
-]
-
-[[package]]
-name = "termcolor"
-version = "3.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Convert repo maintenance scripts from argparse to Click thin boundaries.
- Add shared script-local Click helpers for repeated options and `-h/--help` support.
- Remove unused Fire dev dependency and make Click explicit.
- Add Click contract tests and keep backend server argparse untouched.

## Merge from main
Branch now carries #75 (`cb82cb7`, "ci: speed up docker image publishing workflow"). The Click CLI picks up that PR's additions:
- `--local-base` flag and `BuildOptions.local_base`, routed through `build_base` / `build_model` as `push_after_build`.
- Dynamic `--cuda-version` help text sourced from `CUDA_MICROMAMBA_BASE` in both `build_model_images.py` and `promote_image_tags.py`.
- #75's local-base contract tests, ported to `BuildOptions` / `run_build`.

## Validation
- `uv run pytest tests/contracts -n 4`
- `uv run python scripts/harness/check_repo.py`
- `uv run pre-commit run --all-files`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Updated core dependency to Click 8.1+; removed Fire from development dependencies.

* **Refactor**
  * Replaced legacy argparse CLIs with Click-based command interfaces across maintenance scripts for more consistent, user-friendly command behavior.

* **Tests**
  * Added CLI contract tests validating help output, option parsing, error messages, and end-to-end CLI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
