### PR TITLE
refactor: remove micromamba from images

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -108,9 +108,9 @@ jobs:
           uv run --no-project --with pyyaml python - <<'PY' >> "$GITHUB_OUTPUT"
           import json
 
-          from boileroom.images.metadata import CUDA_MICROMAMBA_BASE, DEFAULT_CUDA_VERSION
+          from boileroom.images.metadata import DEFAULT_CUDA_VERSION, SUPPORTED_CUDA_VERSIONS
 
-          print(f"cuda_versions={json.dumps(sorted(CUDA_MICROMAMBA_BASE))}")
+          print(f"cuda_versions={json.dumps(sorted(SUPPORTED_CUDA_VERSIONS))}")
           print(f"default_cuda_version={DEFAULT_CUDA_VERSION}")
           PY
 

--- a/boileroom/__init__.py
+++ b/boileroom/__init__.py
@@ -1,4 +1,4 @@
-# Lazy imports to avoid importing modal when not needed (e.g., in conda backend)
+# Lazy imports to avoid importing modal when not needed (e.g., in image-backed runtimes)
 def __getattr__(name: str):
     """Lazy import for model classes to avoid importing modal dependencies."""
     if name == "ESMFold":

--- a/boileroom/backend/apptainer.py
+++ b/boileroom/backend/apptainer.py
@@ -202,11 +202,11 @@ def _check_architecture_compatibility(host_arch: str, image_arch: str) -> bool:
 
 
 def _build_ld_library_path() -> str:
-    """Build LD_LIBRARY_PATH for CUDA libraries in conda environments.
+    """Build LD_LIBRARY_PATH for CUDA libraries in the container.
 
     Includes paths for:
     - cuequivariance_ops (libcue_ops.so)
-    - NVIDIA conda packages (libcublas.so.12)
+    - NVIDIA Python wheel packages (libcublas.so.12)
     - PyTorch CUDA libraries (libnvrtc.so.12)
     - System CUDA toolkit paths
     - NVIDIA driver libraries (added by --nv flag)
@@ -216,20 +216,17 @@ def _build_ld_library_path() -> str:
     str
         Colon-separated LD_LIBRARY_PATH string.
     """
-    conda_base = "/opt/conda/lib"
     python_version = "3.12"
-    site_packages = f"{conda_base}/python{python_version}/site-packages"
+    site_packages = f"/usr/local/lib/python{python_version}/site-packages"
 
-    # Conda package-specific library paths (highest priority)
-    conda_lib_paths = [
+    python_lib_paths = [
         f"{site_packages}/cuequivariance_ops/lib",  # libcue_ops.so
         f"{site_packages}/nvidia/cublas/lib",  # libcublas.so.12
         f"{site_packages}/torch/lib",  # libnvrtc.so.12 and other PyTorch CUDA libs
-        f"{site_packages}/nvidia",  # Other NVIDIA conda packages
-        conda_base,  # Base conda lib directory
+        f"{site_packages}/nvidia",  # Other NVIDIA Python wheel packages
     ]
 
-    # System CUDA toolkit paths (fallback if not in conda)
+    # System CUDA toolkit paths (fallback if provided by the container)
     cuda_toolkit_paths = [
         "/usr/local/cuda/lib64",
         "/usr/local/cuda/lib",
@@ -245,7 +242,7 @@ def _build_ld_library_path() -> str:
     ]
 
     # Combine all paths in priority order
-    ld_path_parts = conda_lib_paths + cuda_toolkit_paths + nvidia_driver_paths
+    ld_path_parts = python_lib_paths + cuda_toolkit_paths + nvidia_driver_paths
 
     # Append host LD_LIBRARY_PATH if present (lowest priority)
     if "LD_LIBRARY_PATH" in os.environ:
@@ -481,7 +478,6 @@ class ApptainerBackend(Backend):
             "PYTHONPATH": container_boileroom,
             # Override temp directory variables to use container's /tmp
             # This prevents issues when host TMPDIR points to a path that doesn't exist in container
-            # CRITICAL: Must override TMPDIR before micromamba runs, otherwise it fails
             "TMPDIR": "/tmp",
             "TMP": "/tmp",
             "TEMP": "/tmp",
@@ -490,9 +486,7 @@ class ApptainerBackend(Backend):
             "CXX": "g++",
         }
 
-        # Build LD_LIBRARY_PATH to include all necessary CUDA library paths
-        # This ensures conda-installed CUDA libraries (libcue_ops.so, libcublas.so.12, libnvrtc.so.12)
-        # and system CUDA toolkit libraries are accessible
+        # Build LD_LIBRARY_PATH to include Python wheel CUDA libraries and driver paths.
         env_vars["LD_LIBRARY_PATH"] = _build_ld_library_path()
 
         if device_number is not None:
@@ -517,10 +511,6 @@ class ApptainerBackend(Backend):
         cmd.append(str(self._sif_path))
         cmd.extend(
             [
-                "micromamba",
-                "run",
-                "-n",
-                "base",
                 "python",
                 container_server_path,
                 "--host",

--- a/boileroom/backend/server.py
+++ b/boileroom/backend/server.py
@@ -1,7 +1,7 @@
-"""Generic unified model server for conda backend.
+"""Generic unified model server for Apptainer and image-backed runtimes.
 
 This server dynamically loads any Core class and exposes it via HTTP endpoints.
-It runs in a separate conda environment with model-specific dependencies.
+It runs inside a model-specific runtime image with model dependencies installed.
 """
 
 import argparse
@@ -15,17 +15,15 @@ import sysconfig
 from pathlib import Path
 from typing import Any
 
-# Ensure conda library paths are in LD_LIBRARY_PATH for cuequivariance_ops_torch
-# This is needed because libcue_ops.so and libcublas.so.12 are in conda site-packages
+# Ensure Python wheel library paths are in LD_LIBRARY_PATH for CUDA extension modules.
 _site_packages = sysconfig.get_path("purelib")
-_conda_lib_paths = [
-    f"{_site_packages}/cuequivariance_ops/lib",
-    f"{_site_packages}/nvidia/cublas/lib",
-    "/opt/conda/lib",
-]
+_runtime_lib_paths = [f"{_site_packages}/cuequivariance_ops/lib", f"{_site_packages}/torch/lib"]
+_nvidia_package_dir = Path(_site_packages) / "nvidia"
+if _nvidia_package_dir.exists():
+    _runtime_lib_paths.extend(str(path) for path in _nvidia_package_dir.glob("*/lib"))
 _current_ld_path = os.environ.get("LD_LIBRARY_PATH", "")
 _ld_path_parts = [p for p in _current_ld_path.split(":") if p] if _current_ld_path else []
-for lib_path in _conda_lib_paths:
+for lib_path in _runtime_lib_paths:
     if lib_path not in _ld_path_parts:
         _ld_path_parts.insert(0, lib_path)  # Insert at beginning for priority
 if _ld_path_parts:
@@ -64,10 +62,10 @@ def _import_with_modal_fix(name, globals=None, locals=None, fromlist=(), level=0
                 # If it's our local modal.py, raise clear error
                 if "boileroom" in str(origin_path) and "backend" in str(origin_path) and origin_path.name == "modal.py":
                     raise ImportError(
-                        "The 'modal' package is not installed in this conda environment. "
-                        "The conda backend does not require modal. "
+                        "The 'modal' package is not installed in this runtime environment. "
+                        "The image-backed server does not require modal. "
                         "This error occurred because the local boileroom/backend/modal.py file "
-                        "is shadowing the modal package. The conda backend should not import modal."
+                        "is shadowing the modal package. The image-backed server should not import modal."
                     )
         except Exception:
             pass
@@ -264,7 +262,7 @@ async def fold(request: FoldRequest) -> JSONResponse:
 
 def main() -> None:
     """Main entry point for the server."""
-    parser = argparse.ArgumentParser(description="Generic model server for conda backend")
+    parser = argparse.ArgumentParser(description="Generic model server for image-backed runtimes")
     parser.add_argument("--host", default="127.0.0.1", help="Host to bind to")
     parser.add_argument("--port", type=int, default=8000, help="Port to bind to")
     args = parser.parse_args()

--- a/boileroom/base.py
+++ b/boileroom/base.py
@@ -468,7 +468,7 @@ class ModelWrapper:
     def __del__(self) -> None:
         """Clean up backend when ModelWrapper is destroyed.
 
-        This ensures that backend resources (such as conda backend subprocesses)
+        This ensures that backend resources (such as image-backed subprocesses)
         are properly shut down when the ModelWrapper instance is garbage collected.
         """
         backend = getattr(self, "_backend", None)

--- a/boileroom/images/Dockerfile
+++ b/boileroom/images/Dockerfile
@@ -4,15 +4,12 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG BUILDPLATFORM
 
-ARG MICROMAMBA_BASE=mambaorg/micromamba:2.5-cuda12.6.3-ubuntu24.04
-FROM ${MICROMAMBA_BASE}
+ARG PYTHON_BASE=python:3.12-slim-bookworm
+FROM ${PYTHON_BASE}
 
-USER ${MAMBA_USER}
-
-ARG MAMBA_DOCKERFILE_ACTIVATE=1
 ENV PIP_NO_CACHE_DIR=1
+ENV UV_SYSTEM_PYTHON=1
 
-USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends eatmydata \
     && eatmydata apt-get install -y --no-install-recommends \
@@ -20,14 +17,11 @@ RUN apt-get update \
     && apt-get purge -y eatmydata \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
-USER ${MAMBA_USER}
 
-RUN micromamba install -y -c conda-forge python=3.12 pip uv \
-    && micromamba clean --all --yes \
-    && rm -rf "${HOME}/.cache/pip"
+RUN python -m pip install --upgrade pip uv \
+    && rm -rf /root/.cache/pip
 
 ENV MODEL_DIR=/mnt/models
 ENV TINI_SUBREAPER=1
-ENV PATH=/opt/conda/bin:${PATH}
 
 ENTRYPOINT ["/usr/bin/tini", "--"]

--- a/boileroom/images/import_checks.py
+++ b/boileroom/images/import_checks.py
@@ -8,9 +8,9 @@ from pathlib import Path
 from typing import Final
 
 from .metadata import (
-    CUDA_MICROMAMBA_BASE,
     DEFAULT_DOCKER_REPOSITORY,
     MODEL_IMAGE_SPECS,
+    SUPPORTED_CUDA_VERSIONS,
     RuntimeImageSpec,
     format_image_reference,
     get_supported_cuda,
@@ -37,7 +37,7 @@ Add entries here when a package name does not map cleanly to
 def compute_cuda_versions(requested: list[str] | None, all_cuda: bool) -> list[str]:
     """Resolve CUDA versions requested by the caller."""
     if all_cuda:
-        return sorted(normalize_cuda_version(cuda_version) for cuda_version in CUDA_MICROMAMBA_BASE)
+        return sorted(normalize_cuda_version(cuda_version) for cuda_version in SUPPORTED_CUDA_VERSIONS)
     if not requested:
         return []
     return [normalize_cuda_version(cuda_version) for cuda_version in requested]
@@ -57,7 +57,7 @@ def iter_image_targets(
 ) -> list[tuple[str, str, str, Path, Path]]:
     """Return model-image targets for smoke checks.
 
-    Returns tuples of ``(image_key, image_reference, display_tag, env_path, core_path)``.
+    Returns tuples of ``(image_key, image_reference, display_tag, requirements_path, core_path)``.
     """
     normalized_tag = normalize_requested_tag(tag)
     if cuda_versions and _CUDA_TAG_PATTERN.fullmatch(normalized_tag):
@@ -66,7 +66,7 @@ def iter_image_targets(
     specs = MODEL_IMAGE_SPECS if image_specs is None else image_specs
     targets: list[tuple[str, str, str, Path, Path]] = []
     for spec in specs:
-        env_path = spec.context_path / "environment.yml"
+        requirements_path = spec.context_path / "requirements.txt"
         core_path = spec.context_path / "core.py"
         if cuda_versions:
             for cuda_version in cuda_versions:
@@ -76,9 +76,9 @@ def iter_image_targets(
                     spec.image_name, cuda_version, normalized_tag, docker_repository
                 )[0]
                 display_tag = canonical_ref.rsplit(":", 1)[1]
-                targets.append((spec.key, canonical_ref, display_tag, env_path, core_path))
+                targets.append((spec.key, canonical_ref, display_tag, requirements_path, core_path))
             continue
 
         image_reference = format_image_reference(spec.image_name, normalized_tag, docker_repository)
-        targets.append((spec.key, image_reference, normalized_tag, env_path, core_path))
+        targets.append((spec.key, image_reference, normalized_tag, requirements_path, core_path))
     return targets

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -17,10 +17,7 @@ DEFAULT_CUDA_VERSION: Final = "12.6"
 DOCKER_REPOSITORY_ENV: Final = "BOILEROOM_DOCKER_REPOSITORY"
 MODAL_IMAGE_TAG_ENV: Final = "BOILEROOM_MODAL_IMAGE_TAG"
 
-CUDA_MICROMAMBA_BASE: Final[dict[str, str]] = {
-    "11.8": "mambaorg/micromamba:2.5-cuda11.8.0-ubuntu22.04",
-    "12.6": "mambaorg/micromamba:2.5-cuda12.6.3-ubuntu22.04",
-}
+SUPPORTED_CUDA_VERSIONS: Final[tuple[str, ...]] = ("11.8", "12.6")
 
 CUDA_TORCH_WHEEL_INDEX: Final[dict[str, str]] = {
     "11.8": "https://download.pytorch.org/whl/cu118",
@@ -125,8 +122,8 @@ def normalize_requested_tag(tag: str | None) -> str:
 def normalize_cuda_version(cuda_version: str) -> str:
     """Validate and normalize a CUDA version string."""
     normalized = cuda_version.strip()
-    if normalized not in CUDA_MICROMAMBA_BASE:
-        supported = ", ".join(sorted(CUDA_MICROMAMBA_BASE))
+    if normalized not in SUPPORTED_CUDA_VERSIONS:
+        supported = ", ".join(SUPPORTED_CUDA_VERSIONS)
         raise ValueError(f"Unsupported CUDA version: {cuda_version}. Supported values: {supported}")
     return normalized
 
@@ -243,11 +240,11 @@ def get_model_image_spec(identifier: str) -> RuntimeImageSpec:
 def get_supported_cuda(spec: RuntimeImageSpec) -> tuple[str, ...]:
     """Return supported CUDA versions for a runtime image spec."""
     if spec.config_relative_path is None:
-        return tuple(sorted(CUDA_MICROMAMBA_BASE))
+        return SUPPORTED_CUDA_VERSIONS
 
     config_path = get_repo_root() / spec.config_relative_path
     if not config_path.exists():
-        return tuple(sorted(CUDA_MICROMAMBA_BASE))
+        return SUPPORTED_CUDA_VERSIONS
 
     import yaml
 
@@ -261,7 +258,7 @@ def get_supported_cuda(spec: RuntimeImageSpec) -> tuple[str, ...]:
         supported_cuda = []
 
     if not supported_cuda:
-        return tuple(sorted(CUDA_MICROMAMBA_BASE))
+        return SUPPORTED_CUDA_VERSIONS
     return tuple(supported_cuda)
 
 

--- a/boileroom/models/__init__.py
+++ b/boileroom/models/__init__.py
@@ -1,4 +1,4 @@
-# Lazy imports to avoid importing modal when not needed (e.g., in conda backend)
+# Lazy imports to avoid importing modal when not needed (e.g., in image-backed runtimes)
 def __getattr__(name: str):
     """Lazy import for model classes to avoid importing modal dependencies."""
     if name == "ESMFold":

--- a/boileroom/models/boltz/Dockerfile
+++ b/boileroom/models/boltz/Dockerfile
@@ -16,6 +16,6 @@ ENV PIP_EXTRA_INDEX_URL=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX_STRATEGY=unsafe-best-match
 
-RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv,sharing=locked \
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv \
     uv pip install --system -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt

--- a/boileroom/models/boltz/Dockerfile
+++ b/boileroom/models/boltz/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # BuildKit platform arguments
 ARG TARGETPLATFORM
 ARG TARGETARCH
@@ -10,10 +11,11 @@ FROM ${BASE_IMAGE}
 COPY requirements.txt /tmp/requirements.txt
 
 ARG TORCH_WHEEL_INDEX=https://download.pytorch.org/whl/cu118
+ARG UV_CACHE_ID=boileroom-uv
 ENV PIP_EXTRA_INDEX_URL=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX_STRATEGY=unsafe-best-match
 
-RUN uv pip install --system -r /tmp/requirements.txt \
-    && rm -rf /root/.cache/pip /root/.cache/uv \
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv,sharing=locked \
+    uv pip install --system -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt

--- a/boileroom/models/boltz/Dockerfile
+++ b/boileroom/models/boltz/Dockerfile
@@ -7,20 +7,13 @@ ARG BUILDPLATFORM
 ARG BASE_IMAGE=docker.io/jakublala/boileroom-base:local
 FROM ${BASE_IMAGE}
 
-ARG ENV_FILE=environment.yml
-COPY ${ENV_FILE} /tmp/environment.yml
 COPY requirements.txt /tmp/requirements.txt
-USER root
-RUN chown ${MAMBA_USER}:${MAMBA_USER} /tmp/environment.yml /tmp/requirements.txt
-USER ${MAMBA_USER}
 
 ARG TORCH_WHEEL_INDEX=https://download.pytorch.org/whl/cu118
 ENV PIP_EXTRA_INDEX_URL=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX_STRATEGY=unsafe-best-match
 
-RUN micromamba env update -n base -f /tmp/environment.yml \
-    && uv pip install --python /opt/conda/bin/python -r /tmp/requirements.txt \
-    && micromamba clean --all --yes \
-    && rm -rf "${HOME}/.cache/pip" "${HOME}/.cache/uv" \
-    && rm /tmp/environment.yml /tmp/requirements.txt
+RUN uv pip install --system -r /tmp/requirements.txt \
+    && rm -rf /root/.cache/pip /root/.cache/uv \
+    && rm /tmp/requirements.txt

--- a/boileroom/models/boltz/environment.yml
+++ b/boileroom/models/boltz/environment.yml
@@ -1,8 +1,0 @@
-name: boileroom-boltz
-channels:
-  - conda-forge
-  - defaults
-dependencies:
-  - python=3.12
-  - numpy<2.0
-  - pip

--- a/boileroom/models/boltz/requirements.txt
+++ b/boileroom/models/boltz/requirements.txt
@@ -1,3 +1,4 @@
+numpy<2.0
 torch>=2.5.1,<2.7.0
 pytorch-lightning
 boltz[cuda]==2.2.1

--- a/boileroom/models/chai/Dockerfile
+++ b/boileroom/models/chai/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 # BuildKit platform arguments
 ARG TARGETPLATFORM
 ARG TARGETARCH
@@ -10,12 +11,13 @@ FROM ${BASE_IMAGE}
 COPY requirements.txt /tmp/requirements.txt
 
 ARG TORCH_WHEEL_INDEX=https://download.pytorch.org/whl/cu118
+ARG UV_CACHE_ID=boileroom-uv
 ENV PIP_EXTRA_INDEX_URL=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX_STRATEGY=unsafe-best-match
 
-RUN uv pip install --system -r /tmp/requirements.txt \
-    && rm -rf /root/.cache/pip /root/.cache/uv \
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv,sharing=locked \
+    uv pip install --system -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt
 
 ENV HF_HUB_ENABLE_HF_TRANSFER=1 \

--- a/boileroom/models/chai/Dockerfile
+++ b/boileroom/models/chai/Dockerfile
@@ -16,7 +16,7 @@ ENV PIP_EXTRA_INDEX_URL=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX_STRATEGY=unsafe-best-match
 
-RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv,sharing=locked \
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv \
     uv pip install --system -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt
 

--- a/boileroom/models/chai/Dockerfile
+++ b/boileroom/models/chai/Dockerfile
@@ -7,23 +7,16 @@ ARG BUILDPLATFORM
 ARG BASE_IMAGE=docker.io/jakublala/boileroom-base:local
 FROM ${BASE_IMAGE}
 
-ARG ENV_FILE=environment.yml
-COPY ${ENV_FILE} /tmp/environment.yml
 COPY requirements.txt /tmp/requirements.txt
-USER root
-RUN chown ${MAMBA_USER}:${MAMBA_USER} /tmp/environment.yml /tmp/requirements.txt
-USER ${MAMBA_USER}
 
 ARG TORCH_WHEEL_INDEX=https://download.pytorch.org/whl/cu118
 ENV PIP_EXTRA_INDEX_URL=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX_STRATEGY=unsafe-best-match
 
-RUN micromamba env update -n base -f /tmp/environment.yml \
-    && uv pip install --python /opt/conda/bin/python -r /tmp/requirements.txt \
-    && micromamba clean --all --yes \
-    && rm -rf "${HOME}/.cache/pip" "${HOME}/.cache/uv" \
-    && rm /tmp/environment.yml /tmp/requirements.txt
+RUN uv pip install --system -r /tmp/requirements.txt \
+    && rm -rf /root/.cache/pip /root/.cache/uv \
+    && rm /tmp/requirements.txt
 
 ENV HF_HUB_ENABLE_HF_TRANSFER=1 \
     DISABLE_PANDERA_IMPORT_WARNING=True

--- a/boileroom/models/chai/environment.yml
+++ b/boileroom/models/chai/environment.yml
@@ -1,9 +1,0 @@
-name: boileroom-chai
-channels:
-  - conda-forge
-  - defaults
-dependencies:
-  - python=3.12
-  - numpy<2.0
-  - rdkit
-  - pip

--- a/boileroom/models/chai/requirements.txt
+++ b/boileroom/models/chai/requirements.txt
@@ -1,3 +1,5 @@
+numpy<2.0
+rdkit
 torch>=2.5.1,<2.7.0
 chai_lab==0.6.1
 hf_transfer==0.1.8

--- a/boileroom/models/esm/Dockerfile
+++ b/boileroom/models/esm/Dockerfile
@@ -6,12 +6,7 @@ ARG BUILDPLATFORM
 ARG BASE_IMAGE=docker.io/jakublala/boileroom-base:local
 FROM ${BASE_IMAGE}
 
-ARG ENV_FILE=environment.yml
-COPY ${ENV_FILE} /tmp/environment.yml
 COPY requirements.txt /tmp/requirements.txt
-USER root
-RUN chown ${MAMBA_USER}:${MAMBA_USER} /tmp/environment.yml /tmp/requirements.txt
-USER ${MAMBA_USER}
 
 ARG TORCH_WHEEL_INDEX=https://download.pytorch.org/whl/cu118
 ENV PIP_EXTRA_INDEX_URL=${TORCH_WHEEL_INDEX}
@@ -19,8 +14,6 @@ ENV UV_INDEX=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX_STRATEGY=unsafe-best-match
 ENV PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 
-RUN micromamba env update -n base -f /tmp/environment.yml \
-    && uv pip install --python /opt/conda/bin/python -r /tmp/requirements.txt \
-    && micromamba clean --all --yes \
-    && rm -rf "${HOME}/.cache/pip" "${HOME}/.cache/uv" \
-    && rm /tmp/environment.yml /tmp/requirements.txt
+RUN uv pip install --system -r /tmp/requirements.txt \
+    && rm -rf /root/.cache/pip /root/.cache/uv \
+    && rm /tmp/requirements.txt

--- a/boileroom/models/esm/Dockerfile
+++ b/boileroom/models/esm/Dockerfile
@@ -16,6 +16,6 @@ ENV UV_INDEX=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX_STRATEGY=unsafe-best-match
 ENV PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 
-RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv,sharing=locked \
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv \
     uv pip install --system -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt

--- a/boileroom/models/esm/Dockerfile
+++ b/boileroom/models/esm/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1.7
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETOS
@@ -9,11 +10,12 @@ FROM ${BASE_IMAGE}
 COPY requirements.txt /tmp/requirements.txt
 
 ARG TORCH_WHEEL_INDEX=https://download.pytorch.org/whl/cu118
+ARG UV_CACHE_ID=boileroom-uv
 ENV PIP_EXTRA_INDEX_URL=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX=${TORCH_WHEEL_INDEX}
 ENV UV_INDEX_STRATEGY=unsafe-best-match
 ENV PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 
-RUN uv pip install --system -r /tmp/requirements.txt \
-    && rm -rf /root/.cache/pip /root/.cache/uv \
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv,sharing=locked \
+    uv pip install --system -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt

--- a/boileroom/models/esm/__init__.py
+++ b/boileroom/models/esm/__init__.py
@@ -1,4 +1,4 @@
-# Lazy imports to avoid importing modal when not needed (e.g., in conda backend)
+# Lazy imports to avoid importing modal when not needed (e.g., in image-backed runtimes)
 def __getattr__(name: str):
     """Lazy import for ESMFold and ESM2 to avoid importing modal dependencies."""
     if name == "ESMFold":

--- a/boileroom/models/esm/environment.yml
+++ b/boileroom/models/esm/environment.yml
@@ -1,8 +1,0 @@
-name: boileroom-esm
-channels:
-  - conda-forge
-  - defaults
-dependencies:
-  - python=3.12
-  - numpy
-  - pip

--- a/boileroom/models/esm/requirements.txt
+++ b/boileroom/models/esm/requirements.txt
@@ -1,3 +1,4 @@
+numpy
 torch>=2.5.1,<2.7.0
 transformers==4.49.0
 biotite>=1.0.1

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -59,6 +59,7 @@ uv run pytest -v -m integration --docker-user=my-dockerhub-user --image-tag=0.3.
 
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
 Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.
+Model Dockerfiles also mount a shared BuildKit uv cache for the active CUDA line, for example `boileroom-uv-cu12.6`, so parallel model builds in the same GitHub Actions matrix job can reuse downloaded wheels even when a full dependency-install layer has to run again.
 Pass `--verbose` to stream Docker build output and plain BuildKit progress while still writing per-image log files.
 In CI, the release workflow splits CUDA lines across separate GitHub-hosted runners and passes `--max-workers` within each CUDA job. That keeps the base image dependency order intact while letting model image builds and Docker Hub transfers overlap.
 For single-platform publishing, pass `--local-base` to build and tag images with `buildx --load` before pushing. This keeps dependent model builds from waiting on Docker Hub to receive and then re-serve the base image. Model builds also receive the loaded base tag as a named `docker-image://` build context so their `FROM` instruction resolves locally while preserving BuildKit registry cache import/export.

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -1,12 +1,12 @@
 ## Boileroom Docker images
 
 ### What exists today
-- **base**: `boileroom/images/Dockerfile` → CUDA-enabled micromamba base with Python 3.12. Tag: `docker.io/jakublala/boileroom-base`.
-- **boltz**: `boileroom/models/boltz/Dockerfile` → copies `environment.yml` and installs the Boltz env. Tag: `docker.io/jakublala/boileroom-boltz`.
-- **chai1**: `boileroom/models/chai/Dockerfile` → copies `environment.yml`, installs chai-specific deps, sets HF env vars. Tag: `docker.io/jakublala/boileroom-chai1`.
-- **esm**: `boileroom/models/esm/Dockerfile` → copies `environment.yml` shared by esm2/esmfold. Tag: `docker.io/jakublala/boileroom-esm`.
+- **base**: `boileroom/images/Dockerfile` → Python 3.12 slim base with shared OS build/runtime tools. Tag: `docker.io/jakublala/boileroom-base`.
+- **boltz**: `boileroom/models/boltz/Dockerfile` → installs Boltz runtime dependencies from `requirements.txt`. Tag: `docker.io/jakublala/boileroom-boltz`.
+- **chai1**: `boileroom/models/chai/Dockerfile` → installs Chai runtime dependencies from `requirements.txt`, sets HF env vars. Tag: `docker.io/jakublala/boileroom-chai1`.
+- **esm**: `boileroom/models/esm/Dockerfile` → installs ESM runtime dependencies from `requirements.txt` shared by esm2/esmfold. Tag: `docker.io/jakublala/boileroom-esm`.
 
-Dockerfiles are the canonical image definition for all runtimes. Docker/Apptainer images are built from these Dockerfiles, and Modal pulls the corresponding published model image from Docker Hub instead of maintaining a separate handwritten dependency stack.
+Dockerfiles are the canonical image definition for all runtimes. Docker/Apptainer images are built from these Dockerfiles, and Modal pulls the corresponding published model image from Docker Hub instead of maintaining a separate handwritten dependency stack. CUDA variants select the PyTorch wheel index; the runtime images rely on PyTorch/NVIDIA wheels for user-space CUDA libraries and on Docker/Apptainer GPU integration for host driver libraries.
 
 ### Tag scheme
 - Canonical published tags are CUDA-qualified, for example `cuda12.6-0.3.0`, `cuda11.8-0.3.0`, `cuda12.6-0.3.1-alpha.1`, or `cuda12.6-sha-abc1234`.

--- a/harness/model_family_contract.yaml
+++ b/harness/model_family_contract.yaml
@@ -7,7 +7,6 @@ model_family:
     - types.py
     - image.py
     - Dockerfile
-    - environment.yml
     - requirements.txt
     - config.yaml
 

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -103,6 +103,11 @@ def build_cache_reference(docker_repository: str, image_name: str, cuda_version:
     return f"{docker_repository}/{image_name}:buildcache-cuda{cuda_version}"
 
 
+def uv_cache_id(cuda_version: str) -> str:
+    """Return the shared BuildKit cache id for uv downloads in one CUDA line."""
+    return f"boileroom-uv-cu{normalize_cuda_version(cuda_version)}"
+
+
 def append_registry_cache_args(
     cmd: list[str],
     image_name: str,
@@ -385,6 +390,8 @@ def build_model(
             f"BASE_IMAGE={task.base_image_reference}",
             "--build-arg",
             f"TORCH_WHEEL_INDEX={CUDA_TORCH_WHEEL_INDEX[task.cuda_version]}",
+            "--build-arg",
+            f"UV_CACHE_ID={uv_cache_id(task.cuda_version)}",
         ]
     else:
         cmd = [
@@ -397,6 +404,8 @@ def build_model(
             f"BASE_IMAGE={task.base_image_reference}",
             "--build-arg",
             f"TORCH_WHEEL_INDEX={CUDA_TORCH_WHEEL_INDEX[task.cuda_version]}",
+            "--build-arg",
+            f"UV_CACHE_ID={uv_cache_id(task.cuda_version)}",
         ]
         append_registry_cache_args(
             cmd,

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -18,11 +18,11 @@ if str(REPO_ROOT) not in sys.path:
 
 from boileroom.images.metadata import (  # noqa: E402
     BASE_IMAGE_SPEC,
-    CUDA_MICROMAMBA_BASE,
     CUDA_TORCH_WHEEL_INDEX,
     DEFAULT_DOCKER_REPOSITORY,
     MODEL_IMAGE_SPECS,
     RuntimeImageSpec,
+    SUPPORTED_CUDA_VERSIONS,
     get_supported_cuda,
     normalize_docker_repository,
     normalize_cuda_version,
@@ -253,7 +253,7 @@ def resolve_publish_tag(tag: str | None) -> str:
 def compute_cuda_versions(requested: list[str] | None, all_cuda: bool) -> list[str]:
     """Resolve the CUDA versions to build."""
     if all_cuda:
-        return sorted(CUDA_MICROMAMBA_BASE)
+        return sorted(SUPPORTED_CUDA_VERSIONS)
     if not requested:
         raise ValueError("Specify at least one --cuda-version or use --all-cuda.")
     return [normalize_cuda_version(cuda_version) for cuda_version in requested]
@@ -305,11 +305,9 @@ def build_base(
     """Build the shared base image and return its canonical reference."""
     references = published_image_references(BASE_IMAGE_SPEC.image_name, cuda_version, tag, docker_repository)
     canonical_reference = references[0]
-    micromamba_base = CUDA_MICROMAMBA_BASE[cuda_version]
 
     log_info("")
     log_info(Colors.wrap(f"=== Building base image for CUDA {cuda_version}: {canonical_reference}", Colors.bold))
-    log_info(f"Using micromamba base: {micromamba_base}")
     log_info(f"Publishing tags: {', '.join(references)}")
 
     log_file = Path.cwd() / f"{canonical_reference.replace('/', '_').replace(':', '_')}.log"
@@ -320,8 +318,6 @@ def build_base(
             "build",
             "--platform",
             platform,
-            "--build-arg",
-            f"MICROMAMBA_BASE={micromamba_base}",
         ]
     else:
         cmd = [
@@ -330,8 +326,6 @@ def build_base(
             "build",
             "--platform",
             platform,
-            "--build-arg",
-            f"MICROMAMBA_BASE={micromamba_base}",
         ]
         append_registry_cache_args(
             cmd,

--- a/scripts/images/check_model_imports.py
+++ b/scripts/images/check_model_imports.py
@@ -76,7 +76,7 @@ def _remove_image(image_reference: str) -> None:
 def check_image(
     image_key: str,
     image_reference: str,
-    env_path: Path,
+    requirements_path: Path,
     core_path: Path,
     pull: bool,
     cleanup: bool = False,
@@ -87,8 +87,8 @@ def check_image(
     if pull:
         subprocess.run(["docker", "pull", image_reference], check=True)
 
-    if not env_path.exists():
-        raise FileNotFoundError(f"Missing environment file: {env_path}")
+    if not requirements_path.exists():
+        raise FileNotFoundError(f"Missing requirements file: {requirements_path}")
     if not core_path.exists():
         raise FileNotFoundError(f"Missing core module: {core_path}")
 
@@ -112,35 +112,20 @@ import re
 import sys
 from pathlib import Path
 
-env_yml = Path({str(env_path)!r})
-requirements_txt = env_yml.with_name('requirements.txt')
+requirements_txt = Path({str(requirements_path)!r})
 core_file = Path({str(core_path)!r})
 import_name_overrides = {IMPORT_NAME_OVERRIDES!r}
 
 deps = []
-requirements_files = [requirements_txt] if requirements_txt.exists() else [env_yml]
-for requirements_file in requirements_files:
-    in_pip_section = requirements_file.suffix in {{'.txt', '.in'}}
-    with requirements_file.open(encoding="utf-8") as handle:
-        for line in handle:
-            stripped = line.strip()
-            if stripped == '- pip:' or stripped == 'pip:':
-                in_pip_section = True
-                continue
-            if not in_pip_section:
-                continue
-            if requirements_file == env_yml:
-                if not stripped or (not line.startswith(' ') and not line.startswith('\\t')):
-                    in_pip_section = False
-                    if not stripped:
-                        continue
-                    break
-            if not stripped or stripped.startswith('#'):
-                continue
-            pkg_name = re.split(r'[>=<!=;\\[]', stripped.lstrip('- '))[0].strip()
-            import_name = import_name_overrides.get(pkg_name, pkg_name.replace('-', '_'))
-            if import_name:
-                deps.append(import_name)
+with requirements_txt.open(encoding="utf-8") as handle:
+    for line in handle:
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+        pkg_name = re.split(r'[>=<!=;\\[]', stripped)[0].strip()
+        import_name = import_name_overrides.get(pkg_name, pkg_name.replace('-', '_'))
+        if import_name:
+            deps.append(import_name)
 
 deps.append('numpy')
 
@@ -170,10 +155,6 @@ for dep in deps:
             "-e",
             f"PYTHONPATH={REPO_ROOT}",
             image_reference,
-            "micromamba",
-            "run",
-            "-n",
-            "base",
             "python",
             "-c",
             script,
@@ -195,8 +176,8 @@ def run_import_checks(options: ImportCheckOptions) -> None:
     if not targets:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 
-    for image_key, image_reference, _display_tag, env_path, core_path in targets:
-        check_image(image_key, image_reference, env_path, core_path, options.pull, options.cleanup)
+    for image_key, image_reference, _display_tag, requirements_path, core_path in targets:
+        check_image(image_key, image_reference, requirements_path, core_path, options.pull, options.cleanup)
 
     print(f"All module imports succeeded for tag selection: {normalize_requested_tag(options.tag)}")
 

--- a/scripts/images/check_model_server_health.py
+++ b/scripts/images/check_model_server_health.py
@@ -139,10 +139,6 @@ def check_server_health(
         "--env",
         f"{TRANSPORT_HMAC_KEY_ENV}=healthcheck-secret",
         image_reference,
-        "micromamba",
-        "run",
-        "-n",
-        "base",
         "python",
         str(SERVER_PATH),
         "--host",
@@ -188,7 +184,7 @@ def run_server_health_checks(options: HealthCheckOptions) -> None:
     if not targets:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 
-    for image_key, image_reference, _display_tag, _env_path, _core_path in targets:
+    for image_key, image_reference, _display_tag, _requirements_path, _core_path in targets:
         check_server_health(image_key, image_reference, options.pull, options.timeout, options.cleanup)
 
     print(f"All server health checks succeeded for tag selection: {normalize_requested_tag(options.tag)}")

--- a/scripts/images/promote_image_tags.py
+++ b/scripts/images/promote_image_tags.py
@@ -15,7 +15,6 @@ if str(REPO_ROOT) not in sys.path:
 
 from boileroom.images.metadata import (  # noqa: E402
     BASE_IMAGE_SPEC,
-    CUDA_MICROMAMBA_BASE,
     DEFAULT_DOCKER_REPOSITORY,
     MODEL_IMAGE_SPECS,
     RuntimeImageSpec,

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -70,6 +70,11 @@ def test_build_cache_reference_uses_explicit_repository() -> None:
     )
 
 
+def test_uv_cache_id_is_scoped_by_cuda_version() -> None:
+    """Model builds should share uv downloads within a CUDA matrix job."""
+    assert build_model_images.uv_cache_id("12.6") == "boileroom-uv-cu12.6"
+
+
 def test_cli_exposes_documented_flags(monkeypatch: MonkeyPatch) -> None:
     """The build helper should accept the documented flags."""
 
@@ -259,6 +264,8 @@ def test_build_model_local_base_uses_buildx_cache_context_then_push(monkeypatch:
     assert "--push" not in build_cmd
     assert "--cache-from" in build_cmd
     assert "--cache-to" in build_cmd
+    assert "--build-arg" in build_cmd
+    assert f"UV_CACHE_ID=boileroom-uv-cu{DEFAULT_CUDA_VERSION}" in build_cmd
     assert "--build-context" in build_cmd
     assert f"{base_image_reference}=docker-image://{base_image_reference}" in build_cmd
     assert push_cmds == [


### PR DESCRIPTION
## Summary
- Replace the CUDA micromamba base with a Python 3.12 slim base and install model runtime dependencies directly with uv/pip.
- Remove per-family `environment.yml` files and move their remaining lightweight dependencies into `requirements.txt`.
- Keep CUDA variants as PyTorch wheel-index selection, add shared BuildKit uv cache mounts for model image builds, and update image smoke/server scripts to run Python directly.
- Update Apptainer/server library paths for pip-installed NVIDIA/PyTorch libraries and refresh Docker image docs/harness expectations.

## Validation
- `uv run pytest tests/contracts/test_build_model_images.py -q`
- `uv run python -m compileall scripts/images`
- `docker buildx build --check` for Boltz, Chai, and ESM Dockerfiles
- `uv run --extra dev pre-commit run --all-files`
- Manual image build/push verification for `sha-e1a16d09d866`
- Modal integration suite: `uv run pytest -v -n 4 --dist loadgroup -m integration --image-tag sha-e1a16d09d866 --gpu L4` -> `30 passed, 15 skipped, 2 warnings`
- Passing integration tests - https://github.com/softnanolab/boileroom/actions/runs/24914703000
- Passing Docker image build - https://github.com/softnanolab/boileroom/actions/runs/24914186414

Closes #42


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Transitioned Docker images from conda-based build system to lightweight Python 3.12 foundation.
  * Updated dependencies to use requirements.txt instead of environment configuration files.
  * Added build caching for package downloads to improve build performance.

* **Documentation**
  * Updated Docker image descriptions to reflect wheel-based dependency management approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->