### PR TITLE
ci: cache uv setup in GitHub actions

### DIFF
--- a/.github/workflows/arm64-image-smoke.yml
+++ b/.github/workflows/arm64-image-smoke.yml
@@ -25,17 +25,18 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: arm64-image-smoke
 
-      - name: Install dependencies
-        run: uv sync --extra dev
+      - name: Prepare image smoke script dependencies
+        run: uv run --no-project --with pyyaml python -c "import yaml"
 
       - name: Determine default CUDA version
         id: image_metadata
         run: |
-          uv run python - <<'PY' >> "$GITHUB_OUTPUT"
+          uv run --no-project --with pyyaml python - <<'PY' >> "$GITHUB_OUTPUT"
           from boileroom.images.metadata import DEFAULT_CUDA_VERSION
 
           print(f"default_cuda_version={DEFAULT_CUDA_VERSION}")
@@ -43,7 +44,7 @@ jobs:
 
       - name: Build ARM64 image set
         run: |
-          uv run python scripts/images/build_model_images.py \
+          uv run --no-project --with pyyaml python scripts/images/build_model_images.py \
             --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
             --tag=arm64-ci \
             --platform=linux/arm64 \
@@ -52,12 +53,12 @@ jobs:
 
       - name: Run ARM64 import smoke
         run: |
-          uv run python scripts/images/check_model_imports.py \
+          uv run --no-project --with pyyaml python scripts/images/check_model_imports.py \
             --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
             --tag=arm64-ci
 
       - name: Run ARM64 server health smoke
         run: |
-          uv run python scripts/images/check_model_server_health.py \
+          uv run --no-project --with pyyaml python scripts/images/check_model_server_health.py \
             --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
             --tag=arm64-ci

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -72,12 +72,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        run: uv sync --extra dev
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: image-prepare
 
       - name: Determine Boileroom version
         id: version
@@ -87,7 +85,7 @@ jobs:
             version_args+=(--release-tag "$GITHUB_REF_NAME")
           fi
 
-          uv run python ./scripts/ci/derive_version.py "${version_args[@]}" --github-output "$GITHUB_OUTPUT"
+          uv run --no-project --with pyyaml python ./scripts/ci/derive_version.py "${version_args[@]}" --github-output "$GITHUB_OUTPUT"
 
       - name: Determine validation tag
         id: validation_tag
@@ -96,7 +94,7 @@ jobs:
       - name: Determine image metadata
         id: image_metadata
         run: |
-          uv run python - <<'PY' >> "$GITHUB_OUTPUT"
+          uv run --no-project --with pyyaml python - <<'PY' >> "$GITHUB_OUTPUT"
           import json
 
           from boileroom.images.metadata import CUDA_MICROMAMBA_BASE, DEFAULT_CUDA_VERSION
@@ -128,12 +126,13 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: image-build-${{ matrix.platform }}-${{ matrix.cuda_version }}
 
-      - name: Install dependencies
-        run: uv sync --extra dev
+      - name: Prepare image script dependencies
+        run: uv run --no-project --with pyyaml python -c "import yaml"
 
       - name: Log in to Docker Hub
         if: matrix.platform == 'linux/amd64'
@@ -151,7 +150,7 @@ jobs:
             build_args+=(--push --local-base)
           fi
 
-          uv run python ./scripts/images/build_model_images.py \
+          uv run --no-project --with pyyaml python ./scripts/images/build_model_images.py \
             --cuda-version=${{ matrix.cuda_version }} \
             --tag=${{ needs.prepare-release.outputs.validation_tag }} \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
@@ -162,14 +161,14 @@ jobs:
 
       - name: Verify local canonical validation image imports
         run: |
-          uv run python ./scripts/images/check_model_imports.py \
+          uv run --no-project --with pyyaml python ./scripts/images/check_model_imports.py \
             --cuda-version=${{ matrix.cuda_version }} \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
       - name: Verify local canonical validation image server health
         run: |
-          uv run python ./scripts/images/check_model_server_health.py \
+          uv run --no-project --with pyyaml python ./scripts/images/check_model_server_health.py \
             --cuda-version=${{ matrix.cuda_version }} \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
@@ -177,14 +176,14 @@ jobs:
       - name: Verify local validation alias image imports
         if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
-          uv run python ./scripts/images/check_model_imports.py \
+          uv run --no-project --with pyyaml python ./scripts/images/check_model_imports.py \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
       - name: Verify local validation alias image server health
         if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
-          uv run python ./scripts/images/check_model_server_health.py \
+          uv run --no-project --with pyyaml python ./scripts/images/check_model_server_health.py \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --tag=${{ needs.prepare-release.outputs.validation_tag }}
 
@@ -207,12 +206,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Install dependencies
-        run: uv sync --extra dev
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: image-promote
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -226,7 +223,7 @@ jobs:
 
       - name: Promote validated images to target tag
         run: |
-          uv run python ./scripts/images/promote_image_tags.py \
+          uv run --no-project --with pyyaml python ./scripts/images/promote_image_tags.py \
             --all-cuda \
             --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --source-tag=${{ needs.prepare-release.outputs.validation_tag }} \

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -24,9 +24,10 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: integration-tests
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -17,13 +17,14 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: pypi-publish
 
       - name: Apply release version
         run: |
-          uv run python ./scripts/ci/derive_version.py --release-tag "${GITHUB_REF_NAME}" --write-pyproject pyproject.toml
+          uv run --no-project python ./scripts/ci/derive_version.py --release-tag "${GITHUB_REF_NAME}" --write-pyproject pyproject.toml
 
       - name: Build and publish to PyPI
         run: |

--- a/.github/workflows/python-checks.yaml
+++ b/.github/workflows/python-checks.yaml
@@ -18,9 +18,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: python-harness
 
       - name: Install dependencies
         run: uv sync
@@ -39,9 +40,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: python-lint
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -60,9 +62,10 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: python-unit
 
       - name: Install dependencies
         run: uv sync --extra dev

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ dist/
 .cursor/
 .idea/
 .claude/
+.codex/
 script.py
 
 

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -51,6 +51,8 @@ For single-platform publishing, pass `--local-base` to build and tag images with
 ### ARM64 smoke workflow
 The `.github/workflows/arm64-image-smoke.yml` workflow runs on pull requests to `main` and on manual dispatch. It uses an `ubuntu-24.04-arm` runner, builds the image set for `linux/arm64` with the `arm64-ci` tag, and then runs the import and server-health smoke checks. It is informational and does not push images.
 
+The workflow does not install the full project dependency set on the host runner. Host-side image scripts run with `uv run --no-project --with pyyaml`, while heavy model dependencies such as PyTorch and SciPy are validated inside the Docker images themselves.
+
 On `main`, ARM64 image smoke is folded into the Docker publishing workflow instead of running as a second separate workflow. That keeps the branch smoke path fast and local while making release promotion wait for the same ARM64 smoke coverage.
 
 To reproduce the same path locally on an ARM64 machine, run:


### PR DESCRIPTION
Fixes #83

## Summary
- replace shell-based uv installation with `astral-sh/setup-uv@v7` and enabled cache across GitHub Actions workflows
- avoid full project dependency sync in image smoke and image publishing host-side scripts by using `uv run --no-project --with pyyaml`
- document the lean ARM64 image smoke host dependency path

## Validation
- parsed all workflow YAML files with PyYAML
- checked image helper scripts and release version helper with `uv run --no-project --with pyyaml ... --help`