### PR TITLE
chore: standardize apptainer test ergonomics

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -90,7 +90,7 @@ jobs:
       - name: Run integration tests
         shell: bash -l {0}
         env:
-          BOILEROOM_MODAL_IMAGE_TAG: ${{ steps.resolve_tag.outputs.docker_tag }}
+          BOILEROOM_IMAGE_TAG: ${{ steps.resolve_tag.outputs.docker_tag }}
         run: |
           if [ "${{ inputs.execution-mode || 'parallel' }}" = "series" ]; then
             uv run pytest -v -m integration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@
 - Use f-strings.
 - Use NumPy-style docstrings.
 - Keep the high-level public API stable unless a breaking change is intentional and documented.
+- While the project is on a prerelease (no matching `vX.Y.Z` GitHub release for the pyproject version), back-compat shims are not required — make the breaking change cleanly and call it out in the PR.
 
 ## Testing
 - Prefer pytest functions and fixtures.
@@ -46,6 +47,7 @@
 - Canonical published tags are CUDA-qualified, for example `cuda12.6-0.3.0` or `cuda12.6-0.3.1-alpha.1`.
 - The default CUDA line `12.6` also gets an unqualified alias for the same version, for example `0.3.0` or `0.3.1-alpha.1`.
 - Temporary validation tags such as `sha-<commit>` are allowed and should be deleted after use.
+- Renames of runtime-facing env vars (e.g. `BOILEROOM_*`) bake into Modal images at build time. After such a rename, Modal images may need to be rebuilt before consumers can rely on the new name; verify before assuming the override propagates.
 
 ## Release Flow
 - Merging to `main` publishes Docker Hub images for an automatically derived alpha prerelease tag such as `0.3.1-alpha.1`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,8 @@
 - Runtime image lookup defaults to the installed boileroom package version.
 - `latest` is not published or used as a runtime default.
 - Explicit image-tag overrides still work:
-  - Modal via `BOILEROOM_MODAL_IMAGE_TAG`
-  - Apptainer via `backend="apptainer:<tag>"`
+  - Both backends honor `BOILEROOM_IMAGE_TAG`
+  - Apptainer also accepts an inline tag via `backend="apptainer:<tag>"`, which wins over the env var
 - Canonical published tags are CUDA-qualified, for example `cuda12.6-0.3.0` or `cuda12.6-0.3.1-alpha.1`.
 - The default CUDA line `12.6` also gets an unqualified alias for the same version, for example `0.3.0` or `0.3.1-alpha.1`.
 - Temporary validation tags such as `sha-<commit>` are allowed and should be deleted after use.

--- a/README.md
+++ b/README.md
@@ -115,11 +115,13 @@ uv run pytest --gpu A100-40GB
 To run Modal integration tests against a specific Docker Hub namespace, image tag, and GPU type:
 
 ```bash
-uv run pytest -v -n 4 --dist loadgroup -m integration \
+BOILEROOM_IMAGE_TAG=cuda12.6-my-test-tag uv run pytest -v -n 4 --dist loadgroup -m integration \
   --docker-user <your-dockerhub-user> \
-  --image-tag cuda12.6-my-test-tag \
   --gpu A10
 ```
+
+The same env var works for the Apptainer backend; for Apptainer you can also pass the tag inline as
+`--backend apptainer:<tag>` (the inline suffix wins over the env var).
 
 Available GPU options include `T4`, `A100-40GB`, `A100-80GB`, and other Modal-supported GPU types.
 

--- a/boileroom/backend/apptainer.py
+++ b/boileroom/backend/apptainer.py
@@ -241,13 +241,12 @@ def _build_ld_library_path() -> str:
         "/.singularity.d/libs",
     ]
 
-    # Combine all paths in priority order
+    # Combine all paths in priority order. Host LD_LIBRARY_PATH is intentionally
+    # NOT appended: the container has its own torch wheel and `--nv` provides
+    # driver libs, while host paths can drag in libs (including a host libpython)
+    # that collide with the container's, producing
+    # `Fatal Python error: _PyImport_Init: global import state already initialized`.
     ld_path_parts = python_lib_paths + cuda_toolkit_paths + nvidia_driver_paths
-
-    # Append host LD_LIBRARY_PATH if present (lowest priority)
-    if "LD_LIBRARY_PATH" in os.environ:
-        host_paths = [p for p in os.environ["LD_LIBRARY_PATH"].split(":") if p and p not in ld_path_parts]
-        ld_path_parts.extend(host_paths)
 
     return ":".join(ld_path_parts)
 
@@ -435,16 +434,30 @@ class ApptainerBackend(Backend):
         container_boileroom = str(project_root)
         container_server_path = str(server_path)
 
-        # Build apptainer exec command
-        cmd = ["apptainer", "exec"]
+        # Build apptainer exec command.
+        # --cleanenv: container starts with only the env we explicitly pass via --env.
+        #   Without this, host PATH (with .venv/bin first under `uv run`), VIRTUAL_ENV,
+        #   PYTHONHOME, and LD_LIBRARY_PATH leak into the container, allowing the host
+        #   libpython to be loaded alongside the container's libpython and triggering
+        #   `Fatal Python error: _PyImport_Init: global import state already initialized`.
+        # --home /tmp: set the container's HOME to /tmp (writable, auto-mounted) and
+        #   suppress the auto-mount of the host $HOME. `HOME` cannot be set via --env
+        #   (apptainer ignores APPTAINERENV_HOME and warns); --home is the supported way.
+        #   xet writes its logs/chunks under $HOME/.cache/huggingface, so HOME must
+        #   resolve to a writable path inside the container.
+        cmd = ["apptainer", "exec", "--cleanenv", "--home", "/tmp"]
 
         # Enable NVIDIA GPU support if device is CUDA
         device_number = _extract_device_number(self._device)
         if self._device.startswith("cuda"):
             cmd.append("--nv")
 
-        # Bind mount boileroom source code (read-only)
-        cmd.extend(["-B", f"{container_boileroom}:{container_boileroom}:ro"])
+        # Bind mount only the boileroom package directory, read-only.
+        # Binding the full project root would expose the host .venv/ inside the
+        # container; the resulting host-built C extensions on the import path can
+        # load a second libpython and crash interpreter startup.
+        host_pkg_dir = project_root / "boileroom"
+        cmd.extend(["-B", f"{host_pkg_dir}:{host_pkg_dir}:ro"])
 
         # Bind mount MODEL_DIR if present
         if model_dir:
@@ -469,13 +482,18 @@ class ApptainerBackend(Backend):
             cmd.extend(["-B", f"{model_dir_path}:{container_model_dir}"])
             logger.info(f"Bind mounting MODEL_DIR: {model_dir_path} -> {container_model_dir}")
 
-        # Set environment variables
+        # Set environment variables. With --cleanenv, these are the *only* vars
+        # the container sees, so we must set everything the server needs (PATH,
+        # HOME, locale) ourselves rather than relying on inheritance.
         env_vars = {
             "MODEL_CLASS": self._core_class_path,
             "MODEL_CONFIG": json.dumps(self._config),
             "DEVICE": self._device,
             TRANSPORT_HMAC_KEY_ENV: self._transport_secret,
             "PYTHONPATH": container_boileroom,
+            "PATH": "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "LANG": "C.UTF-8",
+            "LC_ALL": "C.UTF-8",
             # Override temp directory variables to use container's /tmp
             # This prevents issues when host TMPDIR points to a path that doesn't exist in container
             "TMPDIR": "/tmp",
@@ -507,11 +525,13 @@ class ApptainerBackend(Backend):
         for key, value in env_vars.items():
             cmd.extend(["--env", f"{key}={value}"])
 
-        # Add image and command
+        # Add image and command. Use the absolute path to the container's
+        # python so PATH-based resolution can never reach a host binary that
+        # leaked through the bind mounts.
         cmd.append(str(self._sif_path))
         cmd.extend(
             [
-                "python",
+                "/usr/local/bin/python3.12",
                 container_server_path,
                 "--host",
                 "0.0.0.0",

--- a/boileroom/base.py
+++ b/boileroom/base.py
@@ -12,7 +12,7 @@ from typing import Any, ClassVar, Literal, Protocol, cast
 import numpy as np
 import torch
 
-from .images.metadata import format_image_reference, get_default_image_tag
+from .images.metadata import format_image_reference, get_image_tag
 from .models.registry import ModelSpec, resolve_object
 from .utils import validate_sequence
 
@@ -450,8 +450,9 @@ class ModelWrapper:
             A tuple of ``(backend_type, backend_tag)`` where ``backend_type`` is
             the base backend identifier (for example ``\"modal\"`` or
             ``\"apptainer\"``) and ``backend_tag`` is either the tag string for
-            ``\"apptainer\"`` backends (defaulting to the installed package version
-            when no tag is provided) or ``None`` for all other backends.
+            ``\"apptainer\"`` backends (the explicit suffix wins, otherwise it
+            falls back to ``BOILEROOM_IMAGE_TAG`` env var, otherwise the
+            installed package version) or ``None`` for all other backends.
         """
         if ":" in backend:
             backend_type, backend_tag = backend.split(":", 1)
@@ -460,7 +461,8 @@ class ModelWrapper:
 
         backend_type = backend_type.strip()
         if backend_type == "apptainer":
-            backend_tag = (backend_tag or get_default_image_tag()).strip() or get_default_image_tag()
+            explicit = (backend_tag or "").strip()
+            backend_tag = explicit if explicit else get_image_tag()
             return backend_type, backend_tag
 
         return backend_type, None

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -15,7 +15,7 @@ DEFAULT_DOCKER_REPOSITORY: Final = "docker.io/jakublala"
 PACKAGE_NAME: Final = "boileroom"
 DEFAULT_CUDA_VERSION: Final = "12.6"
 DOCKER_REPOSITORY_ENV: Final = "BOILEROOM_DOCKER_REPOSITORY"
-MODAL_IMAGE_TAG_ENV: Final = "BOILEROOM_MODAL_IMAGE_TAG"
+IMAGE_TAG_ENV: Final = "BOILEROOM_IMAGE_TAG"
 
 SUPPORTED_CUDA_VERSIONS: Final[tuple[str, ...]] = ("11.8", "12.6")
 
@@ -101,7 +101,7 @@ def get_default_image_tag() -> str:
     except importlib.metadata.PackageNotFoundError:
         raise RuntimeError(
             "Unable to determine the default boileroom image tag. "
-            f"Install {PACKAGE_NAME} or set {MODAL_IMAGE_TAG_ENV} explicitly."
+            f"Install {PACKAGE_NAME} or set {IMAGE_TAG_ENV} explicitly."
         ) from None
 
 
@@ -217,14 +217,18 @@ def published_image_references(
     return tuple(f"{repository}/{image_name}:{published_tag}" for published_tag in published_tags(cuda_version, tag))
 
 
-def get_modal_image_tag() -> str:
-    """Return the tag Modal should pull from the registry."""
-    return resolve_registry_tag(os.environ.get(MODAL_IMAGE_TAG_ENV))
+def get_image_tag() -> str:
+    """Return the runtime image tag for both Modal and Apptainer backends.
+
+    Reads the ``BOILEROOM_IMAGE_TAG`` env var if set; otherwise falls back to
+    the package-default tag derived from ``pyproject.toml``.
+    """
+    return resolve_registry_tag(os.environ.get(IMAGE_TAG_ENV))
 
 
 def get_modal_base_image_reference() -> str:
     """Return the base image Modal should use for the shared runtime layer."""
-    return format_image_reference(BASE_IMAGE_SPEC.image_name, get_modal_image_tag())
+    return format_image_reference(BASE_IMAGE_SPEC.image_name, get_image_tag())
 
 
 def get_model_image_spec(identifier: str) -> RuntimeImageSpec:
@@ -267,7 +271,7 @@ def render_modal_runtime_env(spec: RuntimeImageSpec, model_dir: str) -> dict[str
     env = {
         "MODEL_DIR": model_dir,
         DOCKER_REPOSITORY_ENV: get_docker_repository(),
-        MODAL_IMAGE_TAG_ENV: get_modal_image_tag(),
+        IMAGE_TAG_ENV: get_image_tag(),
     }
     for key, value in spec.modal_runtime_env:
         env[key] = value.replace("{MODEL_DIR}", model_dir)

--- a/boileroom/images/modal.py
+++ b/boileroom/images/modal.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from modal import Image
 
 from ..utils import MODAL_MODEL_DIR
-from .metadata import format_image_reference, get_modal_image_tag, get_model_image_spec, render_modal_runtime_env
+from .metadata import format_image_reference, get_image_tag, get_model_image_spec, render_modal_runtime_env
 
 
 def get_modal_image(identifier: str) -> Image:
     """Return a Modal image sourced from the published Docker image for a model."""
     spec = get_model_image_spec(identifier)
-    image = Image.from_registry(format_image_reference(spec.image_name, get_modal_image_tag()))
+    image = Image.from_registry(format_image_reference(spec.image_name, get_image_tag()))
     return image.env(render_modal_runtime_env(spec, MODAL_MODEL_DIR))

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -36,26 +36,27 @@ uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=0.3
 
 The image build, smoke check, and promotion helpers all accept the same `--docker-user` flag.
 
-Modal pytest uses `docker.io/jakublala` plus the current package version by default. To run against manually published images, pass the same user and tag:
+Pytest uses `docker.io/jakublala` plus the current package version by default. To run against manually published images, set `BOILEROOM_IMAGE_TAG` and pass `--docker-user`:
 
 ```bash
-uv run pytest --backend=modal --docker-user=my-dockerhub-user --image-tag=0.3.0
+BOILEROOM_IMAGE_TAG=0.3.0 uv run pytest --backend=modal --docker-user=my-dockerhub-user
 ```
 
 For the Modal integration suite, use grouped xdist scheduling so each model family runs in its own worker and Modal app:
 
 ```bash
-uv run pytest -v -n 4 --dist loadgroup -m integration \
+BOILEROOM_IMAGE_TAG=0.3.0 uv run pytest -v -n 4 --dist loadgroup -m integration \
   --docker-user=my-dockerhub-user \
-  --image-tag=0.3.0 \
   --gpu=A10
 ```
 
 For serial integration execution against the same image, omit xdist:
 
 ```bash
-uv run pytest -v -m integration --docker-user=my-dockerhub-user --image-tag=0.3.0 --gpu=A10
+BOILEROOM_IMAGE_TAG=0.3.0 uv run pytest -v -m integration --docker-user=my-dockerhub-user --gpu=A10
 ```
+
+`BOILEROOM_IMAGE_TAG` is honored by both the Modal and Apptainer backends. The Apptainer backend additionally accepts an inline tag via `--backend apptainer:<tag>`, which wins over the env var.
 
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
 Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.

--- a/tests/boltz/test_boltz2.py
+++ b/tests/boltz/test_boltz2.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 from biotite.structure import AtomArray, rmsd, superimpose
 from biotite.structure.io.pdbx import CIFFile, get_structure
-from modal import enable_output
 
 from boileroom import Boltz2
 from boileroom.constants import restype_3to1
@@ -20,23 +19,32 @@ nipah_virus_sequence = "ICLQKTSNQILKPKLISYTLGQSGTCITDPLLAMDEGYFAYSHLERIGSCSRGVSK
 
 
 @pytest.fixture(scope="module")
-def boltz2_model(config: dict | None = None, gpu_device: str | None = None) -> Generator[Boltz2, None, None]:
-    """Provide a Boltz2 model instance configured for the Modal backend.
+def boltz2_model(
+    backend_option: str,
+    device_option: str | None,
+    output_ctx,
+    config: dict | None = None,
+) -> Generator[Boltz2, None, None]:
+    """Provide a Boltz2 model instance configured for the selected backend.
 
     Parameters
     ----------
+    backend_option : str
+        Backend selector ("modal" or "apptainer[:<tag>]").
+    device_option : Optional[str]
+        Backend-resolved device string.
+    output_ctx : Callable
+        Factory yielding a backend-appropriate context manager.
     config : Optional[dict]
         Optional model configuration overrides to apply when constructing the Boltz2 instance.
-    gpu_device : Optional[str]
-        Optional device identifier to run the model on (for example, "cuda:0" or similar).
 
     Yields
     ------
     Boltz2
-        A Boltz2 instance configured with backend="modal", the specified device, and the provided configuration.
+        A Boltz2 instance configured for the chosen backend.
     """
     model_config = dict(config) if config is not None else {}
-    with enable_output(), Boltz2(backend="modal", device=gpu_device, config=model_config) as model:
+    with output_ctx(), Boltz2(backend=backend_option, device=device_option, config=model_config) as model:
         yield model
 
 

--- a/tests/chai/test_chai1.py
+++ b/tests/chai/test_chai1.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 from biotite.structure import AtomArray, rmsd, superimpose
 from biotite.structure.io.pdbx import CIFFile, get_structure
-from modal import enable_output
 
 from boileroom import Chai1
 from boileroom.models.chai.types import Chai1Output
@@ -53,17 +52,26 @@ def _quick_options(include_fields: list[str] | None = None) -> dict[str, object]
     return options
 
 
-# Module scope keeps a single Modal app lifecycle for the Chai integration shard.
+# Module scope keeps a single backend lifecycle for the Chai integration shard.
 @pytest.fixture(scope="module")
-def chai1_model(config: dict | None = None, gpu_device: str | None = None) -> Generator[Chai1, None, None]:
-    """Provide a Chai1 model instance configured to run with the Modal backend.
+def chai1_model(
+    backend_option: str,
+    device_option: str | None,
+    output_ctx,
+    config: dict | None = None,
+) -> Generator[Chai1, None, None]:
+    """Provide a Chai1 model instance configured to run with the selected backend.
 
     Parameters
     ----------
+    backend_option : str
+        Backend selector ("modal" or "apptainer[:<tag>]").
+    device_option : Optional[str]
+        Backend-resolved device string.
+    output_ctx : Callable
+        Factory yielding a backend-appropriate context manager.
     config : Optional[dict]
         Optional model configuration mapping used when creating the model.
-    gpu_device : Optional[str]
-        Optional device identifier passed to the model (e.g., "cpu" or a CUDA device string).
 
     Yields
     ------
@@ -71,7 +79,7 @@ def chai1_model(config: dict | None = None, gpu_device: str | None = None) -> Ge
         A Chai1 model instance yielded by the generator for use in tests.
     """
     model_config = dict(config) if config is not None else {}
-    with enable_output(), Chai1(backend="modal", device=gpu_device, config=model_config) as model:
+    with output_ctx(), Chai1(backend=backend_option, device=device_option, config=model_config) as model:
         yield model
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,9 +100,7 @@ def pytest_configure(config: pytest.Config) -> None:
     if family not in ("modal", "apptainer"):
         raise pytest.UsageError(f"--backend must be 'modal' or 'apptainer[:<tag>]'; got {backend!r}")
     if family == "modal" and ":" in backend:
-        raise pytest.UsageError(
-            "--backend 'modal' does not accept a ':<tag>' suffix; set BOILEROOM_IMAGE_TAG instead."
-        )
+        raise pytest.UsageError("--backend 'modal' does not accept a ':<tag>' suffix; set BOILEROOM_IMAGE_TAG instead.")
 
     gpu = config.getoption("--gpu")
     device = config.getoption("--device")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import re
 
 import pytest
 
-from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, MODAL_IMAGE_TAG_ENV, normalize_docker_repository
+from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, IMAGE_TAG_ENV, normalize_docker_repository
 from boileroom.utils import GPUS_AVAIL_ON_MODAL
 
 _APPTAINER_DEVICE_RE = re.compile(r"^(cpu|cuda(:\d+)?)$")
@@ -16,10 +16,11 @@ _APPTAINER_DEVICE_RE = re.compile(r"^(cpu|cuda(:\d+)?)$")
 def pytest_report_header(config: pytest.Config) -> list[str]:
     """Report the runtime image tag and Docker repository at the top of every pytest run.
 
-    The Modal backend pulls the boileroom package from a prebuilt Docker image whose
-    tag is resolved by ``boileroom.images.metadata.get_modal_image_tag``. Surfacing
-    that tag in the pytest header avoids ambiguity about which image the integration
-    tests are actually exercising.
+    Both Modal and Apptainer backends pull the boileroom package from a prebuilt
+    Docker image whose tag is resolved by
+    ``boileroom.images.metadata.get_image_tag``. Surfacing that tag in the pytest
+    header avoids ambiguity about which image the integration tests are actually
+    exercising.
 
     Parameters
     ----------
@@ -32,14 +33,14 @@ def pytest_report_header(config: pytest.Config) -> list[str]:
         One-line-per-entry header additions.
     """
     try:
-        from boileroom.images.metadata import MODAL_IMAGE_TAG_ENV, get_docker_repository, get_modal_image_tag
+        from boileroom.images.metadata import IMAGE_TAG_ENV, get_docker_repository, get_image_tag
     except ImportError as exc:  # pragma: no cover - defensive; keep pytest running if the module is missing
         return [f"boileroom image: <unresolved: {exc!s}>"]
 
-    tag = get_modal_image_tag()
+    tag = get_image_tag()
     repository = get_docker_repository()
-    override = os.environ.get(MODAL_IMAGE_TAG_ENV)
-    source = f"override via {MODAL_IMAGE_TAG_ENV}" if override else "from pyproject.toml"
+    override = os.environ.get(IMAGE_TAG_ENV)
+    source = f"override via {IMAGE_TAG_ENV}" if override else "from pyproject.toml"
     return [f"boileroom image: {repository}/boileroom-<family>:{tag} ({source})"]
 
 
@@ -126,7 +127,7 @@ def pytest_configure(config: pytest.Config) -> None:
     if docker_user := config.getoption("--docker-user"):
         os.environ[DOCKER_REPOSITORY_ENV] = normalize_docker_repository(docker_user)
     if image_tag:
-        os.environ[MODAL_IMAGE_TAG_ENV] = image_tag
+        os.environ[IMAGE_TAG_ENV] = image_tag
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,16 @@
 """Pytest configuration for the boileroom package."""
 
+import contextlib
 import os
 import pathlib
+import re
 
 import pytest
 
 from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, MODAL_IMAGE_TAG_ENV, normalize_docker_repository
+from boileroom.utils import GPUS_AVAIL_ON_MODAL
+
+_APPTAINER_DEVICE_RE = re.compile(r"^(cpu|cuda(:\d+)?)$")
 
 
 def pytest_report_header(config: pytest.Config) -> list[str]:
@@ -56,14 +61,23 @@ def pytest_addoption(parser):
         "--backend",
         action="store",
         default="modal",
-        choices=("modal", "apptainer"),
-        help="Execution backend for models in tests: modal (default) or apptainer (runs locally in containers)",
+        help=(
+            "Execution backend for models in tests: 'modal' (default) or "
+            "'apptainer' (runs locally in containers). Apptainer accepts an "
+            "optional image tag via 'apptainer:<tag>' (e.g. 'apptainer:sha-abc1234')."
+        ),
     )
     parser.addoption(
         "--gpu",
         action="store",
         default=None,
-        help="GPU type for Modal backend tests (e.g., A100-40GB, A100-80GB, T4). Defaults to None (uses default T4).",
+        help="Modal-only: GPU class to reserve (e.g. T4, A100-40GB, A100-80GB). Ignored for apptainer.",
+    )
+    parser.addoption(
+        "--device",
+        action="store",
+        default=None,
+        help="Apptainer-only: CUDA device string (e.g. cuda:0, cuda:1, cpu). Ignored for modal. Defaults to cuda:0.",
     )
     parser.addoption(
         "--docker-user",
@@ -80,10 +94,38 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Apply image lookup options before test modules import Modal wrappers."""
+    """Validate CLI options and apply image lookup overrides before test modules import wrappers."""
+    backend = config.getoption("--backend")
+    family, _, backend_tag = backend.partition(":")
+    family = family.strip()
+    if family not in ("modal", "apptainer"):
+        raise pytest.UsageError(f"--backend must be 'modal' or 'apptainer[:<tag>]'; got {backend!r}")
+    if family == "modal" and ":" in backend:
+        raise pytest.UsageError("--backend 'modal' does not accept a ':<tag>' suffix; use --image-tag instead.")
+    image_tag = config.getoption("--image-tag")
+    if family == "apptainer" and backend_tag.strip() and image_tag:
+        raise pytest.UsageError("Pass the apptainer image tag via --backend apptainer:<tag> OR --image-tag, not both.")
+
+    gpu = config.getoption("--gpu")
+    device = config.getoption("--device")
+    if family == "modal":
+        if device is not None:
+            raise pytest.UsageError("--device is apptainer-only; for the modal backend pick a GPU class with --gpu.")
+        if gpu is not None and gpu not in GPUS_AVAIL_ON_MODAL:
+            raise pytest.UsageError(f"--gpu={gpu!r} is not a Modal GPU class; expected one of {GPUS_AVAIL_ON_MODAL}.")
+    else:  # apptainer
+        if gpu is not None:
+            raise pytest.UsageError(
+                "--gpu is modal-only; for the apptainer backend pick a CUDA device with --device (e.g. cuda:0)."
+            )
+        if device is not None and not _APPTAINER_DEVICE_RE.match(device):
+            raise pytest.UsageError(
+                f"--device={device!r} is not a valid Apptainer device; expected 'cpu' or 'cuda[:<N>]'."
+            )
+
     if docker_user := config.getoption("--docker-user"):
         os.environ[DOCKER_REPOSITORY_ENV] = normalize_docker_repository(docker_user)
-    if image_tag := config.getoption("--image-tag"):
+    if image_tag:
         os.environ[MODAL_IMAGE_TAG_ENV] = image_tag
 
 
@@ -116,19 +158,64 @@ def backend_option(request):
 
 @pytest.fixture(scope="session")
 def gpu_device(request):
-    """Provide the selected GPU device type from the `--gpu` command-line option.
+    """Modal GPU class from ``--gpu`` (e.g. ``T4``, ``A100-80GB``).
 
-    Parameters
-    ----------
-    request : Any
-        Pytest request object.
+    Modal-only. For the apptainer backend, prefer ``device_option`` instead.
 
     Returns
     -------
     Optional[str]
-        The GPU device string as provided via `--gpu`, or `None` if the option was not set.
+        ``--gpu`` value, or ``None`` if not set.
     """
     return request.config.getoption("--gpu")
+
+
+def _backend_family(backend: str) -> str:
+    """Return the backend family ("modal" or "apptainer") from a backend string."""
+    return backend.split(":", 1)[0].strip()
+
+
+@pytest.fixture(scope="session")
+def device_option(backend_option: str, request) -> str | None:
+    """Resolve the device kwarg for model wrappers based on the active backend.
+
+    For the modal backend this returns ``--gpu`` (a Modal GPU class such as
+    ``T4`` or ``A100-80GB``, or ``None`` to let the wrapper apply its per-class
+    default). For the apptainer backend this returns ``--device`` (a CUDA
+    device string such as ``cuda:0`` or ``cpu``), defaulting to ``cuda:0``.
+
+    Validity of each flag against the active backend is enforced by
+    ``pytest_configure``.
+    """
+    if _backend_family(backend_option) == "apptainer":
+        return request.config.getoption("--device") or "cuda:0"
+    return request.config.getoption("--gpu")
+
+
+@pytest.fixture(scope="session")
+def output_ctx(backend_option: str):
+    """Provide a factory that builds a fresh per-call context manager for the active backend.
+
+    Usage::
+
+        with output_ctx(), Model(backend=backend_option) as model:
+            ...
+
+    For the Modal backend, each call returns ``modal.enable_output()``. For Apptainer
+    each call returns ``contextlib.nullcontext()``. This preserves the original
+    "fresh context per use" semantics of pre-refactor tests while keeping the
+    Modal import gated behind backend selection.
+    """
+    is_modal = _backend_family(backend_option) == "modal"
+
+    def _make():
+        if is_modal:
+            from modal import enable_output
+
+            return enable_output()
+        return contextlib.nullcontext()
+
+    return _make
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import re
 
 import pytest
 
-from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, IMAGE_TAG_ENV, normalize_docker_repository
+from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, normalize_docker_repository
 from boileroom.utils import GPUS_AVAIL_ON_MODAL
 
 _APPTAINER_DEVICE_RE = re.compile(r"^(cpu|cuda(:\d+)?)$")
@@ -47,11 +47,15 @@ def pytest_report_header(config: pytest.Config) -> list[str]:
 def pytest_addoption(parser):
     """Register pytest CLI options used by the test suite.
 
-    Adds two command-line options:
-    - --backend: selects the execution backend for tests; allowed values are "modal" and "apptainer", defaults to "modal".
-    - --gpu: specifies the GPU type for Modal backend tests (examples: "A100-40GB", "A100-80GB", "T4"); defaults to None which uses the test-suite default.
-    - --docker-user: overrides the default Docker Hub user or namespace for Modal image lookup; defaults to None, which uses the package default.
-    - --image-tag: selects the runtime image tag for Modal image lookup; defaults to None, which uses the current package version.
+    Adds the following command-line options:
+    - --backend: selects the execution backend ("modal" or "apptainer[:<tag>]"); defaults to "modal".
+    - --gpu: Modal-only GPU class (e.g. "T4", "A100-80GB").
+    - --device: Apptainer-only CUDA device (e.g. "cuda:0", "cpu"). Defaults to cuda:0.
+    - --docker-user: overrides the Docker Hub user or namespace for image lookup.
+
+    Set the runtime image tag via the ``BOILEROOM_IMAGE_TAG`` environment variable
+    (e.g. ``BOILEROOM_IMAGE_TAG=sha-abc1234 uv run pytest``). Both Modal and
+    Apptainer backends honor it.
 
     Parameters
     ----------
@@ -84,28 +88,21 @@ def pytest_addoption(parser):
         "--docker-user",
         action="store",
         default=None,
-        help="Docker Hub user or namespace for Modal image lookup.",
-    )
-    parser.addoption(
-        "--image-tag",
-        action="store",
-        default=None,
-        help="Runtime image tag for Modal image lookup.",
+        help="Docker Hub user or namespace for image lookup (sets BOILEROOM_DOCKER_REPOSITORY).",
     )
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Validate CLI options and apply image lookup overrides before test modules import wrappers."""
+    """Validate CLI options and apply Docker repository overrides before test modules import wrappers."""
     backend = config.getoption("--backend")
-    family, _, backend_tag = backend.partition(":")
+    family, _, _ = backend.partition(":")
     family = family.strip()
     if family not in ("modal", "apptainer"):
         raise pytest.UsageError(f"--backend must be 'modal' or 'apptainer[:<tag>]'; got {backend!r}")
     if family == "modal" and ":" in backend:
-        raise pytest.UsageError("--backend 'modal' does not accept a ':<tag>' suffix; use --image-tag instead.")
-    image_tag = config.getoption("--image-tag")
-    if family == "apptainer" and backend_tag.strip() and image_tag:
-        raise pytest.UsageError("Pass the apptainer image tag via --backend apptainer:<tag> OR --image-tag, not both.")
+        raise pytest.UsageError(
+            "--backend 'modal' does not accept a ':<tag>' suffix; set BOILEROOM_IMAGE_TAG instead."
+        )
 
     gpu = config.getoption("--gpu")
     device = config.getoption("--device")
@@ -126,8 +123,6 @@ def pytest_configure(config: pytest.Config) -> None:
 
     if docker_user := config.getoption("--docker-user"):
         os.environ[DOCKER_REPOSITORY_ENV] = normalize_docker_repository(docker_user)
-    if image_tag:
-        os.environ[IMAGE_TAG_ENV] = image_tag
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -9,8 +9,8 @@ from boileroom.images.metadata import (
     format_image_reference,
     get_default_image_tag,
     get_docker_repository,
+    get_image_tag,
     get_modal_base_image_reference,
-    get_modal_image_tag,
     get_model_image_spec,
     get_supported_cuda,
     normalize_docker_repository,
@@ -49,22 +49,22 @@ def test_model_specs_report_supported_cuda_from_config() -> None:
     assert get_supported_cuda(get_model_image_spec("esm")) == ("11.8", "12.6")
 
 
-def test_modal_tag_uses_env_override(monkeypatch) -> None:
-    """Modal image lookups should respect an optional tag override."""
-    monkeypatch.delenv("BOILEROOM_MODAL_IMAGE_TAG", raising=False)
-    assert get_modal_image_tag() == get_default_image_tag()
+def test_image_tag_uses_env_override(monkeypatch) -> None:
+    """Image lookups should respect an optional tag override via BOILEROOM_IMAGE_TAG."""
+    monkeypatch.delenv("BOILEROOM_IMAGE_TAG", raising=False)
+    assert get_image_tag() == get_default_image_tag()
 
-    monkeypatch.setenv("BOILEROOM_MODAL_IMAGE_TAG", "0.3.0")
-    assert get_modal_image_tag() == "0.3.0"
+    monkeypatch.setenv("BOILEROOM_IMAGE_TAG", "0.3.0")
+    assert get_image_tag() == "0.3.0"
 
-    monkeypatch.setenv("BOILEROOM_MODAL_IMAGE_TAG", "cuda12.6")
-    assert get_modal_image_tag() == f"cuda12.6-{get_default_image_tag()}"
+    monkeypatch.setenv("BOILEROOM_IMAGE_TAG", "cuda12.6")
+    assert get_image_tag() == f"cuda12.6-{get_default_image_tag()}"
 
 
 def test_modal_base_image_reference_uses_repository_and_tag(monkeypatch) -> None:
     """Modal base image lookups should use the same repository and tag as model images."""
     monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
-    monkeypatch.setenv("BOILEROOM_MODAL_IMAGE_TAG", "0.3.0.1")
+    monkeypatch.setenv("BOILEROOM_IMAGE_TAG", "0.3.0.1")
 
     assert get_modal_base_image_reference() == "docker.io/example/boileroom-base:0.3.0.1"
 
@@ -72,13 +72,13 @@ def test_modal_base_image_reference_uses_repository_and_tag(monkeypatch) -> None
 def test_modal_runtime_env_carries_image_lookup_overrides(monkeypatch) -> None:
     """Modal containers should re-import wrappers with the same resolved image lookup settings."""
     monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
-    monkeypatch.setenv("BOILEROOM_MODAL_IMAGE_TAG", "0.3.0.1")
+    monkeypatch.setenv("BOILEROOM_IMAGE_TAG", "0.3.0.1")
 
     env = render_modal_runtime_env(get_model_image_spec("boltz"), "/mnt/models")
 
     assert env["BOILEROOM_DOCKER_REPOSITORY"] == "docker.io/example"
-    assert env["BOILEROOM_MODAL_IMAGE_TAG"] == "0.3.0.1"
-    assert set(env) == {"MODEL_DIR", "BOILEROOM_DOCKER_REPOSITORY", "BOILEROOM_MODAL_IMAGE_TAG"}
+    assert env["BOILEROOM_IMAGE_TAG"] == "0.3.0.1"
+    assert set(env) == {"MODEL_DIR", "BOILEROOM_DOCKER_REPOSITORY", "BOILEROOM_IMAGE_TAG"}
 
 
 def test_docker_repository_uses_env_override(monkeypatch) -> None:

--- a/tests/contracts/test_model_wrappers.py
+++ b/tests/contracts/test_model_wrappers.py
@@ -204,11 +204,19 @@ def test_public_wrapper_dispatch_uses_shared_initializer(monkeypatch: pytest.Mon
     assert records["call_kwargs"] == {"options": None}
 
 
-def test_parse_backend_apptainer_tag_handling() -> None:
-    """Apptainer backend tags should keep the explicit tag or default to the package version."""
+def test_parse_backend_apptainer_tag_handling(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Apptainer tag resolution: explicit suffix > BOILEROOM_IMAGE_TAG env var > package default."""
+    monkeypatch.delenv("BOILEROOM_IMAGE_TAG", raising=False)
     assert ModelWrapper.parse_backend("modal") == ("modal", None)
     assert ModelWrapper.parse_backend("modal:dev") == ("modal", None)
+    # Without an env var or explicit suffix, fall back to package default.
     assert ModelWrapper.parse_backend("apptainer") == ("apptainer", get_default_image_tag())
+    # Explicit suffix wins.
+    assert ModelWrapper.parse_backend("apptainer:dev") == ("apptainer", "dev")
+    # Env var is honored when no explicit suffix is given.
+    monkeypatch.setenv("BOILEROOM_IMAGE_TAG", "sha-test")
+    assert ModelWrapper.parse_backend("apptainer") == ("apptainer", "sha-test")
+    # Explicit suffix still wins over env var.
     assert ModelWrapper.parse_backend("apptainer:dev") == ("apptainer", "dev")
 
 

--- a/tests/contracts/test_pytest_image_options.py
+++ b/tests/contracts/test_pytest_image_options.py
@@ -1,4 +1,4 @@
-"""Contract tests for pytest image lookup options."""
+"""Contract tests for the ``--docker-user`` pytest option."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, IMAGE_TAG_ENV
+from boileroom.images.metadata import DOCKER_REPOSITORY_ENV
 
 
 def _load_test_conftest() -> Any:
@@ -31,46 +31,23 @@ class FakeConfig:
         return self.options.get(name)
 
 
-def test_pytest_image_options_set_modal_lookup_env(monkeypatch) -> None:
+def test_docker_user_sets_repository_env(monkeypatch) -> None:
+    """``--docker-user`` should write the normalized repository to the env var."""
     monkeypatch.delenv(DOCKER_REPOSITORY_ENV, raising=False)
-    monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
     conftest = _load_test_conftest()
 
     try:
-        conftest.pytest_configure(FakeConfig({"--docker-user": "phauglin", "--image-tag": "sha-test"}))
-
+        conftest.pytest_configure(FakeConfig({"--docker-user": "phauglin"}))
         assert os.environ[DOCKER_REPOSITORY_ENV] == "docker.io/phauglin"
-        assert os.environ[IMAGE_TAG_ENV] == "sha-test"
     finally:
         os.environ.pop(DOCKER_REPOSITORY_ENV, None)
-        os.environ.pop(IMAGE_TAG_ENV, None)
 
 
-def test_pytest_image_options_leave_env_unset_when_absent(monkeypatch) -> None:
+def test_docker_user_absent_leaves_repository_env_unset(monkeypatch) -> None:
+    """Without ``--docker-user``, the repository env var should not be touched."""
     monkeypatch.delenv(DOCKER_REPOSITORY_ENV, raising=False)
-    monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
     conftest = _load_test_conftest()
 
-    conftest.pytest_configure(FakeConfig({"--docker-user": None, "--image-tag": None}))
+    conftest.pytest_configure(FakeConfig({"--docker-user": None}))
 
     assert DOCKER_REPOSITORY_ENV not in os.environ
-    assert IMAGE_TAG_ENV not in os.environ
-
-
-def test_pytest_image_options_can_set_only_one_env(monkeypatch) -> None:
-    monkeypatch.delenv(DOCKER_REPOSITORY_ENV, raising=False)
-    monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
-    conftest = _load_test_conftest()
-
-    try:
-        conftest.pytest_configure(FakeConfig({"--docker-user": "phauglin", "--image-tag": None}))
-        assert os.environ[DOCKER_REPOSITORY_ENV] == "docker.io/phauglin"
-        assert IMAGE_TAG_ENV not in os.environ
-
-        os.environ.pop(DOCKER_REPOSITORY_ENV, None)
-        conftest.pytest_configure(FakeConfig({"--docker-user": None, "--image-tag": "sha-test"}))
-        assert DOCKER_REPOSITORY_ENV not in os.environ
-        assert os.environ[IMAGE_TAG_ENV] == "sha-test"
-    finally:
-        os.environ.pop(DOCKER_REPOSITORY_ENV, None)
-        os.environ.pop(IMAGE_TAG_ENV, None)

--- a/tests/contracts/test_pytest_image_options.py
+++ b/tests/contracts/test_pytest_image_options.py
@@ -20,9 +20,12 @@ def _load_test_conftest() -> Any:
     return module
 
 
+_BACKEND_DEFAULTS: dict[str, str | None] = {"--backend": "modal", "--gpu": None, "--device": None}
+
+
 class FakeConfig:
     def __init__(self, options: dict[str, str | None]) -> None:
-        self.options = options
+        self.options = {**_BACKEND_DEFAULTS, **options}
 
     def getoption(self, name: str) -> str | None:
         return self.options.get(name)

--- a/tests/contracts/test_pytest_image_options.py
+++ b/tests/contracts/test_pytest_image_options.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, MODAL_IMAGE_TAG_ENV
+from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, IMAGE_TAG_ENV
 
 
 def _load_test_conftest() -> Any:
@@ -33,44 +33,44 @@ class FakeConfig:
 
 def test_pytest_image_options_set_modal_lookup_env(monkeypatch) -> None:
     monkeypatch.delenv(DOCKER_REPOSITORY_ENV, raising=False)
-    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
+    monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
     conftest = _load_test_conftest()
 
     try:
         conftest.pytest_configure(FakeConfig({"--docker-user": "phauglin", "--image-tag": "sha-test"}))
 
         assert os.environ[DOCKER_REPOSITORY_ENV] == "docker.io/phauglin"
-        assert os.environ[MODAL_IMAGE_TAG_ENV] == "sha-test"
+        assert os.environ[IMAGE_TAG_ENV] == "sha-test"
     finally:
         os.environ.pop(DOCKER_REPOSITORY_ENV, None)
-        os.environ.pop(MODAL_IMAGE_TAG_ENV, None)
+        os.environ.pop(IMAGE_TAG_ENV, None)
 
 
 def test_pytest_image_options_leave_env_unset_when_absent(monkeypatch) -> None:
     monkeypatch.delenv(DOCKER_REPOSITORY_ENV, raising=False)
-    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
+    monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
     conftest = _load_test_conftest()
 
     conftest.pytest_configure(FakeConfig({"--docker-user": None, "--image-tag": None}))
 
     assert DOCKER_REPOSITORY_ENV not in os.environ
-    assert MODAL_IMAGE_TAG_ENV not in os.environ
+    assert IMAGE_TAG_ENV not in os.environ
 
 
 def test_pytest_image_options_can_set_only_one_env(monkeypatch) -> None:
     monkeypatch.delenv(DOCKER_REPOSITORY_ENV, raising=False)
-    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
+    monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
     conftest = _load_test_conftest()
 
     try:
         conftest.pytest_configure(FakeConfig({"--docker-user": "phauglin", "--image-tag": None}))
         assert os.environ[DOCKER_REPOSITORY_ENV] == "docker.io/phauglin"
-        assert MODAL_IMAGE_TAG_ENV not in os.environ
+        assert IMAGE_TAG_ENV not in os.environ
 
         os.environ.pop(DOCKER_REPOSITORY_ENV, None)
         conftest.pytest_configure(FakeConfig({"--docker-user": None, "--image-tag": "sha-test"}))
         assert DOCKER_REPOSITORY_ENV not in os.environ
-        assert os.environ[MODAL_IMAGE_TAG_ENV] == "sha-test"
+        assert os.environ[IMAGE_TAG_ENV] == "sha-test"
     finally:
         os.environ.pop(DOCKER_REPOSITORY_ENV, None)
-        os.environ.pop(MODAL_IMAGE_TAG_ENV, None)
+        os.environ.pop(IMAGE_TAG_ENV, None)

--- a/tests/esm/test_esm2.py
+++ b/tests/esm/test_esm2.py
@@ -6,43 +6,55 @@ from boileroom import ESM2
 pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.gpu, pytest.mark.xdist_group("esm2")]
 
 
-# Each test instantiates its own model; keeping function scope avoids long-lived Modal handles.
+# Each test instantiates its own model; keeping function scope avoids long-lived backend handles.
 @pytest.fixture
-def esm2_model_factory(gpu_device: str | None):
+def esm2_model_factory(backend_option: str, gpu_device: str | None, device_option: str | None):
     """Create a factory that builds configured ESM2 model instances.
 
     Parameters
     ----------
+    backend_option : str
+        Backend selector as provided via ``--backend`` ("modal" or "apptainer[:<tag>]").
     gpu_device : Optional[str]
-        If provided, forces the model device to this value; otherwise the device is inferred from the provided model_name in the factory call:
+        Modal GPU class from ``--gpu`` (e.g. ``T4``, ``A100-80GB``). When not
+        provided, the Modal device is inferred from model_name:
         - model_name containing "15B" → "A100-80GB"
         - model_name containing "3B" → "A100-40GB"
         - otherwise → "T4"
+    device_option : Optional[str]
+        Backend-resolved device string. For apptainer this is ``--device``
+        (defaulting to ``cuda:0``).
 
     Returns
     -------
     Callable[..., ESM2]
-        A function that accepts model configuration kwargs (must include `model_name`) and returns an ESM2 instance with backend "modal" and device chosen as described above.
+        A function that accepts model configuration kwargs (must include `model_name`) and returns an ESM2 instance with the chosen backend and resolved device.
     """
+    is_modal = backend_option.split(":", 1)[0].strip() == "modal"
 
     def _make_model(**kwargs):
         config = {**kwargs}
+        device: str | None
 
-        # Use gpu_device from command line if provided, otherwise fall back to model-name-based selection
-        if gpu_device is not None:
-            gpu_type = gpu_device
-        else:
-            model_name = config.get("model_name")
-            if model_name is None:
-                raise ValueError("model_name is required when gpu_device is not provided")
-            if "15B" in model_name:
-                gpu_type = "A100-80GB"
-            elif "3B" in model_name:
-                gpu_type = "A100-40GB"
+        if is_modal:
+            # Modal: pick a GPU class. Honor --gpu if set, else infer from model size.
+            if gpu_device is not None:
+                device = gpu_device
             else:
-                gpu_type = "T4"
+                model_name = config.get("model_name")
+                if model_name is None:
+                    raise ValueError("model_name is required when --gpu is not provided")
+                if "15B" in model_name:
+                    device = "A100-80GB"
+                elif "3B" in model_name:
+                    device = "A100-40GB"
+                else:
+                    device = "T4"
+        else:
+            # Apptainer: device is whichever local CUDA index the user picked.
+            device = device_option
 
-        return ESM2(backend="modal", device=gpu_type, config=config)
+        return ESM2(backend=backend_option, device=device, config=config)
 
     return _make_model
 

--- a/tests/esm/test_esmfold.py
+++ b/tests/esm/test_esmfold.py
@@ -8,7 +8,6 @@ import pytest
 import torch
 from biotite.structure import AtomArray, rmsd
 from biotite.structure.io.pdb import PDBFile
-from modal import enable_output
 
 from boileroom import ESMFold
 from boileroom.constants import restype_3to1
@@ -19,15 +18,19 @@ from boileroom.models.esm.types import ESMFoldOutput
 pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.gpu, pytest.mark.xdist_group("esmfold")]
 
 
-# Module scope keeps a single Modal container alive for the duration of the suite.
+# Module scope keeps a single backend container alive for the duration of the suite.
 @pytest.fixture(scope="module")
-def esmfold_model(gpu_device: str | None = None) -> Generator[ESMFold, None, None]:
+def esmfold_model(backend_option: str, device_option: str | None, output_ctx) -> Generator[ESMFold, None, None]:
     """Provide a configured ESMFold model instance for tests.
 
     Parameters
     ----------
-    gpu_device : Optional[str]
-        Optional device identifier (e.g., "cuda:0" or "cpu") to initialize the model on.
+    backend_option : str
+        Backend selector ("modal" or "apptainer[:<tag>]").
+    device_option : Optional[str]
+        Backend-resolved device string (e.g. "T4" for Modal, "cuda:0" for Apptainer).
+    output_ctx : Callable
+        Factory yielding a backend-appropriate context manager.
 
     Yields
     ------
@@ -35,8 +38,8 @@ def esmfold_model(gpu_device: str | None = None) -> Generator[ESMFold, None, Non
         A configured ESMFold instance ready for use in tests.
     """
     model_config: dict[str, object] = {}
-    with enable_output():
-        yield ESMFold(backend="modal", device=gpu_device, config=model_config)
+    with output_ctx():
+        yield ESMFold(backend=backend_option, device=device_option, config=model_config)
 
 
 def test_esmfold_basic(test_sequences: dict[str, str], esmfold_model: ESMFold):
@@ -52,10 +55,15 @@ def test_esmfold_basic(test_sequences: dict[str, str], esmfold_model: ESMFold):
     assert result.plddt is None, "plddt should be None in minimal output"
 
 
-def test_esmfold_full_output(test_sequences: dict[str, str], gpu_device: str | None):
+def test_esmfold_full_output(
+    test_sequences: dict[str, str],
+    backend_option: str,
+    device_option: str | None,
+    output_ctx,
+):
     """Test ESMFold with full output requested."""
-    with enable_output():
-        model = ESMFold(backend="modal", device=gpu_device, config={"include_fields": ["*"]})
+    with output_ctx():
+        model = ESMFold(backend=backend_option, device=device_option, config={"include_fields": ["*"]})
         result = model.fold(test_sequences["short"])
 
     assert isinstance(result, ESMFoldOutput), "Result should be an ESMFoldOutput"
@@ -65,10 +73,12 @@ def test_esmfold_full_output(test_sequences: dict[str, str], gpu_device: str | N
     assert np.all(result.plddt <= 100), "pLDDT scores should be less than or equal to 100"
 
 
-def test_esmfold_multimer(test_sequences, gpu_device: str | None):
+def test_esmfold_multimer(test_sequences, backend_option: str, device_option: str | None, output_ctx):
     """Test ESMFold multimer functionality."""
-    with enable_output():  # TODO: make this better with a fixture, re-using the logic
-        model = ESMFold(backend="modal", device=gpu_device, config={"include_fields": ["*"]})  # Request all fields
+    with output_ctx():
+        model = ESMFold(
+            backend=backend_option, device=device_option, config={"include_fields": ["*"]}
+        )  # Request all fields
         result = model.fold(test_sequences["multimer"])
 
     assert result.pdb is not None, "PDB output should be generated"
@@ -141,18 +151,23 @@ def test_esmfold_linker_map():
     assert torch.all(linker_map == gt_map), "Linker map mismatch"
 
 
-def test_esmfold_no_glycine_linker(test_sequences, gpu_device: str | None):
+def test_esmfold_no_glycine_linker(
+    test_sequences,
+    backend_option: str,
+    device_option: str | None,
+    output_ctx,
+):
     """Test ESMFold no glycine linker."""
     model = ESMFold(
-        backend="modal",
-        device=gpu_device,
+        backend=backend_option,
+        device=device_option,
         config={
             "glycine_linker": "",
             "include_fields": ["*"],  # Request all fields
         },
     )
 
-    with enable_output():
+    with output_ctx():
         result = model.fold(test_sequences["multimer"])
 
     assert result.residue_index is not None, "Residue index should be generated"
@@ -189,10 +204,17 @@ def test_esmfold_chain_indices():
     assert np.array_equal(chain_indices[0], expected_chain_indices), "Chain indices mismatch"
 
 
-def test_esmfold_batch(test_sequences: dict[str, str], gpu_device: str | None):
+def test_esmfold_batch(
+    test_sequences: dict[str, str],
+    backend_option: str,
+    device_option: str | None,
+    output_ctx,
+):
     """Test ESMFold batch prediction."""
-    with enable_output():
-        model = ESMFold(backend="modal", device=gpu_device, config={"include_fields": ["*"]})  # Request all fields
+    with output_ctx():
+        model = ESMFold(
+            backend=backend_option, device=device_option, config={"include_fields": ["*"]}
+        )  # Request all fields
         # Define input sequences
         sequences = [test_sequences["short"], test_sequences["medium"]]
         # Make prediction
@@ -306,7 +328,13 @@ def test_esmfold_static_config_enforcement(test_sequences: dict[str, str]):
         esmfold_core.fold(test_sequences["short"], options={"device": "cuda:0"})
 
 
-def test_esmfold_output_pdb_cif(data_dir: pathlib.Path, test_sequences: dict[str, str], gpu_device: str | None):
+def test_esmfold_output_pdb_cif(
+    data_dir: pathlib.Path,
+    test_sequences: dict[str, str],
+    backend_option: str,
+    device_option: str | None,
+    output_ctx,
+):
     """
     Validate that ESMFold produces consistent PDB and AtomArray outputs and matches saved reference PDB files.
 
@@ -337,9 +365,9 @@ def test_esmfold_output_pdb_cif(data_dir: pathlib.Path, test_sequences: dict[str
         one_letter_codes = [restype_3to1[three_letter_code] for three_letter_code in three_letter_codes]
         return "".join(one_letter_codes)
 
-    with enable_output():
+    with output_ctx():
         model = ESMFold(
-            backend="modal", device=gpu_device, config={"include_fields": ["pdb", "atom_array"]}
+            backend=backend_option, device=device_option, config={"include_fields": ["pdb", "atom_array"]}
         )  # Request PDB and atom_array
         # Define input sequences
         sequences = [test_sequences["short"], test_sequences["medium"]]


### PR DESCRIPTION
## Context

While locally validating your #91 (the micromamba removal) on an HPC node, I hit two bugs and one chunk of pre-existing test infra that wanted commits. This PR is the cleanup follow-up.

The two bugs:

1. **Apptainer container crashed at startup on hosts where the test runner has its own Python venv.** Symptom: `Fatal Python error: _PyImport_Init: global import state already initialized`. Cause: host `LD_LIBRARY_PATH`, `VIRTUAL_ENV`, `PYTHONHOME`, and `PATH` (with `.venv/bin` first under `uv run`) were leaking into the container, loading host libpython alongside the container's. Fixed by `--cleanenv`, narrower bind mount, explicit env, absolute interpreter path.
2. **`--image-tag` pytest flag was silently ignored by the apptainer backend.** `parse_backend("apptainer")` in `boileroom/base.py:463` called `get_default_image_tag()` which only reads `pyproject.toml`, never checked `BOILEROOM_MODAL_IMAGE_TAG`. So `pytest --image-tag X --backend apptainer` quietly used the pyproject default. The only working override path was `--backend apptainer:<tag>` syntax. Fixed by introducing a single backend-neutral resolver and consolidating both flag and env knobs onto one env var (`BOILEROOM_IMAGE_TAG`).

While in there, I committed the pre-existing local WIP for apptainer test ergonomics (a `--device` option, conftest validation, fixtures that pick the right per-backend device kwarg). It was the work that made apptainer locally testable in the first place.

This PR follows the new CLAUDE.md prerelease guideline: hard rename, no back-compat shim, since `0.3.x` is still pre-release.

## Summary

1. **Container isolation fix** for apptainer.
2. **Test ergonomics**: new `--device` option for apptainer + cross-cutting `backend_option` / `device_option` / `output_ctx` fixtures so each test runs against either backend.
3. **Image-tag override unified**: `BOILEROOM_IMAGE_TAG` is now honored by both Modal and Apptainer (previously only Modal). Drop the redundant pytest `--image-tag` flag.

## Commits (atomic, each green on CI gates)

1. `docs: allow back-compat-breaking changes during prerelease` — adds two CLAUDE.md guidelines (back-compat is optional during prereleases; rename of runtime-facing env vars may require Modal image rebuilds).
2. `fix(apptainer): isolate container env to prevent host libpython collision` — `--cleanenv`, `--home /tmp`, narrower bind mount, drop host LD_LIBRARY_PATH, explicit PATH/LANG, absolute python path.
3. `feat(tests): add --device option and apptainer-aware test fixtures` — `--device` cli, validation, fixtures, and per-test migrations.
4. `refactor: standardize image-tag override on BOILEROOM_IMAGE_TAG` — rename `MODAL_IMAGE_TAG_ENV → IMAGE_TAG_ENV`, `get_modal_image_tag → get_image_tag`, fix `parse_backend("apptainer")` to honor the env var, update all call sites in source / tests / CI.
5. `refactor: remove pytest --image-tag flag in favor of BOILEROOM_IMAGE_TAG` — drops the flag (shadow of the env var); slims `test_pytest_image_options.py` to cover only `--docker-user`.
6. `docs: document BOILEROOM_IMAGE_TAG for both backends` — README, docs/docker_images.md updates.

## Migration

| Before | After |
|---|---|
| `pytest --image-tag X --backend apptainer` (silently used pyproject default — bug) | `BOILEROOM_IMAGE_TAG=X pytest --backend apptainer` |
| `pytest --image-tag X --backend modal` | `BOILEROOM_IMAGE_TAG=X pytest --backend modal` |
| `pytest --backend apptainer:X` | unchanged — inline tag still works and wins over env |

The CI workflow `.github/workflows/integration-tests.yaml` already uses the new env var (`BOILEROOM_IMAGE_TAG`).

## Risk callout: Modal image rebuilds

Modal images bake the env-var name in at build time (via `render_modal_runtime_env`). Existing alpha-tagged Modal images on Docker Hub still write `BOILEROOM_MODAL_IMAGE_TAG` into their container env at deploy time; on a host running the new code, they will instead read `BOILEROOM_IMAGE_TAG` from the env we set, so deployments still work. **New Modal image builds from this commit forward will write only the new name.** No action needed for end users.

## Test plan

- [x] `uv run pytest -m "not integration"` → 97 passed, 1 skipped locally
- [x] `uv run --extra dev pre-commit run --all-files` → all hooks pass
- [x] Direct verification of `parse_backend()` precedence: explicit suffix > env var > pyproject default
- [x] Apptainer integration suite end-to-end via PBS job (`551593.pbs-6` on A100-80GB): **34 passed, 1 skipped, 940s** — see comment below for full output. The 1 skipped is `test_chai1_static_config_enforcement`, one of the always-skipped tests already documented in #93 (host-side import of `chai_lab` which intentionally only lives inside the chai container).

Boltz tests were deselected from the PBS run via `--ignore=tests/boltz` due to a pre-existing local stale-cache issue (`.model_cache/boltz/mols/` missing canonical AAs). Not introduced by this PR; not a blocker.

## Related

- Closes the `--image-tag silently ignored by apptainer` issue raised in my review of #91.
- #93 (10 always-skipped tests) — independent follow-up; this PR doesn't touch it.
- #94 (Docker Hub tag lifecycle: stale `sha-*` tags accumulate forever) — independent follow-up; ~360 tags manually cleaned in jakublala namespace today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)