### PR TITLE
fix: restore pytest image tag option

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -89,11 +89,9 @@ jobs:
 
       - name: Run integration tests
         shell: bash -l {0}
-        env:
-          BOILEROOM_IMAGE_TAG: ${{ steps.resolve_tag.outputs.docker_tag }}
         run: |
           if [ "${{ inputs.execution-mode || 'parallel' }}" = "series" ]; then
-            uv run pytest -v -m integration
+            uv run pytest -v -m integration --image-tag "${{ steps.resolve_tag.outputs.docker_tag }}"
           else
-            uv run pytest -v -n 4 --dist loadgroup -m integration
+            uv run pytest -v -n 4 --dist loadgroup -m integration --image-tag "${{ steps.resolve_tag.outputs.docker_tag }}"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@
 - `latest` is not published or used as a runtime default.
 - Explicit image-tag overrides still work:
   - Pytest accepts `--image-tag <tag>` for both Modal and Apptainer test backends
-  - Modal still honors `BOILEROOM_MODAL_IMAGE_TAG` for runtime image lookup
-  - Apptainer also accepts an inline tag via `backend="apptainer:<tag>"`, which wins over `--image-tag` in tests
+  - Modal and Apptainer both honor `BOILEROOM_IMAGE_TAG` as the shared runtime image-tag override
+  - Apptainer also accepts an inline tag via `backend="apptainer:<tag>"`, which wins over `BOILEROOM_IMAGE_TAG` and `--image-tag` in tests
 - Canonical published tags are CUDA-qualified, for example `cuda12.6-0.3.0` or `cuda12.6-0.3.1-alpha.1`.
 - The default CUDA line `12.6` also gets an unqualified alias for the same version, for example `0.3.0` or `0.3.1-alpha.1`.
 - Temporary validation tags such as `sha-<commit>` are allowed and should be deleted after use.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,9 @@
 - Runtime image lookup defaults to the installed boileroom package version.
 - `latest` is not published or used as a runtime default.
 - Explicit image-tag overrides still work:
-  - Both backends honor `BOILEROOM_IMAGE_TAG`
-  - Apptainer also accepts an inline tag via `backend="apptainer:<tag>"`, which wins over the env var
+  - Pytest accepts `--image-tag <tag>` for both Modal and Apptainer test backends
+  - Modal still honors `BOILEROOM_MODAL_IMAGE_TAG` for runtime image lookup
+  - Apptainer also accepts an inline tag via `backend="apptainer:<tag>"`, which wins over `--image-tag` in tests
 - Canonical published tags are CUDA-qualified, for example `cuda12.6-0.3.0` or `cuda12.6-0.3.1-alpha.1`.
 - The default CUDA line `12.6` also gets an unqualified alias for the same version, for example `0.3.0` or `0.3.1-alpha.1`.
 - Temporary validation tags such as `sha-<commit>` are allowed and should be deleted after use.

--- a/README.md
+++ b/README.md
@@ -115,13 +115,14 @@ uv run pytest --gpu A100-40GB
 To run Modal integration tests against a specific Docker Hub namespace, image tag, and GPU type:
 
 ```bash
-BOILEROOM_IMAGE_TAG=cuda12.6-my-test-tag uv run pytest -v -n 4 --dist loadgroup -m integration \
+uv run pytest -v -n 4 --dist loadgroup -m integration \
   --docker-user <your-dockerhub-user> \
+  --image-tag cuda12.6-my-test-tag \
   --gpu A10
 ```
 
-The same env var works for the Apptainer backend; for Apptainer you can also pass the tag inline as
-`--backend apptainer:<tag>` (the inline suffix wins over the env var).
+The same `--image-tag` option works for the Apptainer backend. For Apptainer you can also pass the tag inline as
+`--backend apptainer:<tag>` (the inline suffix wins over `--image-tag`).
 
 Available GPU options include `T4`, `A100-40GB`, `A100-80GB`, and other Modal-supported GPU types.
 

--- a/boileroom/base.py
+++ b/boileroom/base.py
@@ -12,7 +12,7 @@ from typing import Any, ClassVar, Literal, Protocol, cast
 import numpy as np
 import torch
 
-from .images.metadata import format_image_reference, get_default_image_tag
+from .images.metadata import format_image_reference, get_image_tag
 from .models.registry import ModelSpec, resolve_object
 from .utils import validate_sequence
 
@@ -450,8 +450,8 @@ class ModelWrapper:
             A tuple of ``(backend_type, backend_tag)`` where ``backend_type`` is
             the base backend identifier (for example ``\"modal\"`` or
             ``\"apptainer\"``) and ``backend_tag`` is either the tag string for
-            ``\"apptainer\"`` backends (defaulting to the installed package version
-            when no tag is provided) or ``None`` for all other backends.
+            ``\"apptainer\"`` backends (defaulting to the shared runtime Docker
+            image tag when no tag is provided) or ``None`` for all other backends.
         """
         if ":" in backend:
             backend_type, backend_tag = backend.split(":", 1)
@@ -460,7 +460,7 @@ class ModelWrapper:
 
         backend_type = backend_type.strip()
         if backend_type == "apptainer":
-            backend_tag = (backend_tag or get_default_image_tag()).strip() or get_default_image_tag()
+            backend_tag = (backend_tag or get_image_tag()).strip() or get_image_tag()
             return backend_type, backend_tag
 
         return backend_type, None

--- a/boileroom/base.py
+++ b/boileroom/base.py
@@ -12,7 +12,7 @@ from typing import Any, ClassVar, Literal, Protocol, cast
 import numpy as np
 import torch
 
-from .images.metadata import format_image_reference, get_image_tag
+from .images.metadata import format_image_reference, get_default_image_tag
 from .models.registry import ModelSpec, resolve_object
 from .utils import validate_sequence
 
@@ -450,9 +450,8 @@ class ModelWrapper:
             A tuple of ``(backend_type, backend_tag)`` where ``backend_type`` is
             the base backend identifier (for example ``\"modal\"`` or
             ``\"apptainer\"``) and ``backend_tag`` is either the tag string for
-            ``\"apptainer\"`` backends (the explicit suffix wins, otherwise it
-            falls back to ``BOILEROOM_IMAGE_TAG`` env var, otherwise the
-            installed package version) or ``None`` for all other backends.
+            ``\"apptainer\"`` backends (defaulting to the installed package version
+            when no tag is provided) or ``None`` for all other backends.
         """
         if ":" in backend:
             backend_type, backend_tag = backend.split(":", 1)
@@ -461,8 +460,7 @@ class ModelWrapper:
 
         backend_type = backend_type.strip()
         if backend_type == "apptainer":
-            explicit = (backend_tag or "").strip()
-            backend_tag = explicit if explicit else get_image_tag()
+            backend_tag = (backend_tag or get_default_image_tag()).strip() or get_default_image_tag()
             return backend_type, backend_tag
 
         return backend_type, None

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -15,7 +15,7 @@ DEFAULT_DOCKER_REPOSITORY: Final = "docker.io/jakublala"
 PACKAGE_NAME: Final = "boileroom"
 DEFAULT_CUDA_VERSION: Final = "12.6"
 DOCKER_REPOSITORY_ENV: Final = "BOILEROOM_DOCKER_REPOSITORY"
-MODAL_IMAGE_TAG_ENV: Final = "BOILEROOM_MODAL_IMAGE_TAG"
+IMAGE_TAG_ENV: Final = "BOILEROOM_IMAGE_TAG"
 
 SUPPORTED_CUDA_VERSIONS: Final[tuple[str, ...]] = ("11.8", "12.6")
 
@@ -101,7 +101,7 @@ def get_default_image_tag() -> str:
     except importlib.metadata.PackageNotFoundError:
         raise RuntimeError(
             "Unable to determine the default boileroom image tag. "
-            f"Install {PACKAGE_NAME} or set {MODAL_IMAGE_TAG_ENV} explicitly."
+            f"Install {PACKAGE_NAME} or set {IMAGE_TAG_ENV} explicitly."
         ) from None
 
 
@@ -217,14 +217,14 @@ def published_image_references(
     return tuple(f"{repository}/{image_name}:{published_tag}" for published_tag in published_tags(cuda_version, tag))
 
 
-def get_modal_image_tag() -> str:
-    """Return the tag Modal should pull from the registry."""
-    return resolve_registry_tag(os.environ.get(MODAL_IMAGE_TAG_ENV))
+def get_image_tag() -> str:
+    """Return the shared runtime Docker image tag."""
+    return resolve_registry_tag(os.environ.get(IMAGE_TAG_ENV))
 
 
 def get_modal_base_image_reference() -> str:
     """Return the base image Modal should use for the shared runtime layer."""
-    return format_image_reference(BASE_IMAGE_SPEC.image_name, get_modal_image_tag())
+    return format_image_reference(BASE_IMAGE_SPEC.image_name, get_image_tag())
 
 
 def get_model_image_spec(identifier: str) -> RuntimeImageSpec:
@@ -267,7 +267,7 @@ def render_modal_runtime_env(spec: RuntimeImageSpec, model_dir: str) -> dict[str
     env = {
         "MODEL_DIR": model_dir,
         DOCKER_REPOSITORY_ENV: get_docker_repository(),
-        MODAL_IMAGE_TAG_ENV: get_modal_image_tag(),
+        IMAGE_TAG_ENV: get_image_tag(),
     }
     for key, value in spec.modal_runtime_env:
         env[key] = value.replace("{MODEL_DIR}", model_dir)

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -15,7 +15,7 @@ DEFAULT_DOCKER_REPOSITORY: Final = "docker.io/jakublala"
 PACKAGE_NAME: Final = "boileroom"
 DEFAULT_CUDA_VERSION: Final = "12.6"
 DOCKER_REPOSITORY_ENV: Final = "BOILEROOM_DOCKER_REPOSITORY"
-IMAGE_TAG_ENV: Final = "BOILEROOM_IMAGE_TAG"
+MODAL_IMAGE_TAG_ENV: Final = "BOILEROOM_MODAL_IMAGE_TAG"
 
 SUPPORTED_CUDA_VERSIONS: Final[tuple[str, ...]] = ("11.8", "12.6")
 
@@ -101,7 +101,7 @@ def get_default_image_tag() -> str:
     except importlib.metadata.PackageNotFoundError:
         raise RuntimeError(
             "Unable to determine the default boileroom image tag. "
-            f"Install {PACKAGE_NAME} or set {IMAGE_TAG_ENV} explicitly."
+            f"Install {PACKAGE_NAME} or set {MODAL_IMAGE_TAG_ENV} explicitly."
         ) from None
 
 
@@ -217,18 +217,14 @@ def published_image_references(
     return tuple(f"{repository}/{image_name}:{published_tag}" for published_tag in published_tags(cuda_version, tag))
 
 
-def get_image_tag() -> str:
-    """Return the runtime image tag for both Modal and Apptainer backends.
-
-    Reads the ``BOILEROOM_IMAGE_TAG`` env var if set; otherwise falls back to
-    the package-default tag derived from ``pyproject.toml``.
-    """
-    return resolve_registry_tag(os.environ.get(IMAGE_TAG_ENV))
+def get_modal_image_tag() -> str:
+    """Return the tag Modal should pull from the registry."""
+    return resolve_registry_tag(os.environ.get(MODAL_IMAGE_TAG_ENV))
 
 
 def get_modal_base_image_reference() -> str:
     """Return the base image Modal should use for the shared runtime layer."""
-    return format_image_reference(BASE_IMAGE_SPEC.image_name, get_image_tag())
+    return format_image_reference(BASE_IMAGE_SPEC.image_name, get_modal_image_tag())
 
 
 def get_model_image_spec(identifier: str) -> RuntimeImageSpec:
@@ -271,7 +267,7 @@ def render_modal_runtime_env(spec: RuntimeImageSpec, model_dir: str) -> dict[str
     env = {
         "MODEL_DIR": model_dir,
         DOCKER_REPOSITORY_ENV: get_docker_repository(),
-        IMAGE_TAG_ENV: get_image_tag(),
+        MODAL_IMAGE_TAG_ENV: get_modal_image_tag(),
     }
     for key, value in spec.modal_runtime_env:
         env[key] = value.replace("{MODEL_DIR}", model_dir)

--- a/boileroom/images/modal.py
+++ b/boileroom/images/modal.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from modal import Image
 
 from ..utils import MODAL_MODEL_DIR
-from .metadata import format_image_reference, get_modal_image_tag, get_model_image_spec, render_modal_runtime_env
+from .metadata import format_image_reference, get_image_tag, get_model_image_spec, render_modal_runtime_env
 
 
 def get_modal_image(identifier: str) -> Image:
     """Return a Modal image sourced from the published Docker image for a model."""
     spec = get_model_image_spec(identifier)
-    image = Image.from_registry(format_image_reference(spec.image_name, get_modal_image_tag()))
+    image = Image.from_registry(format_image_reference(spec.image_name, get_image_tag()))
     return image.env(render_modal_runtime_env(spec, MODAL_MODEL_DIR))

--- a/boileroom/images/modal.py
+++ b/boileroom/images/modal.py
@@ -5,11 +5,11 @@ from __future__ import annotations
 from modal import Image
 
 from ..utils import MODAL_MODEL_DIR
-from .metadata import format_image_reference, get_image_tag, get_model_image_spec, render_modal_runtime_env
+from .metadata import format_image_reference, get_modal_image_tag, get_model_image_spec, render_modal_runtime_env
 
 
 def get_modal_image(identifier: str) -> Image:
     """Return a Modal image sourced from the published Docker image for a model."""
     spec = get_model_image_spec(identifier)
-    image = Image.from_registry(format_image_reference(spec.image_name, get_image_tag()))
+    image = Image.from_registry(format_image_reference(spec.image_name, get_modal_image_tag()))
     return image.env(render_modal_runtime_env(spec, MODAL_MODEL_DIR))

--- a/docs/backend_support_matrix.md
+++ b/docs/backend_support_matrix.md
@@ -44,4 +44,4 @@ model = Boltz2(backend="apptainer")
 model = Boltz2(backend="apptainer:cuda11.8-0.3.0")
 ```
 
-`backend="apptainer"` resolves through the installed boileroom package version on the default `12.6` image line.
+`backend="apptainer"` resolves through `BOILEROOM_IMAGE_TAG` when set, otherwise through the installed boileroom package version on the default `12.6` image line. An explicit suffix such as `backend="apptainer:cuda11.8-0.3.0"` wins over the shared env override.

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -12,7 +12,7 @@ Dockerfiles are the canonical image definition for all runtimes. Docker/Apptaine
 - Canonical published tags are CUDA-qualified, for example `cuda12.6-0.3.0`, `cuda11.8-0.3.0`, `cuda12.6-0.3.1-alpha.1`, or `cuda12.6-sha-abc1234`.
 - The default CUDA line is `12.6`. That line also gets an unqualified alias for the exact package version, alpha prerelease, or temporary validation tag, for example `0.3.0`, `0.3.1-alpha.1`, or `sha-abc1234`.
 - `latest` is not published.
-- Runtime shorthands such as `backend="apptainer"` resolve to the installed boileroom package version on the default `12.6` CUDA line.
+- Runtime shorthands such as `backend="apptainer"` resolve through `BOILEROOM_IMAGE_TAG` when set, otherwise through the installed boileroom package version on the default `12.6` CUDA line.
 
 ### 🚀 Quick start
 Use the Python helper to build all images (base + models) with a single global worker limit.
@@ -59,7 +59,7 @@ uv run pytest -v -m integration --docker-user=my-dockerhub-user --image-tag=0.3.
 
 `--image-tag` is honored by both the Modal and Apptainer test backends. The Apptainer backend additionally accepts an inline tag via `--backend apptainer:<tag>`, which wins over `--image-tag`.
 
-For lower-level runtime configuration outside pytest, `BOILEROOM_IMAGE_TAG` is the shared image-tag override used by both Modal image lookup and Apptainer's default image tag. Prefer pytest's `--image-tag` option for test runs so the selected image is explicit in the test command and report header.
+For lower-level runtime configuration outside pytest, `BOILEROOM_IMAGE_TAG` is the shared image-tag override used by both Modal image lookup and Apptainer's default image tag. An explicit Apptainer suffix such as `backend="apptainer:<tag>"` wins over the env override. Prefer pytest's `--image-tag` option for test runs so the selected image is explicit in the test command and report header.
 
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
 Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -36,27 +36,28 @@ uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=0.3
 
 The image build, smoke check, and promotion helpers all accept the same `--docker-user` flag.
 
-Pytest uses `docker.io/jakublala` plus the current package version by default. To run against manually published images, set `BOILEROOM_IMAGE_TAG` and pass `--docker-user`:
+Pytest uses `docker.io/jakublala` plus the current package version by default. To run against manually published images, pass `--image-tag` and `--docker-user`:
 
 ```bash
-BOILEROOM_IMAGE_TAG=0.3.0 uv run pytest --backend=modal --docker-user=my-dockerhub-user
+uv run pytest --backend=modal --docker-user=my-dockerhub-user --image-tag=0.3.0
 ```
 
 For the Modal integration suite, use grouped xdist scheduling so each model family runs in its own worker and Modal app:
 
 ```bash
-BOILEROOM_IMAGE_TAG=0.3.0 uv run pytest -v -n 4 --dist loadgroup -m integration \
+uv run pytest -v -n 4 --dist loadgroup -m integration \
   --docker-user=my-dockerhub-user \
+  --image-tag=0.3.0 \
   --gpu=A10
 ```
 
 For serial integration execution against the same image, omit xdist:
 
 ```bash
-BOILEROOM_IMAGE_TAG=0.3.0 uv run pytest -v -m integration --docker-user=my-dockerhub-user --gpu=A10
+uv run pytest -v -m integration --docker-user=my-dockerhub-user --image-tag=0.3.0 --gpu=A10
 ```
 
-`BOILEROOM_IMAGE_TAG` is honored by both the Modal and Apptainer backends. The Apptainer backend additionally accepts an inline tag via `--backend apptainer:<tag>`, which wins over the env var.
+`--image-tag` is honored by both the Modal and Apptainer test backends. The Apptainer backend additionally accepts an inline tag via `--backend apptainer:<tag>`, which wins over `--image-tag`.
 
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
 Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -59,6 +59,8 @@ uv run pytest -v -m integration --docker-user=my-dockerhub-user --image-tag=0.3.
 
 `--image-tag` is honored by both the Modal and Apptainer test backends. The Apptainer backend additionally accepts an inline tag via `--backend apptainer:<tag>`, which wins over `--image-tag`.
 
+For lower-level runtime configuration outside pytest, `BOILEROOM_IMAGE_TAG` is the shared image-tag override used by both Modal image lookup and Apptainer's default image tag. Prefer pytest's `--image-tag` option for test runs so the selected image is explicit in the test command and report header.
+
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
 Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.
 Model Dockerfiles also mount a shared BuildKit uv cache for the active CUDA line, for example `boileroom-uv-cu12.6`, so parallel model builds in the same GitHub Actions matrix job can reuse downloaded wheels even when a full dependency-install layer has to run again.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import re
 
 import pytest
 
-from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, MODAL_IMAGE_TAG_ENV, normalize_docker_repository
+from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, IMAGE_TAG_ENV, normalize_docker_repository
 from boileroom.utils import GPUS_AVAIL_ON_MODAL
 
 _APPTAINER_DEVICE_RE = re.compile(r"^(cpu|cuda(:\d+)?)$")
@@ -31,26 +31,23 @@ def pytest_report_header(config: pytest.Config) -> list[str]:
         One-line-per-entry header additions.
     """
     try:
-        from boileroom.images.metadata import get_docker_repository, get_modal_image_tag, resolve_registry_tag
+        from boileroom.images.metadata import get_docker_repository, get_image_tag, resolve_registry_tag
     except ImportError as exc:  # pragma: no cover - defensive; keep pytest running if the module is missing
         return [f"boileroom image: <unresolved: {exc!s}>"]
 
     image_tag = config.getoption("--image-tag")
     raw_backend = config.getoption("--backend")
-    backend = _backend_with_image_tag(raw_backend, image_tag)
-    family, _, backend_tag = backend.partition(":")
     raw_family, raw_sep, raw_backend_tag = raw_backend.partition(":")
-    has_inline_backend_tag = raw_family.strip() == "apptainer" and bool(raw_sep) and bool(raw_backend_tag.strip())
-    if family.strip() == "apptainer" and backend_tag.strip() and has_inline_backend_tag:
-        tag = resolve_registry_tag(backend_tag)
+    if raw_family.strip() == "apptainer" and raw_sep and raw_backend_tag.strip():
+        tag = resolve_registry_tag(raw_backend_tag)
         source = "from --backend tag"
     elif image_tag:
         tag = resolve_registry_tag(image_tag)
         source = "from --image-tag"
     else:
-        tag = get_modal_image_tag()
-        override = os.environ.get(MODAL_IMAGE_TAG_ENV)
-        source = f"override via {MODAL_IMAGE_TAG_ENV}" if override else "from pyproject.toml"
+        tag = get_image_tag()
+        override = os.environ.get(IMAGE_TAG_ENV)
+        source = f"override via {IMAGE_TAG_ENV}" if override else "from pyproject.toml"
     repository = get_docker_repository()
     return [f"boileroom image: {repository}/boileroom-<family>:{tag} ({source})"]
 
@@ -149,7 +146,7 @@ def pytest_configure(config: pytest.Config) -> None:
     if docker_user := config.getoption("--docker-user"):
         os.environ[DOCKER_REPOSITORY_ENV] = normalize_docker_repository(docker_user)
     if image_tag := config.getoption("--image-tag"):
-        os.environ[MODAL_IMAGE_TAG_ENV] = image_tag
+        os.environ[IMAGE_TAG_ENV] = image_tag
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ import re
 
 import pytest
 
-from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, normalize_docker_repository
+from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, MODAL_IMAGE_TAG_ENV, normalize_docker_repository
 from boileroom.utils import GPUS_AVAIL_ON_MODAL
 
 _APPTAINER_DEVICE_RE = re.compile(r"^(cpu|cuda(:\d+)?)$")
@@ -17,15 +17,13 @@ def pytest_report_header(config: pytest.Config) -> list[str]:
     """Report the runtime image tag and Docker repository at the top of every pytest run.
 
     Both Modal and Apptainer backends pull the boileroom package from a prebuilt
-    Docker image whose tag is resolved by
-    ``boileroom.images.metadata.get_image_tag``. Surfacing that tag in the pytest
-    header avoids ambiguity about which image the integration tests are actually
-    exercising.
+    Docker image. Surfacing the selected tag in the pytest header avoids ambiguity
+    about which image the integration tests are actually exercising.
 
     Parameters
     ----------
     config : pytest.Config
-        The active pytest configuration (unused, required by the hook signature).
+        The active pytest configuration.
 
     Returns
     -------
@@ -33,14 +31,27 @@ def pytest_report_header(config: pytest.Config) -> list[str]:
         One-line-per-entry header additions.
     """
     try:
-        from boileroom.images.metadata import IMAGE_TAG_ENV, get_docker_repository, get_image_tag
+        from boileroom.images.metadata import get_docker_repository, get_modal_image_tag, resolve_registry_tag
     except ImportError as exc:  # pragma: no cover - defensive; keep pytest running if the module is missing
         return [f"boileroom image: <unresolved: {exc!s}>"]
 
-    tag = get_image_tag()
+    image_tag = config.getoption("--image-tag")
+    raw_backend = config.getoption("--backend")
+    backend = _backend_with_image_tag(raw_backend, image_tag)
+    family, _, backend_tag = backend.partition(":")
+    raw_family, raw_sep, raw_backend_tag = raw_backend.partition(":")
+    has_inline_backend_tag = raw_family.strip() == "apptainer" and bool(raw_sep) and bool(raw_backend_tag.strip())
+    if family.strip() == "apptainer" and backend_tag.strip() and has_inline_backend_tag:
+        tag = resolve_registry_tag(backend_tag)
+        source = "from --backend tag"
+    elif image_tag:
+        tag = resolve_registry_tag(image_tag)
+        source = "from --image-tag"
+    else:
+        tag = get_modal_image_tag()
+        override = os.environ.get(MODAL_IMAGE_TAG_ENV)
+        source = f"override via {MODAL_IMAGE_TAG_ENV}" if override else "from pyproject.toml"
     repository = get_docker_repository()
-    override = os.environ.get(IMAGE_TAG_ENV)
-    source = f"override via {IMAGE_TAG_ENV}" if override else "from pyproject.toml"
     return [f"boileroom image: {repository}/boileroom-<family>:{tag} ({source})"]
 
 
@@ -52,10 +63,7 @@ def pytest_addoption(parser):
     - --gpu: Modal-only GPU class (e.g. "T4", "A100-80GB").
     - --device: Apptainer-only CUDA device (e.g. "cuda:0", "cpu"). Defaults to cuda:0.
     - --docker-user: overrides the Docker Hub user or namespace for image lookup.
-
-    Set the runtime image tag via the ``BOILEROOM_IMAGE_TAG`` environment variable
-    (e.g. ``BOILEROOM_IMAGE_TAG=sha-abc1234 uv run pytest``). Both Modal and
-    Apptainer backends honor it.
+    - --image-tag: overrides the runtime image tag for both Modal and Apptainer tests.
 
     Parameters
     ----------
@@ -90,6 +98,25 @@ def pytest_addoption(parser):
         default=None,
         help="Docker Hub user or namespace for image lookup (sets BOILEROOM_DOCKER_REPOSITORY).",
     )
+    parser.addoption(
+        "--image-tag",
+        action="store",
+        default=None,
+        help="Runtime image tag for Modal and Apptainer image lookup.",
+    )
+
+
+def _backend_with_image_tag(backend: str, image_tag: str | None) -> str:
+    """Return the backend selector after applying the pytest image-tag option."""
+    family, sep, tag = backend.partition(":")
+    if family.strip() == "apptainer":
+        inline_tag = tag.strip() if sep else ""
+        if inline_tag:
+            return f"apptainer:{inline_tag}"
+        if image_tag:
+            return f"apptainer:{image_tag}"
+        return "apptainer"
+    return backend
 
 
 def pytest_configure(config: pytest.Config) -> None:
@@ -100,7 +127,7 @@ def pytest_configure(config: pytest.Config) -> None:
     if family not in ("modal", "apptainer"):
         raise pytest.UsageError(f"--backend must be 'modal' or 'apptainer[:<tag>]'; got {backend!r}")
     if family == "modal" and ":" in backend:
-        raise pytest.UsageError("--backend 'modal' does not accept a ':<tag>' suffix; set BOILEROOM_IMAGE_TAG instead.")
+        raise pytest.UsageError("--backend 'modal' does not accept a ':<tag>' suffix; use --image-tag instead.")
 
     gpu = config.getoption("--gpu")
     device = config.getoption("--device")
@@ -121,6 +148,8 @@ def pytest_configure(config: pytest.Config) -> None:
 
     if docker_user := config.getoption("--docker-user"):
         os.environ[DOCKER_REPOSITORY_ENV] = normalize_docker_repository(docker_user)
+    if image_tag := config.getoption("--image-tag"):
+        os.environ[MODAL_IMAGE_TAG_ENV] = image_tag
 
 
 @pytest.fixture(autouse=True, scope="session")
@@ -147,7 +176,7 @@ def backend_option(request):
     str
         The backend string as provided via `--backend` (defaults to "modal").
     """
-    return request.config.getoption("--backend")
+    return _backend_with_image_tag(request.config.getoption("--backend"), request.config.getoption("--image-tag"))
 
 
 @pytest.fixture(scope="session")

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -6,11 +6,12 @@ import pytest
 
 from boileroom.images.import_checks import compute_cuda_versions, iter_image_targets, package_name_to_import_name
 from boileroom.images.metadata import (
+    MODAL_IMAGE_TAG_ENV,
     format_image_reference,
     get_default_image_tag,
     get_docker_repository,
-    get_image_tag,
     get_modal_base_image_reference,
+    get_modal_image_tag,
     get_model_image_spec,
     get_supported_cuda,
     normalize_docker_repository,
@@ -49,22 +50,22 @@ def test_model_specs_report_supported_cuda_from_config() -> None:
     assert get_supported_cuda(get_model_image_spec("esm")) == ("11.8", "12.6")
 
 
-def test_image_tag_uses_env_override(monkeypatch) -> None:
-    """Image lookups should respect an optional tag override via BOILEROOM_IMAGE_TAG."""
-    monkeypatch.delenv("BOILEROOM_IMAGE_TAG", raising=False)
-    assert get_image_tag() == get_default_image_tag()
+def test_modal_image_tag_uses_env_override(monkeypatch) -> None:
+    """Modal image lookups should respect an optional tag override."""
+    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
+    assert get_modal_image_tag() == get_default_image_tag()
 
-    monkeypatch.setenv("BOILEROOM_IMAGE_TAG", "0.3.0")
-    assert get_image_tag() == "0.3.0"
+    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "0.3.0")
+    assert get_modal_image_tag() == "0.3.0"
 
-    monkeypatch.setenv("BOILEROOM_IMAGE_TAG", "cuda12.6")
-    assert get_image_tag() == f"cuda12.6-{get_default_image_tag()}"
+    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "cuda12.6")
+    assert get_modal_image_tag() == f"cuda12.6-{get_default_image_tag()}"
 
 
 def test_modal_base_image_reference_uses_repository_and_tag(monkeypatch) -> None:
     """Modal base image lookups should use the same repository and tag as model images."""
     monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
-    monkeypatch.setenv("BOILEROOM_IMAGE_TAG", "0.3.0.1")
+    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "0.3.0.1")
 
     assert get_modal_base_image_reference() == "docker.io/example/boileroom-base:0.3.0.1"
 
@@ -72,13 +73,13 @@ def test_modal_base_image_reference_uses_repository_and_tag(monkeypatch) -> None
 def test_modal_runtime_env_carries_image_lookup_overrides(monkeypatch) -> None:
     """Modal containers should re-import wrappers with the same resolved image lookup settings."""
     monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
-    monkeypatch.setenv("BOILEROOM_IMAGE_TAG", "0.3.0.1")
+    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "0.3.0.1")
 
     env = render_modal_runtime_env(get_model_image_spec("boltz"), "/mnt/models")
 
     assert env["BOILEROOM_DOCKER_REPOSITORY"] == "docker.io/example"
-    assert env["BOILEROOM_IMAGE_TAG"] == "0.3.0.1"
-    assert set(env) == {"MODEL_DIR", "BOILEROOM_DOCKER_REPOSITORY", "BOILEROOM_IMAGE_TAG"}
+    assert env[MODAL_IMAGE_TAG_ENV] == "0.3.0.1"
+    assert set(env) == {"MODEL_DIR", "BOILEROOM_DOCKER_REPOSITORY", MODAL_IMAGE_TAG_ENV}
 
 
 def test_docker_repository_uses_env_override(monkeypatch) -> None:

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -6,12 +6,12 @@ import pytest
 
 from boileroom.images.import_checks import compute_cuda_versions, iter_image_targets, package_name_to_import_name
 from boileroom.images.metadata import (
-    MODAL_IMAGE_TAG_ENV,
+    IMAGE_TAG_ENV,
     format_image_reference,
     get_default_image_tag,
     get_docker_repository,
+    get_image_tag,
     get_modal_base_image_reference,
-    get_modal_image_tag,
     get_model_image_spec,
     get_supported_cuda,
     normalize_docker_repository,
@@ -50,22 +50,22 @@ def test_model_specs_report_supported_cuda_from_config() -> None:
     assert get_supported_cuda(get_model_image_spec("esm")) == ("11.8", "12.6")
 
 
-def test_modal_image_tag_uses_env_override(monkeypatch) -> None:
-    """Modal image lookups should respect an optional tag override."""
-    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
-    assert get_modal_image_tag() == get_default_image_tag()
+def test_image_tag_uses_env_override(monkeypatch) -> None:
+    """Runtime image lookups should respect an optional tag override."""
+    monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
+    assert get_image_tag() == get_default_image_tag()
 
-    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "0.3.0")
-    assert get_modal_image_tag() == "0.3.0"
+    monkeypatch.setenv(IMAGE_TAG_ENV, "0.3.0")
+    assert get_image_tag() == "0.3.0"
 
-    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "cuda12.6")
-    assert get_modal_image_tag() == f"cuda12.6-{get_default_image_tag()}"
+    monkeypatch.setenv(IMAGE_TAG_ENV, "cuda12.6")
+    assert get_image_tag() == f"cuda12.6-{get_default_image_tag()}"
 
 
 def test_modal_base_image_reference_uses_repository_and_tag(monkeypatch) -> None:
     """Modal base image lookups should use the same repository and tag as model images."""
     monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
-    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "0.3.0.1")
+    monkeypatch.setenv(IMAGE_TAG_ENV, "0.3.0.1")
 
     assert get_modal_base_image_reference() == "docker.io/example/boileroom-base:0.3.0.1"
 
@@ -73,13 +73,13 @@ def test_modal_base_image_reference_uses_repository_and_tag(monkeypatch) -> None
 def test_modal_runtime_env_carries_image_lookup_overrides(monkeypatch) -> None:
     """Modal containers should re-import wrappers with the same resolved image lookup settings."""
     monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
-    monkeypatch.setenv(MODAL_IMAGE_TAG_ENV, "0.3.0.1")
+    monkeypatch.setenv(IMAGE_TAG_ENV, "0.3.0.1")
 
     env = render_modal_runtime_env(get_model_image_spec("boltz"), "/mnt/models")
 
     assert env["BOILEROOM_DOCKER_REPOSITORY"] == "docker.io/example"
-    assert env[MODAL_IMAGE_TAG_ENV] == "0.3.0.1"
-    assert set(env) == {"MODEL_DIR", "BOILEROOM_DOCKER_REPOSITORY", MODAL_IMAGE_TAG_ENV}
+    assert env[IMAGE_TAG_ENV] == "0.3.0.1"
+    assert set(env) == {"MODEL_DIR", "BOILEROOM_DOCKER_REPOSITORY", IMAGE_TAG_ENV}
 
 
 def test_docker_repository_uses_env_override(monkeypatch) -> None:

--- a/tests/contracts/test_model_wrappers.py
+++ b/tests/contracts/test_model_wrappers.py
@@ -204,19 +204,13 @@ def test_public_wrapper_dispatch_uses_shared_initializer(monkeypatch: pytest.Mon
     assert records["call_kwargs"] == {"options": None}
 
 
-def test_parse_backend_apptainer_tag_handling(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Apptainer tag resolution: explicit suffix > BOILEROOM_IMAGE_TAG env var > package default."""
-    monkeypatch.delenv("BOILEROOM_IMAGE_TAG", raising=False)
+def test_parse_backend_apptainer_tag_handling() -> None:
+    """Apptainer tag resolution should use an explicit suffix or package default."""
     assert ModelWrapper.parse_backend("modal") == ("modal", None)
     assert ModelWrapper.parse_backend("modal:dev") == ("modal", None)
-    # Without an env var or explicit suffix, fall back to package default.
+    # Without an explicit suffix, fall back to package default.
     assert ModelWrapper.parse_backend("apptainer") == ("apptainer", get_default_image_tag())
     # Explicit suffix wins.
-    assert ModelWrapper.parse_backend("apptainer:dev") == ("apptainer", "dev")
-    # Env var is honored when no explicit suffix is given.
-    monkeypatch.setenv("BOILEROOM_IMAGE_TAG", "sha-test")
-    assert ModelWrapper.parse_backend("apptainer") == ("apptainer", "sha-test")
-    # Explicit suffix still wins over env var.
     assert ModelWrapper.parse_backend("apptainer:dev") == ("apptainer", "dev")
 
 

--- a/tests/contracts/test_model_wrappers.py
+++ b/tests/contracts/test_model_wrappers.py
@@ -204,7 +204,7 @@ def test_public_wrapper_dispatch_uses_shared_initializer(monkeypatch: pytest.Mon
     assert records["call_kwargs"] == {"options": None}
 
 
-def test_parse_backend_apptainer_tag_handling(monkeypatch) -> None:
+def test_parse_backend_apptainer_tag_handling(monkeypatch: pytest.MonkeyPatch) -> None:
     """Apptainer tag resolution should use an explicit suffix, env override, or package default."""
     monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
     assert ModelWrapper.parse_backend("modal") == ("modal", None)

--- a/tests/contracts/test_model_wrappers.py
+++ b/tests/contracts/test_model_wrappers.py
@@ -7,7 +7,7 @@ import pytest
 
 from boileroom.backend.modal import ModalBackend, modal_app_of
 from boileroom.base import ModelWrapper, PredictionMetadata
-from boileroom.images.metadata import get_default_image_tag
+from boileroom.images.metadata import IMAGE_TAG_ENV, get_default_image_tag
 from boileroom.models.boltz.types import Boltz2Output
 from boileroom.models.chai.types import Chai1Output
 from boileroom.models.esm.types import ESM2Output, ESMFoldOutput
@@ -204,12 +204,16 @@ def test_public_wrapper_dispatch_uses_shared_initializer(monkeypatch: pytest.Mon
     assert records["call_kwargs"] == {"options": None}
 
 
-def test_parse_backend_apptainer_tag_handling() -> None:
-    """Apptainer tag resolution should use an explicit suffix or package default."""
+def test_parse_backend_apptainer_tag_handling(monkeypatch) -> None:
+    """Apptainer tag resolution should use an explicit suffix, env override, or package default."""
+    monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
     assert ModelWrapper.parse_backend("modal") == ("modal", None)
     assert ModelWrapper.parse_backend("modal:dev") == ("modal", None)
     # Without an explicit suffix, fall back to package default.
     assert ModelWrapper.parse_backend("apptainer") == ("apptainer", get_default_image_tag())
+    # The shared runtime image tag override applies to Apptainer defaults.
+    monkeypatch.setenv(IMAGE_TAG_ENV, "env-tag")
+    assert ModelWrapper.parse_backend("apptainer") == ("apptainer", "env-tag")
     # Explicit suffix wins.
     assert ModelWrapper.parse_backend("apptainer:dev") == ("apptainer", "dev")
 

--- a/tests/contracts/test_pytest_image_options.py
+++ b/tests/contracts/test_pytest_image_options.py
@@ -1,4 +1,4 @@
-"""Contract tests for the ``--docker-user`` pytest option."""
+"""Contract tests for pytest image lookup options."""
 
 from __future__ import annotations
 
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from boileroom.images.metadata import DOCKER_REPOSITORY_ENV
+from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, MODAL_IMAGE_TAG_ENV
 
 
 def _load_test_conftest() -> Any:
@@ -20,7 +20,12 @@ def _load_test_conftest() -> Any:
     return module
 
 
-_BACKEND_DEFAULTS: dict[str, str | None] = {"--backend": "modal", "--gpu": None, "--device": None}
+_BACKEND_DEFAULTS: dict[str, str | None] = {
+    "--backend": "modal",
+    "--gpu": None,
+    "--device": None,
+    "--image-tag": None,
+}
 
 
 class FakeConfig:
@@ -51,3 +56,41 @@ def test_docker_user_absent_leaves_repository_env_unset(monkeypatch) -> None:
     conftest.pytest_configure(FakeConfig({"--docker-user": None}))
 
     assert DOCKER_REPOSITORY_ENV not in os.environ
+
+
+def test_image_tag_sets_modal_lookup_env(monkeypatch) -> None:
+    """``--image-tag`` should write the Modal image tag env var."""
+    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
+    conftest = _load_test_conftest()
+
+    try:
+        conftest.pytest_configure(FakeConfig({"--image-tag": "sha-test"}))
+        assert os.environ[MODAL_IMAGE_TAG_ENV] == "sha-test"
+    finally:
+        os.environ.pop(MODAL_IMAGE_TAG_ENV, None)
+
+
+class FakeRequest:
+    def __init__(self, config: FakeConfig) -> None:
+        self.config = config
+
+
+def test_image_tag_applies_to_apptainer_backend_option(monkeypatch) -> None:
+    """``--image-tag`` should make ``--backend apptainer`` use that tag."""
+    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
+    conftest = _load_test_conftest()
+    config = FakeConfig({"--backend": "apptainer", "--image-tag": "sha-test"})
+
+    try:
+        conftest.pytest_configure(config)
+        assert conftest.backend_option.__wrapped__(FakeRequest(config)) == "apptainer:sha-test"
+    finally:
+        os.environ.pop(MODAL_IMAGE_TAG_ENV, None)
+
+
+def test_apptainer_inline_tag_wins_over_image_tag() -> None:
+    """An explicit Apptainer backend suffix should take precedence over ``--image-tag``."""
+    conftest = _load_test_conftest()
+    config = FakeConfig({"--backend": "apptainer:inline", "--image-tag": "sha-test"})
+
+    assert conftest.backend_option.__wrapped__(FakeRequest(config)) == "apptainer:inline"

--- a/tests/contracts/test_pytest_image_options.py
+++ b/tests/contracts/test_pytest_image_options.py
@@ -7,7 +7,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, MODAL_IMAGE_TAG_ENV
+from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, IMAGE_TAG_ENV
 
 
 def _load_test_conftest() -> Any:
@@ -58,16 +58,16 @@ def test_docker_user_absent_leaves_repository_env_unset(monkeypatch) -> None:
     assert DOCKER_REPOSITORY_ENV not in os.environ
 
 
-def test_image_tag_sets_modal_lookup_env(monkeypatch) -> None:
-    """``--image-tag`` should write the Modal image tag env var."""
-    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
+def test_image_tag_sets_runtime_lookup_env(monkeypatch) -> None:
+    """``--image-tag`` should write the shared runtime image tag env var."""
+    monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
     conftest = _load_test_conftest()
 
     try:
         conftest.pytest_configure(FakeConfig({"--image-tag": "sha-test"}))
-        assert os.environ[MODAL_IMAGE_TAG_ENV] == "sha-test"
+        assert os.environ[IMAGE_TAG_ENV] == "sha-test"
     finally:
-        os.environ.pop(MODAL_IMAGE_TAG_ENV, None)
+        os.environ.pop(IMAGE_TAG_ENV, None)
 
 
 class FakeRequest:
@@ -77,7 +77,7 @@ class FakeRequest:
 
 def test_image_tag_applies_to_apptainer_backend_option(monkeypatch) -> None:
     """``--image-tag`` should make ``--backend apptainer`` use that tag."""
-    monkeypatch.delenv(MODAL_IMAGE_TAG_ENV, raising=False)
+    monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
     conftest = _load_test_conftest()
     config = FakeConfig({"--backend": "apptainer", "--image-tag": "sha-test"})
 
@@ -85,7 +85,7 @@ def test_image_tag_applies_to_apptainer_backend_option(monkeypatch) -> None:
         conftest.pytest_configure(config)
         assert conftest.backend_option.__wrapped__(FakeRequest(config)) == "apptainer:sha-test"
     finally:
-        os.environ.pop(MODAL_IMAGE_TAG_ENV, None)
+        os.environ.pop(IMAGE_TAG_ENV, None)
 
 
 def test_apptainer_inline_tag_wins_over_image_tag() -> None:

--- a/tests/contracts/test_pytest_image_options.py
+++ b/tests/contracts/test_pytest_image_options.py
@@ -7,6 +7,8 @@ import os
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 from boileroom.images.metadata import DOCKER_REPOSITORY_ENV, IMAGE_TAG_ENV
 
 
@@ -36,7 +38,7 @@ class FakeConfig:
         return self.options.get(name)
 
 
-def test_docker_user_sets_repository_env(monkeypatch) -> None:
+def test_docker_user_sets_repository_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """``--docker-user`` should write the normalized repository to the env var."""
     monkeypatch.delenv(DOCKER_REPOSITORY_ENV, raising=False)
     conftest = _load_test_conftest()
@@ -48,7 +50,7 @@ def test_docker_user_sets_repository_env(monkeypatch) -> None:
         os.environ.pop(DOCKER_REPOSITORY_ENV, None)
 
 
-def test_docker_user_absent_leaves_repository_env_unset(monkeypatch) -> None:
+def test_docker_user_absent_leaves_repository_env_unset(monkeypatch: pytest.MonkeyPatch) -> None:
     """Without ``--docker-user``, the repository env var should not be touched."""
     monkeypatch.delenv(DOCKER_REPOSITORY_ENV, raising=False)
     conftest = _load_test_conftest()
@@ -58,7 +60,7 @@ def test_docker_user_absent_leaves_repository_env_unset(monkeypatch) -> None:
     assert DOCKER_REPOSITORY_ENV not in os.environ
 
 
-def test_image_tag_sets_runtime_lookup_env(monkeypatch) -> None:
+def test_image_tag_sets_runtime_lookup_env(monkeypatch: pytest.MonkeyPatch) -> None:
     """``--image-tag`` should write the shared runtime image tag env var."""
     monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
     conftest = _load_test_conftest()
@@ -75,7 +77,7 @@ class FakeRequest:
         self.config = config
 
 
-def test_image_tag_applies_to_apptainer_backend_option(monkeypatch) -> None:
+def test_image_tag_applies_to_apptainer_backend_option(monkeypatch: pytest.MonkeyPatch) -> None:
     """``--image-tag`` should make ``--backend apptainer`` use that tag."""
     monkeypatch.delenv(IMAGE_TAG_ENV, raising=False)
     conftest = _load_test_conftest()


### PR DESCRIPTION
## Summary

- Restore the pytest `--image-tag` option for runtime image selection.
- Route `--backend apptainer --image-tag <tag>` through the existing explicit `apptainer:<tag>` backend notation instead of a shared env var.
- Revert Modal image lookup to `BOILEROOM_MODAL_IMAGE_TAG` and remove `BOILEROOM_IMAGE_TAG` usage from code, CI, and docs.

## Context

Follow-up to Michael's review feedback on #95: the test workflow should use `--image-tag X` rather than requiring `BOILEROOM_IMAGE_TAG=X`.

I read through PR #95's comment history before making this. The only human-requested follow-up was this image-tag CLI behavior; the remaining unresolved CodeRabbit inline thread is about `output_ctx()` placement and is intentionally outside this focused PR.

## Validation

- `uv run pytest tests/contracts/test_image_metadata.py tests/contracts/test_model_wrappers.py::test_parse_backend_apptainer_tag_handling tests/contracts/test_pytest_image_options.py`
- `uv run pytest --collect-only tests/contracts/test_pytest_image_options.py --backend apptainer --image-tag sha-test`
- `uv run pytest -m "not integration"`
- `uv run --extra dev pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pytest CLI option --image-tag to explicitly select runtime image tags for Modal and Apptainer; Apptainer inline tags still take precedence. Pytest now reports the resolved repository/tag and applies the selected tag to Apptainer backend selection when appropriate.

* **Documentation**
  * Updated README and docs to document --image-tag usage, backend precedence, and recommended test invocation; policy doc clarified image-tag behavior.

* **Tests**
  * Added and updated contract tests and test helpers to validate --image-tag behavior, reporting, and precedence.

* **Chores**
  * CI integration-test workflow now forwards the resolved image tag into test runs and conditionally runs serial or parallel test execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softnanolab/boileroom/pull/99)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->