### PR TITLE
fix: standardize confidence metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ coordinates = atom_array.coord
 confidence = result.plddt[0]  # Requested explicitly via include_fields above
 ```
 
+Confidence metrics returned by structure wrappers use a consistent public shape: `plddt` entries are unit-scale
+per-residue arrays on `[0, 1]`, and scalar scores such as `ptm` and `iptm` are returned as shape-`(1,)` arrays.
+In `0.3.1`, this replaces ESMFold's old padded pLDDT batch array and moves Boltz `ptm`/`iptm` from nested
+`confidence` dictionaries to top-level fields.
+
 ## Available Models
 
 | Model      | Status | Description                                    | Reference                                              |

--- a/boileroom/models/boltz/types.py
+++ b/boileroom/models/boltz/types.py
@@ -19,8 +19,79 @@ class Boltz2Output(StructurePrediction):
     # Confidence-related outputs (one entry per sample)
     confidence: list[dict[str, Any] | None] | None = None
     plddt: list[np.ndarray | None] | None = None
+    ptm: list[np.ndarray | None] | None = None
+    iptm: list[np.ndarray | None] | None = None
     pae: list[np.ndarray | None] | None = None
     pde: list[np.ndarray | None] | None = None
     # Optional serialized structures (one string per sample)
     pdb: list[str] | None = None
     cif: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize confidence metrics to the public output contract."""
+        if self.plddt is not None:
+            plddt_samples: list[np.ndarray | None] = []
+            for sample in self.plddt:
+                if sample is None:
+                    plddt_samples.append(None)
+                    continue
+                plddt = np.asarray(sample, dtype=np.float32)
+                while plddt.ndim > 1 and plddt.shape[0] == 1:
+                    plddt = plddt[0]
+                if plddt.ndim != 1:
+                    raise ValueError(f"Boltz-2 pLDDT expected a 1D array; got {plddt.shape}")
+                if plddt.size and np.nanmax(plddt) > 1.0:
+                    plddt = plddt / 100.0
+                plddt_samples.append(plddt.astype(np.float32, copy=False))
+            self.plddt = plddt_samples if any(sample is not None for sample in plddt_samples) else None
+
+        confidence_ptm, self.confidence = _extract_score(self.confidence, "ptm")
+        confidence_iptm, self.confidence = _extract_score(self.confidence, "iptm")
+        self.ptm = _normalize_scalar_scores(self.ptm, "Boltz-2 pTM") or confidence_ptm
+        self.iptm = _normalize_scalar_scores(self.iptm, "Boltz-2 iPTM") or confidence_iptm
+
+
+def _normalize_scalar_scores(values: list[np.ndarray | None] | None, label: str) -> list[np.ndarray | None] | None:
+    if values is None:
+        return None
+
+    scores: list[np.ndarray | None] = []
+    for value in values:
+        if value is None:
+            scores.append(None)
+            continue
+        score = np.asarray(value, dtype=np.float32).squeeze()
+        if score.ndim != 0:
+            raise ValueError(f"{label} expected a scalar score; got {score.shape}")
+        scores.append(score.reshape(1))
+    return scores if any(score is not None for score in scores) else None
+
+
+def _extract_score(
+    confidence: list[dict[str, Any] | None] | None,
+    key: str,
+) -> tuple[list[np.ndarray | None] | None, list[dict[str, Any] | None] | None]:
+    if confidence is None:
+        return None, None
+
+    scores: list[np.ndarray | None] = []
+    stripped: list[dict[str, Any] | None] = []
+    for item in confidence:
+        if item is None:
+            scores.append(None)
+            stripped.append(None)
+            continue
+        next_item = dict(item)
+        raw_score = next_item.pop(key, None)
+        score = None if raw_score is None else np.asarray(raw_score, dtype=np.float32).squeeze()
+        if score is not None:
+            if score.ndim != 0:
+                raise ValueError(f"Boltz-2 {key} expected a scalar score; got {score.shape}")
+            score = score.reshape(1)
+        scores.append(score)
+        stripped.append(next_item or None)
+
+    return (
+        scores if any(score is not None for score in scores) else None,
+        stripped if any(item is not None for item in stripped) else None,
+    )

--- a/boileroom/models/chai/types.py
+++ b/boileroom/models/chai/types.py
@@ -21,8 +21,45 @@ class Chai1Output(StructurePrediction):
     # Additional Chai-1-specific outputs (all optional, filtered by include_fields)
     pae: list[np.ndarray] | None = None
     pde: list[np.ndarray] | None = None
-    plddt: list[np.ndarray] | None = None
-    ptm: list[np.ndarray] | None = None
-    iptm: list[np.ndarray] | None = None
+    plddt: list[np.ndarray | None] | None = None
+    ptm: list[np.ndarray | None] | None = None
+    iptm: list[np.ndarray | None] | None = None
     per_chain_iptm: list[np.ndarray] | None = None
     cif: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize confidence metrics to the public output contract."""
+        if self.plddt is not None:
+            plddt_samples: list[np.ndarray | None] = []
+            for sample in self.plddt:
+                if sample is None:
+                    plddt_samples.append(None)
+                    continue
+                plddt = np.asarray(sample, dtype=np.float32)
+                while plddt.ndim > 1 and plddt.shape[0] == 1:
+                    plddt = plddt[0]
+                if plddt.ndim != 1:
+                    raise ValueError(f"Chai-1 pLDDT expected a 1D array; got {plddt.shape}")
+                if plddt.size and np.nanmax(plddt) > 1.0:
+                    plddt = plddt / 100.0
+                plddt_samples.append(plddt.astype(np.float32, copy=False))
+            self.plddt = plddt_samples if any(sample is not None for sample in plddt_samples) else None
+
+        self.ptm = _normalize_scalar_scores(self.ptm, "Chai-1 pTM")
+        self.iptm = _normalize_scalar_scores(self.iptm, "Chai-1 iPTM")
+
+
+def _normalize_scalar_scores(values: list[np.ndarray | None] | None, label: str) -> list[np.ndarray | None] | None:
+    if values is None:
+        return None
+
+    scores: list[np.ndarray | None] = []
+    for value in values:
+        if value is None:
+            scores.append(None)
+            continue
+        score = np.asarray(value, dtype=np.float32).squeeze()
+        if score.ndim != 0:
+            raise ValueError(f"{label} expected a scalar score; got {score.shape}")
+        scores.append(score.reshape(1))
+    return scores if any(score is not None for score in scores) else None

--- a/boileroom/models/esm/core.py
+++ b/boileroom/models/esm/core.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 from .linker import compute_position_ids, replace_glycine_linkers, store_multimer_properties
 from .parsing import ESMSequenceTokens, parse_esm2_sequences
-from .types import ESM2Output, ESMFoldOutput
+from .types import ESM2Output, ESMFoldOutput, _normalize_esmfold_plddt
 
 logger = logging.getLogger(__name__)
 
@@ -963,6 +963,7 @@ class ESMFoldCore(FoldingAlgorithm):
         # change name of predicted_aligned_error to pae
         outputs["pae"] = outputs.pop("predicted_aligned_error")
         outputs["max_pae"] = outputs.pop("max_predicted_aligned_error")
+        outputs["plddt"] = _normalize_esmfold_plddt(outputs.get("plddt"), metadata.sequence_lengths)
 
         # Build full output with all fields (exclude positions as it's only used internally)
         outputs_without_positions = {k: v for k, v in outputs.items() if k != "positions"}

--- a/boileroom/models/esm/types.py
+++ b/boileroom/models/esm/types.py
@@ -10,6 +10,8 @@ from ...base import EmbeddingPrediction, PredictionMetadata, StructurePrediction
 if TYPE_CHECKING:
     from biotite.structure import AtomArray
 
+CA_ATOM37_INDEX = 1
+
 
 @dataclass
 class ESM2Output(EmbeddingPrediction):
@@ -48,9 +50,9 @@ class ESMFoldOutput(StructurePrediction):
     atom37_atom_exists: np.ndarray | None = None  # (batch_size, residue, atom=37)
     residue_index: np.ndarray | None = None  # (batch_size, residue)
     lddt_head: np.ndarray | None = None  # (model_layer, batch_size, residue, atom=37, 50) ??
-    plddt: np.ndarray | None = None  # (batch_size, residue, atom=37)
+    plddt: list[np.ndarray | None] | None = None  # one unit-scale (residue,) array per sample
     ptm_logits: np.ndarray | None = None  # (batch_size, residue, residue, 64) ???
-    ptm: np.ndarray | None = None  # float # TODO: make it into a float when sending to the client
+    ptm: list[np.ndarray | None] | None = None  # one shape-(1,) array per sample
     aligned_confidence_probs: np.ndarray | None = None  # (batch_size, residue, residue, 64)
     pae: np.ndarray | None = None  # (batch_size, residue, residue)
     max_pae: np.ndarray | None = None  # float # TODO: make it into a float when sending to the client
@@ -61,3 +63,51 @@ class ESMFoldOutput(StructurePrediction):
     # TODO: can add a save method here (to a pickle and a pdb file) that can be run locally
     # TODO: add verification of the outputs, and primarily the shape of all the arrays
     # (see test_esmfold_batch_multimer_linkers for the exact batched shapes)
+
+    def __post_init__(self) -> None:
+        """Normalize confidence metrics to the public output contract."""
+        self.plddt = _normalize_esmfold_plddt(self.plddt, self.metadata.sequence_lengths)
+        if self.ptm is not None:
+            ptm = np.asarray(self.ptm, dtype=np.float32).reshape(-1)
+            self.ptm = [np.array([score], dtype=np.float32) for score in ptm]
+
+
+def _normalize_esmfold_plddt(
+    values: np.ndarray | list[np.ndarray | None] | None,
+    sequence_lengths: list[int] | None,
+) -> list[np.ndarray | None] | None:
+    if values is None:
+        return None
+
+    if isinstance(values, list):
+        samples = [_normalize_esmfold_plddt_sample(sample) if sample is not None else None for sample in values]
+        return samples if any(sample is not None for sample in samples) else None
+
+    plddt = np.asarray(values, dtype=np.float32)
+    if plddt.ndim == 3:
+        plddt = plddt[:, :, CA_ATOM37_INDEX]
+    elif plddt.ndim == 1:
+        plddt = plddt[None, :]
+    if plddt.ndim != 2:
+        raise ValueError(f"ESMFold pLDDT expected shape (batch, residue); got {plddt.shape}")
+
+    if plddt.size and np.nanmax(plddt) > 1.0:
+        plddt = plddt / 100.0
+
+    lengths = sequence_lengths or [plddt.shape[1]] * plddt.shape[0]
+    if len(lengths) != plddt.shape[0]:
+        raise ValueError(f"ESMFold pLDDT batch size {plddt.shape[0]} does not match sequence lengths {len(lengths)}")
+    return [plddt[index, :length].astype(np.float32, copy=False) for index, length in enumerate(lengths)]
+
+
+def _normalize_esmfold_plddt_sample(sample: np.ndarray) -> np.ndarray:
+    plddt = np.asarray(sample, dtype=np.float32)
+    if plddt.ndim == 2 and plddt.shape[-1] == 37:
+        plddt = plddt[:, CA_ATOM37_INDEX]
+    while plddt.ndim > 1 and plddt.shape[0] == 1:
+        plddt = plddt[0]
+    if plddt.ndim != 1:
+        raise ValueError(f"ESMFold pLDDT expected a 1D array; got {plddt.shape}")
+    if plddt.size and np.nanmax(plddt) > 1.0:
+        plddt = plddt / 100.0
+    return plddt.astype(np.float32, copy=False)

--- a/boileroom/models/registry.py
+++ b/boileroom/models/registry.py
@@ -167,7 +167,7 @@ BOLTZ2_SPEC = ModelSpec(
             }
         ),
         minimal_output_fields=("metadata", "atom_array"),
-        optional_output_fields=("confidence", "plddt", "pae", "pde", "pdb", "cif"),
+        optional_output_fields=("confidence", "plddt", "ptm", "iptm", "pae", "pde", "pdb", "cif"),
         supports_multimer=True,
     ),
 )

--- a/docs/models.md
+++ b/docs/models.md
@@ -21,6 +21,11 @@ result.pae
 
 ```
 
+Structure-wrapper confidence metrics use a shared output contract. `plddt` is returned as one unit-scale
+per-residue array on `[0, 1]` per sample, while scalar scores such as `ptm` and `iptm` are shape-`(1,)` arrays.
+In `0.3.1`, this replaces ESMFold's old padded pLDDT batch array and moves Boltz `ptm`/`iptm` from nested
+`confidence` dictionaries to top-level fields.
+
 ### ESM-2
 - A fresh `ESM2` instance starts on the backbone-only fast path and automatically switches to an internal masked-LM variant when `include_fields` requests `lm_logits` or `["*"]`; after that first upgrade, the instance keeps the MLM-capable model resident for later calls.
 - Inline `<mask>` tokens are supported directly in sequence strings for both monomers and multimers, and returned logits stay aligned to the residue axis rather than raw tokenizer positions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "hatchling.build"
 [project]
 name = "boileroom"
 # Release automation treats this as the current stable target. Main-branch
-# image builds publish prerelease tags such as 0.3.0-alpha.1 from it.
-version = "0.3.0"
+# image builds publish prerelease tags such as 0.3.1-alpha.1 from it.
+version = "0.3.1"
 authors = [
     { name="Jakub Lála", email="jakublala@gmail.com" },
     { name="Michael Krása", email="michael.krasa@gmail.com" },

--- a/tests/boltz/test_boltz2.py
+++ b/tests/boltz/test_boltz2.py
@@ -591,6 +591,8 @@ def test_boltz2_fold_preserves_per_sample_alignment_for_optional_outputs(monkeyp
         {
             "sample_atom_coords": np.array([[4.0, 5.0, 6.0]], dtype=np.float32),
             "confidence_score": 0.9,
+            "ptm": 0.7,
+            "iptm": np.asarray(0.5, dtype=np.float32),
             "plddt": sample_plddt,
             "pae": sample_pae,
         },
@@ -601,6 +603,12 @@ def test_boltz2_fold_preserves_per_sample_alignment_for_optional_outputs(monkeyp
 
     assert out.atom_array == ["atom-0", "atom-1"]
     assert out.confidence == [None, {"confidence_score": 0.9}]
+    assert out.ptm is not None
+    assert out.ptm[0] is None
+    np.testing.assert_allclose(out.ptm[1], np.array([0.7], dtype=np.float32))
+    assert out.iptm is not None
+    assert out.iptm[0] is None
+    np.testing.assert_allclose(out.iptm[1], np.array([0.5], dtype=np.float32))
     assert out.plddt is not None
     assert out.plddt[0] is None
     assert np.array_equal(out.plddt[1], sample_plddt)

--- a/tests/chai/test_chai1.py
+++ b/tests/chai/test_chai1.py
@@ -124,7 +124,7 @@ def test_chai1_full_output(chai1_model: Chai1):
     assert plddt.shape == (len(nipah_virus_sequence),)
     assert np.all(np.isfinite(plddt)), "pLDDT values should be finite"
     assert np.all(plddt >= 0), "pLDDT scores should be non-negative"
-    assert np.all(plddt <= 100), "pLDDT scores should be less than or equal to 100"
+    assert np.all(plddt <= 1), "pLDDT scores should be less than or equal to 1"
 
     assert result.cif is not None and len(result.cif) > 0, "CIF string should be returned when requested"
     predicted_cif_structure = get_structure(CIFFile.read(StringIO(result.cif[0])), model=1)
@@ -144,6 +144,8 @@ def test_chai1_full_output(chai1_model: Chai1):
     iptm = _scalar(result.iptm[0])
     per_chain_iptm = np.atleast_1d(np.asarray(result.per_chain_iptm[0], dtype=float))
 
+    assert np.asarray(result.ptm[0]).shape == (1,), "ptm should be a shape-(1,) array"
+    assert np.asarray(result.iptm[0]).shape == (1,), "iptm should be a shape-(1,) array"
     assert 0.0 <= ptm <= 1.0, "ptm should be a probability-like score"
     assert 0.0 <= iptm <= 1.0, "iptm should be a probability-like score"
     assert np.all(np.isfinite(per_chain_iptm)), "per_chain_iptm values should be finite"

--- a/tests/contracts/test_confidence_metrics.py
+++ b/tests/contracts/test_confidence_metrics.py
@@ -1,0 +1,90 @@
+"""Contract tests for normalized confidence metric outputs."""
+
+from dataclasses import replace
+
+import numpy as np
+
+from boileroom.base import PredictionMetadata
+from boileroom.models.boltz.types import Boltz2Output
+from boileroom.models.chai.types import Chai1Output
+from boileroom.models.esm.types import ESMFoldOutput
+
+
+def _metadata(model_name: str = "test", sequence_lengths: list[int] | None = None) -> PredictionMetadata:
+    return PredictionMetadata(model_name=model_name, model_version="test", sequence_lengths=sequence_lengths or [3])
+
+
+def test_esmfold_confidence_metrics_are_per_sample_unit_scale_arrays() -> None:
+    """ESMFold should expose per-residue pLDDT and scalar pTM in consumer-friendly shapes."""
+    raw_plddt = np.zeros((2, 3, 37), dtype=np.float32)
+    raw_plddt[0, :, 1] = np.array([10.0, 50.0, 100.0], dtype=np.float32)
+    raw_plddt[1, :, 1] = np.array([25.0, 75.0, 90.0], dtype=np.float32)
+
+    output = ESMFoldOutput(
+        metadata=_metadata("ESMFold", [3, 1]),
+        atom_array=[object(), object()],
+        plddt=raw_plddt,
+        ptm=np.array([0.7, 0.8], dtype=np.float32),
+    )
+
+    assert output.plddt is not None
+    assert len(output.plddt) == 2
+    np.testing.assert_allclose(output.plddt[0], np.array([0.1, 0.5, 1.0], dtype=np.float32))
+    np.testing.assert_allclose(output.plddt[1], np.array([0.25], dtype=np.float32))
+
+    replaced = replace(output)
+    assert replaced.plddt is not None
+    np.testing.assert_allclose(replaced.plddt[1], np.array([0.25], dtype=np.float32))
+
+    assert output.ptm is not None
+    assert [score.shape for score in output.ptm if score is not None] == [(1,), (1,)]
+    np.testing.assert_allclose(output.ptm[0], np.array([0.7], dtype=np.float32))
+    np.testing.assert_allclose(output.ptm[1], np.array([0.8], dtype=np.float32))
+
+
+def test_chai_confidence_metrics_are_per_sample_unit_scale_arrays() -> None:
+    """Chai-1 should normalize percent pLDDT and scalar pTM/iPTM arrays."""
+    output = Chai1Output(
+        metadata=_metadata("Chai-1"),
+        atom_array=[object()],
+        plddt=[np.array([50.0], dtype=np.float32)],
+        ptm=[np.asarray(0.6, dtype=np.float32)],
+        iptm=[np.asarray(0.4, dtype=np.float32)],
+    )
+
+    assert output.plddt is not None
+    np.testing.assert_allclose(output.plddt[0], np.array([0.5], dtype=np.float32))
+    assert output.ptm is not None and output.ptm[0] is not None
+    assert output.iptm is not None and output.iptm[0] is not None
+    assert output.ptm[0].shape == (1,)
+    assert output.iptm[0].shape == (1,)
+    np.testing.assert_allclose(output.ptm[0], np.array([0.6], dtype=np.float32))
+    np.testing.assert_allclose(output.iptm[0], np.array([0.4], dtype=np.float32))
+
+
+def test_boltz_confidence_metrics_are_top_level_and_unit_scale() -> None:
+    """Boltz-2 should lift pTM/iPTM out of nested confidence dictionaries."""
+    output = Boltz2Output(
+        metadata=_metadata("Boltz-2"),
+        atom_array=[object(), object()],
+        confidence=[
+            {"confidence_score": 0.9, "ptm": 0.7, "iptm": np.asarray(0.5, dtype=np.float32)},
+            None,
+        ],
+        plddt=[np.array([0.2], dtype=np.float32), None],
+    )
+
+    assert output.plddt is not None
+    np.testing.assert_allclose(output.plddt[0], np.array([0.2], dtype=np.float32))
+    assert output.plddt[1] is None
+
+    assert output.ptm is not None and output.ptm[0] is not None
+    assert output.iptm is not None and output.iptm[0] is not None
+    assert output.ptm[0].shape == (1,)
+    assert output.iptm[0].shape == (1,)
+    assert output.ptm[1] is None
+    assert output.iptm[1] is None
+    np.testing.assert_allclose(output.ptm[0], np.array([0.7], dtype=np.float32))
+    np.testing.assert_allclose(output.iptm[0], np.array([0.5], dtype=np.float32))
+
+    assert output.confidence == [{"confidence_score": 0.9}, None]

--- a/tests/contracts/test_derive_version.py
+++ b/tests/contracts/test_derive_version.py
@@ -18,7 +18,7 @@ def test_main_version_uses_commit_count_after_baseline(monkeypatch) -> None:
 
     monkeypatch.setattr(derive_version, "run_git", fake_run_git)
 
-    assert derive_version.main_version() == "0.3.0-alpha.7"
+    assert derive_version.main_version() == "0.3.1-alpha.7"
 
 
 def test_main_version_counts_from_latest_stable_release_tag(monkeypatch) -> None:

--- a/tests/esm/test_esmfold.py
+++ b/tests/esm/test_esmfold.py
@@ -69,8 +69,10 @@ def test_esmfold_full_output(
     assert isinstance(result, ESMFoldOutput), "Result should be an ESMFoldOutput"
 
     assert result.plddt is not None, "plddt should be present in full output"
-    assert np.all(result.plddt >= 0), "pLDDT scores should be non-negative"
-    assert np.all(result.plddt <= 100), "pLDDT scores should be less than or equal to 100"
+    plddt = np.asarray(result.plddt[0], dtype=float)
+    assert plddt.ndim == 1, "pLDDT should be a per-residue vector"
+    assert np.all(plddt >= 0), "pLDDT scores should be non-negative"
+    assert np.all(plddt <= 1), "pLDDT scores should be less than or equal to 1"
 
 
 def test_esmfold_multimer(test_sequences, backend_option: str, device_option: str | None, output_ctx):
@@ -118,7 +120,9 @@ def test_esmfold_multimer(test_sequences, backend_option: str, device_option: st
     assert result.lm_logits is not None, "lm_logits should be generated"
     assert result.lddt_head is not None, "lddt_head should be generated"
     assert result.pae.shape == (1, n_residues, n_residues), "PAE matrix shape mismatch"
-    assert result.plddt.shape == (1, n_residues, 37), "pLDDT matrix shape mismatch"
+    assert len(result.plddt) == 1, "pLDDT batch size mismatch"
+    assert result.plddt[0] is not None
+    assert result.plddt[0].shape == (n_residues,), "pLDDT vector shape mismatch"
     assert result.ptm_logits.shape == (1, n_residues, n_residues, 64), "pTM matrix shape mismatch"
     assert result.aligned_confidence_probs.shape == (1, n_residues, n_residues, 64), "aligned confidence shape mismatch"
     assert result.s_z.shape == (1, n_residues, n_residues, 128), "s_z matrix shape mismatch"
@@ -126,7 +130,7 @@ def test_esmfold_multimer(test_sequences, backend_option: str, device_option: st
     assert result.distogram_logits.shape == (1, n_residues, n_residues, 64), "distogram logits matrix shape mismatch"
     assert result.lm_logits.shape == (1, n_residues, 23), "lm logits matrix shape mismatch"
     assert result.lddt_head.shape == (8, 1, n_residues, 37, 50), "lddt head matrix shape mismatch"
-    assert result.plddt.shape == (1, n_residues, 37), "pLDDT matrix shape mismatch"
+    assert result.plddt[0].shape == (n_residues,), "pLDDT vector shape mismatch"
 
 
 def test_esmfold_linker_map():
@@ -226,7 +230,10 @@ def test_esmfold_batch(
     assert result.ptm_logits is not None, "ptm_logits should be present in full output"
     assert result.pae is not None, "pae should be present in full output"
     assert result.aatype.shape[0] == len(sequences), "Batch size mismatch in aatype"
-    assert result.plddt.shape[0] == len(sequences), "Batch size mismatch in plddt"
+    assert len(result.plddt) == len(sequences), "Batch size mismatch in plddt"
+    assert [sample.shape for sample in result.plddt if sample is not None] == [
+        (len(sequence),) for sequence in sequences
+    ], "pLDDT samples should be trimmed to input sequence lengths"
     assert result.ptm_logits.shape[0] == len(sequences), "Batch size mismatch in ptm_logits"
     assert result.pae.shape[0] == len(sequences), "Batch size mismatch in pae"
 

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "boileroom"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "biotite" },


### PR DESCRIPTION
## Summary
- Normalize structure-wrapper `plddt` outputs to unit-scale 1D per-sample arrays.
- Trim ESMFold public `plddt` samples to true sequence lengths while keeping raw padded tensors internal until atom-array/PDB/CIF conversion.
- Normalize scalar `ptm`/`iptm` outputs to top-level shape-`(1,)` arrays, including lifting Boltz scores out of nested `confidence`.
- Keep this scoped to confidence outputs and bump the package target to `0.3.1`.

Closes #100

## Validation
- `uv run pytest tests/contracts/test_confidence_metrics.py tests/boltz/test_boltz2.py::test_boltz2_fold_preserves_per_sample_alignment_for_optional_outputs`
- `uv run pytest -m "not integration"`
- `uv run --extra dev pre-commit run --all-files`