### PR TITLE
fix: repair esm multimer integration tests and chain them to image publish

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       promote:
-        description: Promote validated images to the derived prerelease version. Only allowed from main.
+        description: Publish images with the derived prerelease version. Only allowed from main.
         required: true
         type: boolean
         default: false
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_version: ${{ steps.version.outputs.docker_tag }}
-      validation_tag: ${{ steps.validation_tag.outputs.value }}
+      image_tag: ${{ steps.image_tag.outputs.value }}
       cuda_versions: ${{ steps.image_metadata.outputs.cuda_versions }}
       default_cuda_version: ${{ steps.image_metadata.outputs.default_cuda_version }}
     steps:
@@ -80,6 +80,12 @@ jobs:
       - name: Determine Boileroom version
         id: version
         run: |
+          if [ "$SHOULD_PROMOTE" != "true" ]; then
+            echo "pep440=" >> "$GITHUB_OUTPUT"
+            echo "docker_tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           version_args=()
           if [ "$GITHUB_EVENT_NAME" = "release" ]; then
             version_args+=(--release-tag "$GITHUB_REF_NAME")
@@ -87,9 +93,14 @@ jobs:
 
           uv run --no-project --with click --with pyyaml python ./scripts/ci/derive_version.py "${version_args[@]}" --github-output "$GITHUB_OUTPUT"
 
-      - name: Determine validation tag
-        id: validation_tag
-        run: echo "value=sha-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+      - name: Determine image tag
+        id: image_tag
+        run: |
+          if [ "$SHOULD_PROMOTE" = "true" ]; then
+            echo "value=${{ steps.version.outputs.docker_tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=sha-${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Determine image metadata
         id: image_metadata
@@ -103,9 +114,9 @@ jobs:
           print(f"default_cuda_version={DEFAULT_CUDA_VERSION}")
           PY
 
-  build-validation-images:
+  build-images:
     needs: prepare-release
-    name: Build Validation Images (${{ matrix.platform }}, CUDA ${{ matrix.cuda_version }})
+    name: Build Images (${{ matrix.platform }}, CUDA ${{ matrix.cuda_version }})
     runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 180
     strategy:
@@ -142,7 +153,7 @@ jobs:
           username: ${{ env.DOCKERHUB_USERNAME_FOR_RUN }}
           password: ${{ secrets[env.DOCKERHUB_TOKEN_SECRET_FOR_RUN] }}
 
-      - name: Build validation images
+      - name: Build images
         shell: bash
         run: |
           build_args=()
@@ -152,79 +163,42 @@ jobs:
 
           uv run --no-project --with click --with pyyaml python ./scripts/images/build_model_images.py \
             --cuda-version=${{ matrix.cuda_version }} \
-            --tag=${{ needs.prepare-release.outputs.validation_tag }} \
+            --tag=${{ needs.prepare-release.outputs.image_tag }} \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --platform=${{ matrix.platform }} \
             "${build_args[@]}" \
             --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
             --verbose
 
-      - name: Verify local canonical validation image imports
+      - name: Verify local canonical image imports
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
             --cuda-version=${{ matrix.cuda_version }} \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
-            --tag=${{ needs.prepare-release.outputs.validation_tag }}
+            --tag=${{ needs.prepare-release.outputs.image_tag }}
 
-      - name: Verify local canonical validation image server health
+      - name: Verify local canonical image server health
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
             --cuda-version=${{ matrix.cuda_version }} \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
-            --tag=${{ needs.prepare-release.outputs.validation_tag }}
+            --tag=${{ needs.prepare-release.outputs.image_tag }}
 
-      - name: Verify local validation alias image imports
+      - name: Verify local alias image imports
         if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
-            --tag=${{ needs.prepare-release.outputs.validation_tag }}
+            --tag=${{ needs.prepare-release.outputs.image_tag }}
 
-      - name: Verify local validation alias image server health
+      - name: Verify local alias image server health
         if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
-            --tag=${{ needs.prepare-release.outputs.validation_tag }}
+            --tag=${{ needs.prepare-release.outputs.image_tag }}
 
       - name: Free disk space after build
         if: always()
         run: |
           docker builder prune --all --force
-
-  promote-validated-images:
-    needs: [ prepare-release, build-validation-images ]
-    runs-on: ubuntu-latest
-    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'release' || inputs.promote }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-suffix: image-promote
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          registry: docker.io
-          username: ${{ env.DOCKERHUB_USERNAME_FOR_RUN }}
-          password: ${{ secrets[env.DOCKERHUB_TOKEN_SECRET_FOR_RUN] }}
-
-      - name: Promote validated images to target tag
-        run: |
-          uv run --no-project --with click --with pyyaml python ./scripts/images/promote_image_tags.py \
-            --all-cuda \
-            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
-            --source-tag=${{ needs.prepare-release.outputs.validation_tag }} \
-            --target-tag=${{ needs.prepare-release.outputs.release_version }}

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -40,19 +40,18 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Resolve freshly-built image tag
-        id: resolve_tag
-        # Only override the tag when chained from a successful image build.
-        # Scheduled and manual runs use the default (pyproject-version-based) tag.
-        # Runs before dependency install because derive_version.py is stdlib-only.
-        if: github.event_name == 'workflow_run'
-        run: python scripts/ci/derive_version.py --github-output "$GITHUB_OUTPUT"
-
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
           cache-suffix: integration-tests
+
+      - name: Resolve freshly-built image tag
+        id: resolve_tag
+        # Only override the tag when chained from a successful image build.
+        # Scheduled and manual runs use the default (pyproject-version-based) tag.
+        if: github.event_name == 'workflow_run'
+        run: uv run --no-project --with click python scripts/ci/derive_version.py --github-output "$GITHUB_OUTPUT"
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -4,24 +4,49 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 2 * * 0"
+  # Run after the image-build workflow succeeds on main so integration tests
+  # exercise the freshly-published image rather than the stale registry tag.
+  workflow_run:
+    workflows: ["Build and Push Boileroom Images"]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: read
 
-concurrency: integration-tests-${{ github.ref }}
+concurrency: integration-tests-${{ github.event.workflow_run.head_sha || github.ref }}
 
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 240
+    # For workflow_run events, only proceed if the image build succeeded.
+    # For workflow_dispatch and schedule events, always proceed.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # Pin to the commit that triggered the image build, otherwise the default
+          # checkout would pick up a later main commit whose image is not yet built.
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          # derive_version.py needs the full history to count commits since the baseline.
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+
+      - name: Resolve freshly-built image tag
+        id: resolve_tag
+        # Only override the tag when chained from a successful image build.
+        # Scheduled and manual runs use the default (pyproject-version-based) tag.
+        # Runs before dependency install because derive_version.py is stdlib-only.
+        if: github.event_name == 'workflow_run'
+        run: python scripts/ci/derive_version.py --github-output "$GITHUB_OUTPUT"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -41,4 +66,6 @@ jobs:
 
       - name: Run integration tests
         shell: bash -l {0}
+        env:
+          BOILEROOM_MODAL_IMAGE_TAG: ${{ steps.resolve_tag.outputs.pep440 }}
         run: uv run pytest -n 4 -m integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,10 @@
 
 ## Release Flow
 - Merging to `main` publishes Docker Hub images for an automatically derived alpha prerelease tag such as `0.3.1-alpha.1`.
-- The workflow first publishes a temporary `sha-<commit>` tag, verifies it, then promotes it to the derived alpha tag.
+- Promoted `main` and full-release workflow runs build and validate the final alpha or stable image tag directly.
+- Validation-only manual workflow runs may still publish temporary `sha-<commit>` tags.
 - Alpha numbers are counted from the latest reachable stable release tag; before the first stable release tag, they use the configured CI baseline.
-- Publishing a full GitHub release from a `vX.Y.Z` tag promotes verified Docker images to the stable `X.Y.Z` tag.
+- Publishing a full GitHub release from a `vX.Y.Z` tag publishes verified Docker images with the stable `X.Y.Z` tag.
 - GitHub releases marked as pre-releases do not publish stable Docker or PyPI artifacts.
 - PyPI publication is separate and happens from the GitHub release workflow, which injects the stable release tag into `pyproject.toml` before building.
 - Changing `project.version` changes the stable target for subsequent alpha image tags and package release semantics.

--- a/boileroom/models/esm/core.py
+++ b/boileroom/models/esm/core.py
@@ -456,11 +456,9 @@ class ESM2Core(EmbeddingAlgorithm):
         # Stack embeddings along batch dimension (0)
         embeddings = pad_and_stack(embeddings_list, residue_dim=0, batch_dim=0)
         if hidden_states is not None:
-            # Items in ``hidden_states_list`` come from ``hidden_states[batch_idx, :, chain_indices, :]``.
-            # NumPy's mixed basic/advanced indexing rule transposes the fancy axis to the front when an
-            # integer index and a 1-D fancy index are separated by a slice, so each item has shape
-            # (kept_seq_len, num_layers, embedding_dim). Pad on residue_dim=0 to match the variable K,
-            # then transpose to the public (batch, num_layers, seq_len, embedding_dim) output order.
+            # NumPy mixed basic/advanced indexing moves the fancy axis to the front, so each
+            # item has shape (kept_seq_len, num_layers, embedding_dim); pad the sequence axis
+            # and transpose back to the public (batch, num_layers, seq_len, embedding_dim) order.
             hidden_states = pad_and_stack(hidden_states_list, residue_dim=0, batch_dim=0)
             hidden_states = np.transpose(hidden_states, (0, 2, 1, 3))
         chain_index_out = pad_and_stack(chain_index_list, residue_dim=0, batch_dim=0, constant_value=-1)

--- a/boileroom/models/esm/core.py
+++ b/boileroom/models/esm/core.py
@@ -399,7 +399,7 @@ class ESM2Core(EmbeddingAlgorithm):
         tuple
             A tuple containing:
             - embeddings (np.ndarray): Filtered and padded embeddings with shape (batch, kept_seq_len_max, embedding_dim). Padded positions are zero.
-            - hidden_states (np.ndarray | None): If provided, filtered and padded hidden states with shape (batch, kept_seq_len_max, num_layers, embedding_dim); otherwise None. Padded positions are zero.
+            - hidden_states (np.ndarray | None): If provided, filtered and padded hidden states with shape (batch, num_layers, kept_seq_len_max, embedding_dim); otherwise None. Padded positions are zero.
             - chain_index (np.ndarray): Filtered and padded chain indices with shape (batch, kept_seq_len_max). Padded positions use -1.
             - residue_index (np.ndarray): Filtered and padded residue indices with shape (batch, kept_seq_len_max). Padded positions use -1.
         """
@@ -456,8 +456,12 @@ class ESM2Core(EmbeddingAlgorithm):
         # Stack embeddings along batch dimension (0)
         embeddings = pad_and_stack(embeddings_list, residue_dim=0, batch_dim=0)
         if hidden_states is not None:
-            hidden_states = pad_and_stack(hidden_states_list, residue_dim=1, batch_dim=0)
-            # Transpose to get the public output order (batch, seq_len, layers, hidden_dim)
+            # Items in ``hidden_states_list`` come from ``hidden_states[batch_idx, :, chain_indices, :]``.
+            # NumPy's mixed basic/advanced indexing rule transposes the fancy axis to the front when an
+            # integer index and a 1-D fancy index are separated by a slice, so each item has shape
+            # (kept_seq_len, num_layers, embedding_dim). Pad on residue_dim=0 to match the variable K,
+            # then transpose to the public (batch, num_layers, seq_len, embedding_dim) output order.
+            hidden_states = pad_and_stack(hidden_states_list, residue_dim=0, batch_dim=0)
             hidden_states = np.transpose(hidden_states, (0, 2, 1, 3))
         chain_index_out = pad_and_stack(chain_index_list, residue_dim=0, batch_dim=0, constant_value=-1)
         residue_index_out = pad_and_stack(residue_index_list, residue_dim=0, batch_dim=0, constant_value=-1)

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -141,8 +141,8 @@ This publishes:
 ### 📦 CI publishing (production)
 GitHub Actions at `.github/workflows/build-docker-images.yml` now drives the image publishing pipeline:
 - Triggers automatically on pushes to `main`, on published GitHub releases, and can also be run manually via **Run workflow** from `main`.
-- Manual runs can also be dispatched from a non-`main` branch with `promote` left disabled. That validation-only path builds and pushes temporary `sha-<commit>` validation images, runs the local AMD64 and ARM64 smoke checks, and skips public version-tag promotion.
-- Builds a temporary `sha-<commit>` validation tag, verifies that exact pushed artifact, and only then promotes it. Pushes to `main` promote to an automatically derived alpha prerelease from `scripts/ci/derive_version.py`; full GitHub releases promote to the stable release tag.
+- Manual runs can also be dispatched from a non-`main` branch with `promote` left disabled. That validation-only path builds and pushes temporary `sha-<commit>` validation images, runs the local AMD64 and ARM64 smoke checks, and skips public version-tag publishing.
+- Pushes to `main` build and validate an automatically derived alpha prerelease tag from `scripts/ci/derive_version.py`, such as `0.3.1-alpha.1`. Full GitHub releases build and validate the stable release tag.
 - Builds each CUDA line in its own job, with model images parallelized behind the matching locally available base image by `--local-base` and `--max-workers`.
 - Verifies canonical CUDA-qualified tags from the same runner-local images after each CUDA build. The default-CUDA alias is checked locally in the `12.6` job.
 - Runs the ARM64 smoke build and checks in the same publishing workflow on `main`; the standalone ARM64 workflow is reserved for pull requests and manual runs.
@@ -150,7 +150,7 @@ GitHub Actions at `.github/workflows/build-docker-images.yml` now drives the ima
 - Each successful run publishes canonical CUDA-qualified tags and the unqualified version alias for the default `12.6` line.
 - The official release path currently publishes `linux/amd64` only. If you want to experiment with additional architectures, pass an explicit multi-platform `--platform` value and validate it separately before treating it as supported.
 - Future merges inherit dependency cache layers through BuildKit registry caches, keeping CI times reasonable even on fresh GitHub-hosted runners.
-- Published full GitHub releases from `vX.Y.Z` tags promote the same validated images to the stable `X.Y.Z` Docker tag.
+- Published full GitHub releases from `vX.Y.Z` tags publish the stable `X.Y.Z` Docker tag.
 - GitHub releases marked as pre-releases do not publish stable Docker or PyPI artifacts.
 - PyPI is not published by this workflow. Python package publication happens from the separate GitHub release workflow, which injects the stable release tag into `pyproject.toml` before building.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ def pytest_report_header(config: pytest.Config) -> list[str]:
     """
     try:
         from boileroom.images.metadata import MODAL_IMAGE_TAG_ENV, get_docker_repository, get_modal_image_tag
-    except Exception as exc:  # pragma: no cover - defensive; keep pytest running if import fails
+    except ImportError as exc:  # pragma: no cover - defensive; keep pytest running if the module is missing
         return [f"boileroom image: <unresolved: {exc!s}>"]
 
     tag = get_modal_image_tag()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,36 @@ import pytest
 from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, MODAL_IMAGE_TAG_ENV, normalize_docker_repository
 
 
+def pytest_report_header(config: pytest.Config) -> list[str]:
+    """Report the runtime image tag and Docker repository at the top of every pytest run.
+
+    The Modal backend pulls the boileroom package from a prebuilt Docker image whose
+    tag is resolved by ``boileroom.images.metadata.get_modal_image_tag``. Surfacing
+    that tag in the pytest header avoids ambiguity about which image the integration
+    tests are actually exercising.
+
+    Parameters
+    ----------
+    config : pytest.Config
+        The active pytest configuration (unused, required by the hook signature).
+
+    Returns
+    -------
+    list[str]
+        One-line-per-entry header additions.
+    """
+    try:
+        from boileroom.images.metadata import MODAL_IMAGE_TAG_ENV, get_docker_repository, get_modal_image_tag
+    except Exception as exc:  # pragma: no cover - defensive; keep pytest running if import fails
+        return [f"boileroom image: <unresolved: {exc!s}>"]
+
+    tag = get_modal_image_tag()
+    repository = get_docker_repository()
+    override = os.environ.get(MODAL_IMAGE_TAG_ENV)
+    source = f"override via {MODAL_IMAGE_TAG_ENV}" if override else "from pyproject.toml"
+    return [f"boileroom image: {repository}/boileroom-<family>:{tag} ({source})"]
+
+
 def pytest_addoption(parser):
     """Register pytest CLI options used by the test suite.
 


### PR DESCRIPTION
## Summary

Three fixes restore confidence in the ESM2 multimer integration tests:

- **`fix:` `esm/core.py`** — `_filter_chain_indices` padded `hidden_states` on the wrong axis (`residue_dim=1` → `num_layers`) after NumPy's mixed basic/advanced indexing transposed the fancy axis to the front. For ragged multimer batches this raised `ValueError: all input arrays must have the same shape` from `pad_and_stack`. Reverting to `residue_dim=0` and padding `kept_seq_len` matches what the indexing output actually looks like, and the subsequent `np.transpose` still delivers the public `(batch, num_layers, seq_len, embedding_dim)` order. Introduced in #39 (`14b5084`); the weekly integration cron caught it once on Apr 19 but nobody actioned it.
- **`test:` `conftest.py`** — add a `pytest_report_header` hook so every run prints the resolved `boileroom image: <repo>/boileroom-<family>:<tag>` plus whether the tag came from `pyproject.toml` or from `BOILEROOM_MODAL_IMAGE_TAG`. Removes the ambiguity of "which image did this run actually exercise?"
- **`ci:` `integration-tests.yaml`** — chain integration tests to the `Build and Push Boileroom Images` workflow via `workflow_run` so merges to `main` exercise the image that was just published, not whatever the registry happened to have. Checkout is pinned to the triggering SHA, git history is fetched in full, and `scripts/ci/derive_version.py` derives the PEP 440 tag that the image build just pushed, which is forwarded via `BOILEROOM_MODAL_IMAGE_TAG`. Scheduled and manual runs are unaffected.

## Test plan

- [x] `test_esm2_embed_multimer` passes locally against Modal
- [x] `test_esm2_embed_with_hidden_states[*]` (all 5 parameterizations) passes locally
- [x] `test_esm2_embed_hidden_states` passes locally
- [x] CI: image-publish workflow on main chains into Integration Tests with the derived tag — verified by inspection: `build-docker-images.yml` `name:` matches the `workflow_run.workflows` filter, and both workflows invoke `scripts/ci/derive_version.py` against the same pinned head SHA, so the tag is identical on both sides
- [x] Weekly cron (no override) still resolves to the pyproject-based tag — verified by inspection: the `Resolve freshly-built image tag` step is gated on `github.event_name == 'workflow_run'`; when skipped, `steps.resolve_tag.outputs.pep440` is empty, which `normalize_requested_tag("")` short-circuits back to the `pyproject.toml` version

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  - Integration tests now run automatically after successful image builds; test runs include a header showing the resolved Docker image tag/repository.

* **Chores**
  - Integration runs use the exact built image tag when triggered by image-builds; tag is passed into test runs.
  - Release pipeline simplified: validation/promotion step removed and workflows publish final image tags directly.

* **Documentation**
  - Docs updated to reflect the new single-step publishing behavior and tagging rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->