### PR TITLE
fix: clean up integration tests and chai validation

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -66,7 +66,6 @@ jobs:
         run: |
           if [ -n "$IMAGE_TAG_OVERRIDE" ]; then
             echo "docker_tag=$IMAGE_TAG_OVERRIDE" >> "$GITHUB_OUTPUT"
-            echo "pep440=$IMAGE_TAG_OVERRIDE" >> "$GITHUB_OUTPUT"
           elif [ -n "$WORKFLOW_RUN_HEAD_SHA" ]; then
             uv run --no-project --with click python scripts/ci/derive_version.py \
               --head-ref "$WORKFLOW_RUN_HEAD_SHA" \

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -75,7 +75,7 @@ jobs:
       - name: Run integration tests
         shell: bash -l {0}
         env:
-          BOILEROOM_MODAL_IMAGE_TAG: ${{ steps.resolve_tag.outputs.pep440 }}
+          BOILEROOM_MODAL_IMAGE_TAG: ${{ steps.resolve_tag.outputs.docker_tag }}
         run: |
           if [ "${{ inputs.execution-mode || 'parallel' }}" = "series" ]; then
             uv run pytest -v -m integration

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,6 +1,23 @@
 name: Integration Tests
 
 on:
+  workflow_dispatch:
+    inputs:
+      execution-mode:
+        description: "Run integration tests in parallel model shards or in series"
+        required: false
+        default: "parallel"
+        type: choice
+        options:
+          - parallel
+          - series
+      image-tag:
+        description: "Optional explicit Docker/Modal image tag override"
+        required: false
+        default: ""
+        type: string
+  schedule:
+    - cron: "0 2 * * 0"
   # Run after the image-build workflow succeeds on main so integration tests
   # exercise the freshly-published image for the exact main commit that built it.
   workflow_run:
@@ -18,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 240
     if: >-
+      github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout repository
@@ -42,7 +60,23 @@ jobs:
 
       - name: Resolve freshly-built image tag
         id: resolve_tag
-        run: uv run --no-project --with click python scripts/ci/derive_version.py --github-output "$GITHUB_OUTPUT"
+        env:
+          IMAGE_TAG_OVERRIDE: ${{ github.event.inputs.image-tag || '' }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha || '' }}
+        run: |
+          if [ -n "$IMAGE_TAG_OVERRIDE" ]; then
+            echo "docker_tag=$IMAGE_TAG_OVERRIDE" >> "$GITHUB_OUTPUT"
+            echo "pep440=$IMAGE_TAG_OVERRIDE" >> "$GITHUB_OUTPUT"
+          elif [ -n "$WORKFLOW_RUN_HEAD_SHA" ]; then
+            uv run --no-project --with click python scripts/ci/derive_version.py \
+              --head-ref "$WORKFLOW_RUN_HEAD_SHA" \
+              --github-output "$GITHUB_OUTPUT"
+          else
+            git fetch origin main --tags
+            uv run --no-project --with click python scripts/ci/derive_version.py \
+              --head-ref origin/main \
+              --github-output "$GITHUB_OUTPUT"
+          fi
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -59,4 +93,8 @@ jobs:
         env:
           BOILEROOM_MODAL_IMAGE_TAG: ${{ steps.resolve_tag.outputs.docker_tag }}
         run: |
-          uv run pytest -v -n 4 --dist loadgroup -m integration
+          if [ "${{ inputs.execution-mode || 'parallel' }}" = "series" ]; then
+            uv run pytest -v -m integration
+          else
+            uv run pytest -v -n 4 --dist loadgroup -m integration
+          fi

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,20 +1,8 @@
 name: Integration Tests
 
 on:
-  workflow_dispatch:
-    inputs:
-      execution-mode:
-        description: "Run integration tests in parallel model shards or in series"
-        required: false
-        default: "parallel"
-        type: choice
-        options:
-          - parallel
-          - series
-  schedule:
-    - cron: "0 2 * * 0"
   # Run after the image-build workflow succeeds on main so integration tests
-  # exercise the freshly-published image rather than the stale registry tag.
+  # exercise the freshly-published image for the exact main commit that built it.
   workflow_run:
     workflows: ["Build and Push Boileroom Images"]
     types: [completed]
@@ -29,10 +17,7 @@ jobs:
   integration-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 240
-    # For workflow_run events, only proceed if the image build succeeded.
-    # For workflow_dispatch and schedule events, always proceed.
     if: >-
-      github.event_name != 'workflow_run' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout repository
@@ -57,9 +42,6 @@ jobs:
 
       - name: Resolve freshly-built image tag
         id: resolve_tag
-        # Only override the tag when chained from a successful image build.
-        # Scheduled and manual runs use the default (pyproject-version-based) tag.
-        if: github.event_name == 'workflow_run'
         run: uv run --no-project --with click python scripts/ci/derive_version.py --github-output "$GITHUB_OUTPUT"
 
       - name: Install dependencies
@@ -77,8 +59,4 @@ jobs:
         env:
           BOILEROOM_MODAL_IMAGE_TAG: ${{ steps.resolve_tag.outputs.docker_tag }}
         run: |
-          if [ "${{ inputs.execution-mode || 'parallel' }}" = "series" ]; then
-            uv run pytest -v -m integration
-          else
-            uv run pytest -v -n 4 --dist loadgroup -m integration
-          fi
+          uv run pytest -v -n 4 --dist loadgroup -m integration

--- a/boileroom/models/chai/chai1.py
+++ b/boileroom/models/chai/chai1.py
@@ -14,7 +14,6 @@ from .types import Chai1Output
 
 logger = logging.getLogger(__name__)
 app = get_modal_app("chai1")
-_STATIC_CONFIG_KEYS = frozenset({"device"})
 
 
 ############################################################
@@ -127,7 +126,9 @@ class Chai1(ModelWrapper):
                 "Chai-1 currently supports exactly one top-level sequence per call; use ':' to join chains."
             )
         if options is not None:
-            conflicting_keys = sorted(set(options) & _STATIC_CONFIG_KEYS)
+            from .core import Chai1Core
+
+            conflicting_keys = sorted(set(options) & Chai1Core.STATIC_CONFIG_KEYS)
             if conflicting_keys:
                 raise ValueError(
                     "The following config keys can only be set at initialization and cannot be "

--- a/boileroom/models/chai/chai1.py
+++ b/boileroom/models/chai/chai1.py
@@ -14,6 +14,7 @@ from .types import Chai1Output
 
 logger = logging.getLogger(__name__)
 app = get_modal_app("chai1")
+_STATIC_CONFIG_KEYS = frozenset({"device"})
 
 
 ############################################################
@@ -53,7 +54,9 @@ class ModalChai1:
         sequences : str | Sequence[str]
             One sequence string or a one-item sequence containing a single sequence string. Use ":" inside that sequence to join multiple chains for multimer prediction.
         options : dict, optional
-            Per-call configuration overrides merged with the model's default configuration to control sampling, device, and which result fields to include.
+            Per-call configuration overrides merged with the model's default configuration to control
+            sampling and which result fields to include. Static configuration such as ``device`` must
+            be set when the model is initialized.
 
         Returns
         -------
@@ -123,4 +126,11 @@ class Chai1(ModelWrapper):
             raise ValueError(
                 "Chai-1 currently supports exactly one top-level sequence per call; use ':' to join chains."
             )
+        if options is not None:
+            conflicting_keys = sorted(set(options) & _STATIC_CONFIG_KEYS)
+            if conflicting_keys:
+                raise ValueError(
+                    "The following config keys can only be set at initialization and cannot be "
+                    f"overridden per-call: {conflicting_keys}"
+                )
         return self._call_backend_method("fold", sequences, options=options)

--- a/boileroom/models/chai/core.py
+++ b/boileroom/models/chai/core.py
@@ -7,17 +7,19 @@ import os
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, ClassVar, cast
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import numpy as np
 import torch
 from biotite.structure import AtomArray
 from biotite.structure.io.pdbx import CIFFile, get_structure
-from chai_lab.chai1 import StructureCandidates, run_inference
 
 from ...base import FoldingAlgorithm, PredictionMetadata
 from ...utils import MODAL_MODEL_DIR, Timer
 from .types import Chai1Output
+
+if TYPE_CHECKING:
+    from chai_lab.chai1 import StructureCandidates
 
 logger = logging.getLogger(__name__)
 
@@ -120,6 +122,8 @@ class Chai1Core(FoldingAlgorithm):
                 constraint_path = self._write_constraint(buffer_path, effective_config)
                 output_dir = buffer_path / "outputs"
                 output_dir.mkdir(parents=True, exist_ok=True)
+            from chai_lab.chai1 import run_inference
+
             with Timer("Model Inference") as inference_timer:
                 candidate = run_inference(
                     fasta_file=fasta_path,

--- a/tests/chai/test_chai1.py
+++ b/tests/chai/test_chai1.py
@@ -143,8 +143,13 @@ def test_chai1_full_output(chai1_model: Chai1):
     assert np.all(per_chain_iptm <= 1.0), "per_chain_iptm should be less than or equal to 1"
 
 
-def test_chai1_static_config_enforcement(test_sequences: dict[str, str], chai1_model: Chai1):
+def test_chai1_static_config_enforcement(test_sequences: dict[str, str]):
     """Test that static config keys cannot be overridden in options."""
+    pytest.importorskip("chai_lab", reason="requires chai_lab (backend dependency)")
+    from boileroom.models.chai.core import Chai1Core
+
+    core = Chai1Core(config={"device": "cpu"})
+
     # device is a static config key
     with pytest.raises(ValueError, match="device"):
-        chai1_model.fold(test_sequences["short"], options={"device": "cpu"})
+        core.fold(test_sequences["short"], options={"device": "cpu"})

--- a/tests/contracts/test_model_wrappers.py
+++ b/tests/contracts/test_model_wrappers.py
@@ -234,3 +234,17 @@ def test_chai1_wrapper_rejects_multiple_top_level_sequences(monkeypatch: pytest.
         wrapper.fold(["AAAA", "BBBB"])
 
     assert "method" not in records
+
+
+def test_chai1_wrapper_rejects_static_option_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Chai1 should fail locally when callers try to override static config keys."""
+    records: dict[str, Any] = {}
+    _install_fake_initializer(monkeypatch, records, _make_output(CHAI1_SPEC))
+
+    wrapper_cls = resolve_object(CHAI1_SPEC.wrapper_class_path)
+    wrapper = wrapper_cls(backend="apptainer:dev", device="cuda:0")
+
+    with pytest.raises(ValueError, match="device"):
+        wrapper.fold("AAAA", options={"device": "cpu"})
+
+    assert "method" not in records


### PR DESCRIPTION
## Summary
- fix integration test image tag resolution so manual overrides keep using the provided Docker tag without emitting an inconsistent `pep440` output
- keep integration runs aligned with the actual published Docker image tags and document the intended `main` fallback behavior
- reject Chai-1 static config overrides like `device` at the wrapper layer before dispatching backend calls
- make the Chai-1 core import path lazier while keeping inference timing focused on the actual `run_inference` call
- add and update wrapper and core-level tests covering the Chai-1 static-config guard

## Why
The integration workflow expected the PEP 440 prerelease spelling like `0.3.0a20`, but the published containers use the Docker tag spelling like `0.3.0-alpha.20`.

The Chai-1 wrapper also accepted static config keys in per-call options even though those values must be fixed at initialization time. Failing fast in the wrapper keeps behavior consistent with the underlying core and avoids dispatching invalid remote calls.

The deferred `chai_lab` import should stay out of the inference timer so the reported inference duration measures model execution rather than one-time module import overhead.

## Validation
- `uv run pytest -q tests/contracts/test_model_wrappers.py::test_chai1_wrapper_rejects_static_option_overrides`
- `uv run pytest -q tests/contracts/test_model_wrappers.py tests/chai/test_chai1.py -m "not integration"`
- `uv run --extra dev pre-commit run --files .github/workflows/integration-tests.yaml boileroom/models/chai/core.py boileroom/models/chai/chai1.py tests/chai/test_chai1.py tests/contracts/test_model_wrappers.py`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added runtime validation to prevent overriding static configuration options (e.g., device) at call time.

* **Improvements**
  * Clarified that static configuration must be set during model initialization, not per-call.
  * Enhanced error messaging for invalid configuration attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->