### PR TITLE
fix: route ESM-2 position_ids by default

### DIFF
--- a/boileroom/models/esm/core.py
+++ b/boileroom/models/esm/core.py
@@ -29,25 +29,24 @@ logger = logging.getLogger(__name__)
 
 
 @dataclasses.dataclass(frozen=True)
-class _PositionIdsCompatState:
-    """Per-call state for position-id compatibility mode."""
+class _PositionIdsRoutingState:
+    """Per-call state for explicit ESM position-id routing."""
 
-    enabled: bool
-    position_ids: torch.Tensor | None = None
+    position_ids: torch.Tensor
     attention_mask: torch.Tensor | None = None
 
 
-_POSITION_IDS_COMPAT_STATE: ContextVar[_PositionIdsCompatState | None] = ContextVar(
-    "boileroom_esm_position_ids_compat", default=None
+_POSITION_IDS_ROUTING_STATE: ContextVar[_PositionIdsRoutingState | None] = ContextVar(
+    "boileroom_esm_position_ids_routing", default=None
 )
-_POSITION_IDS_COMPAT_PATCHES_INSTALLED = False
-_POSITION_IDS_COMPAT_WARNING_EMITTED = False
+_POSITION_IDS_ROUTING_PATCHES_INSTALLED = False
+_POSITION_IDS_ROUTING_WARNING_EMITTED = False
 
 
-def _position_ids_compat_state() -> _PositionIdsCompatState | None:
-    """Return the current position-id compatibility state, if active."""
+def _position_ids_routing_state() -> _PositionIdsRoutingState | None:
+    """Return the current explicit position-id routing state, if active."""
 
-    return _POSITION_IDS_COMPAT_STATE.get()
+    return _POSITION_IDS_ROUTING_STATE.get()
 
 
 def _is_default_arange_position_ids(position_ids: torch.Tensor) -> bool:
@@ -74,27 +73,25 @@ def _is_default_arange_position_ids(position_ids: torch.Tensor) -> bool:
 
 
 @contextmanager
-def _position_ids_compat_context(
-    enabled: bool,
+def _position_ids_routing_context(
     position_ids: torch.Tensor | None,
     attention_mask: torch.Tensor | None,
 ):
-    """Scope position-id compatibility context for a single inference call."""
+    """Scope explicit position-id routing for a single inference call."""
 
-    if not enabled:
+    if position_ids is None:
         yield
         return
 
-    state = _PositionIdsCompatState(
-        enabled=enabled,
-        position_ids=None if position_ids is None else position_ids,
+    state = _PositionIdsRoutingState(
+        position_ids=position_ids,
         attention_mask=None if attention_mask is None else attention_mask,
     )
-    token = _POSITION_IDS_COMPAT_STATE.set(state)
+    token = _POSITION_IDS_ROUTING_STATE.set(state)
     try:
         yield
     finally:
-        _POSITION_IDS_COMPAT_STATE.reset(token)
+        _POSITION_IDS_ROUTING_STATE.reset(token)
 
 
 def _maybe_build_position_ids_rotary_cache(
@@ -108,15 +105,15 @@ def _maybe_build_position_ids_rotary_cache(
         return None
 
     if position_ids.shape[0] != k.shape[0] or position_ids.shape[1] != k.shape[-2]:
-        global _POSITION_IDS_COMPAT_WARNING_EMITTED
-        if not _POSITION_IDS_COMPAT_WARNING_EMITTED:
+        global _POSITION_IDS_ROUTING_WARNING_EMITTED
+        if not _POSITION_IDS_ROUTING_WARNING_EMITTED:
             logger.warning(
-                "ESM position-id compatibility disabled for rotary embedding due to incompatible shape: "
+                "ESM position-id routing disabled for rotary embedding due to shape mismatch: "
                 "position_ids=%s, key_shape=%s",
                 tuple(position_ids.shape),
                 tuple(k.shape),
             )
-            _POSITION_IDS_COMPAT_WARNING_EMITTED = True
+            _POSITION_IDS_ROUTING_WARNING_EMITTED = True
         return None
 
     if not torch.is_floating_point(position_ids):
@@ -147,12 +144,10 @@ def _maybe_build_position_ids_rotary_cache(
 
 def _compute_esmfold_position_ids(
     esmaa: torch.Tensor,
-    state: _PositionIdsCompatState,
+    state: _PositionIdsRoutingState,
 ) -> torch.Tensor | None:
     """Build LM stem position ids for ESMFold from wrapped context state."""
 
-    if state.position_ids is None:
-        return None
     position_ids = state.position_ids
     if not torch.is_floating_point(position_ids):
         position_ids = position_ids.to(dtype=torch.long)
@@ -183,54 +178,63 @@ def _compute_esmfold_position_ids(
     return None
 
 
-def _install_esm_position_ids_compat_patches() -> None:
-    """Install guarded compatibility patches into Transformer ESM internals."""
+def _install_esm_position_ids_routing_patches() -> None:
+    """Install guarded position-id routing patches into Transformer ESM internals."""
 
-    global _POSITION_IDS_COMPAT_PATCHES_INSTALLED
-    if _POSITION_IDS_COMPAT_PATCHES_INSTALLED:
+    global _POSITION_IDS_ROUTING_PATCHES_INSTALLED
+    if _POSITION_IDS_ROUTING_PATCHES_INSTALLED:
         return
 
     try:
         from transformers.models.esm import modeling_esm, modeling_esmfold
     except (ImportError, ModuleNotFoundError):
-        logger.debug("Skipping ESM position-id compatibility patch: transformers not importable at import-time.")
+        logger.debug("Skipping ESM position-id routing patch: transformers not importable at import-time.")
         return
 
-    # ESM rotary compatibility layer
-    rotary_forward_sig = inspect.signature(modeling_esm.RotaryEmbedding.forward)
-    if len(rotary_forward_sig.parameters) == 3:
-        original_forward = modeling_esm.RotaryEmbedding.forward
-
-        if not hasattr(original_forward, "__wrapped__"):
-
-            def compat_rotary_forward(self: Any, q: torch.Tensor, k: torch.Tensor):
-                state = _position_ids_compat_state()
-                if state is None or not state.enabled or state.position_ids is None:
-                    return original_forward(self, q, k)
-
-                cache = _maybe_build_position_ids_rotary_cache(self, k, state.position_ids.to(device=k.device))
-                if cache is None:
-                    return original_forward(self, q, k)
-
-                cos, sin = cache
-                from transformers.models.esm.modeling_esm import apply_rotary_pos_emb
-
-                return (
-                    apply_rotary_pos_emb(q, cos, sin).to(dtype=q.dtype),
-                    apply_rotary_pos_emb(k, cos, sin).to(dtype=k.dtype),
-                )
-
-            compat_rotary_forward.__name__ = "position_ids_compat_forward"
-            modeling_esm.RotaryEmbedding._position_ids_compat_original_forward = original_forward
-            modeling_esm.RotaryEmbedding.forward = compat_rotary_forward
+    # ESM rotary layer position-id routing.
+    rotary_embedding_cls = getattr(modeling_esm, "RotaryEmbedding", None) or getattr(
+        modeling_esm, "EsmRotaryEmbedding", None
+    )
+    if rotary_embedding_cls is None:
+        logger.warning("Skipping ESM rotary position-id routing patch: rotary embedding class is unavailable.")
     else:
-        logger.warning(
-            "Skipping ESM rotary compatibility patch: signature mismatch for "
-            "transformers.models.esm.RotaryEmbedding.forward: %s",
-            rotary_forward_sig,
-        )
+        rotary_forward_sig = inspect.signature(rotary_embedding_cls.forward)
+        if len(rotary_forward_sig.parameters) == 3:
+            original_forward = rotary_embedding_cls.forward
 
-    # ESMFold LM stem compatibility layer
+            if not hasattr(original_forward, "__wrapped__"):
+
+                def position_ids_rotary_forward(self: Any, q: torch.Tensor, k: torch.Tensor):
+                    state = _position_ids_routing_state()
+                    if state is None:
+                        return original_forward(self, q, k)
+
+                    cache = _maybe_build_position_ids_rotary_cache(self, k, state.position_ids.to(device=k.device))
+                    if cache is None:
+                        return original_forward(self, q, k)
+
+                    cos, sin = cache
+                    from transformers.models.esm.modeling_esm import apply_rotary_pos_emb
+
+                    return (
+                        apply_rotary_pos_emb(q, cos, sin).to(dtype=q.dtype),
+                        apply_rotary_pos_emb(k, cos, sin).to(dtype=k.dtype),
+                    )
+
+                position_ids_rotary_forward.__name__ = "position_ids_routing_forward"
+                position_ids_rotary_forward.__wrapped__ = original_forward
+                rotary_embedding_cls._position_ids_routing_original_forward = original_forward
+                rotary_embedding_cls.forward = position_ids_rotary_forward
+        elif "position_ids" in rotary_forward_sig.parameters:
+            logger.debug("Skipping ESM rotary position-id routing patch: native rotary embedding accepts position_ids.")
+        else:
+            logger.warning(
+                "Skipping ESM rotary position-id routing patch: signature mismatch for %s.forward: %s",
+                rotary_embedding_cls.__name__,
+                rotary_forward_sig,
+            )
+
+    # ESMFold LM stem position-id routing.
     compute_lm_sig = inspect.signature(modeling_esmfold.EsmForProteinFolding.compute_language_model_representations)
     if len(compute_lm_sig.parameters) == 2:
         original_compute_language_model_representations = (
@@ -239,9 +243,9 @@ def _install_esm_position_ids_compat_patches() -> None:
 
         if not hasattr(original_compute_language_model_representations, "__wrapped__"):
 
-            def compat_compute_language_model_representations(self: Any, esmaa: torch.Tensor):
-                state = _position_ids_compat_state()
-                if state is None or not state.enabled or state.position_ids is None:
+            def position_ids_compute_language_model_representations(self: Any, esmaa: torch.Tensor):
+                state = _position_ids_routing_state()
+                if state is None:
                     return original_compute_language_model_representations(self, esmaa)
 
                 position_ids = _compute_esmfold_position_ids(esmaa, state)
@@ -259,7 +263,7 @@ def _install_esm_position_ids_compat_patches() -> None:
                 esmaa = torch.cat([bos, esmaa, eos], dim=1)
                 esmaa[range(B), (esmaa != 1).sum(1)] = eosi
 
-                # position_ids is passed to the stem when compatibility mode is active.
+                # Route explicit multimer position ids into the LM stem.
                 esm_hidden_states = self.esm(
                     esmaa,
                     attention_mask=esmaa != 1,
@@ -270,22 +274,27 @@ def _install_esm_position_ids_compat_patches() -> None:
                 esm_s = esm_s[:, 1:-1]  # B, L, nLayers, C
                 return esm_s
 
-            compat_compute_language_model_representations.__name__ = (
-                "position_ids_compat_compute_language_model_representations"
+            position_ids_compute_language_model_representations.__name__ = (
+                "position_ids_routing_compute_language_model_representations"
             )
-            modeling_esmfold.EsmForProteinFolding._position_ids_compat_original_compute_language_model_representations = original_compute_language_model_representations
+            position_ids_compute_language_model_representations.__wrapped__ = (
+                original_compute_language_model_representations
+            )
+            modeling_esmfold.EsmForProteinFolding._position_ids_routing_original_compute_language_model_representations = (
+                original_compute_language_model_representations
+            )
             modeling_esmfold.EsmForProteinFolding.compute_language_model_representations = (
-                compat_compute_language_model_representations
+                position_ids_compute_language_model_representations
             )
 
     else:
         logger.warning(
-            "Skipping ESMFold compatibility patch: signature mismatch for "
+            "Skipping ESMFold position-id routing patch: signature mismatch for "
             "transformers.models.esmfold.EsmForProteinFolding.compute_language_model_representations: %s",
             compute_lm_sig,
         )
 
-    _POSITION_IDS_COMPAT_PATCHES_INSTALLED = True
+    _POSITION_IDS_ROUTING_PATCHES_INSTALLED = True
 
 
 ############################################################
@@ -363,7 +372,7 @@ def always_no_grad_forward(self, seq_feats, pair_feats, true_aa, residx, mask, n
 EsmFoldingTrunk.forward = always_no_grad_forward
 
 
-_install_esm_position_ids_compat_patches()
+_install_esm_position_ids_routing_patches()
 
 
 class ESM2Core(EmbeddingAlgorithm):
@@ -376,7 +385,6 @@ class ESM2Core(EmbeddingAlgorithm):
         # Chain linking and positioning config
         "glycine_linker": "",
         "position_ids_skip": 512,
-        "enable_position_ids_compat": False,
     }
     # Static config keys that can only be set at initialization
     STATIC_CONFIG_KEYS: ClassVar[frozenset[str]] = frozenset({"device", "model_name"})
@@ -502,9 +510,9 @@ class ESM2Core(EmbeddingAlgorithm):
             A single protein sequence string or an iterable of sequence strings. Sequence strings may contain one-letter residues, inline ``<mask>`` tokens, and optional ``:`` chain separators for multimers.
         options : dict | None, optional
             Per-call configuration that is merged with the core config; can control glycine_linker, position_ids_skip,
-            `enable_position_ids_compat`, `include_fields`, and other runtime options. Request `include_fields=["lm_logits"]`
-            for full-vocabulary masked-language-model logits or `include_fields=["hidden_states", "lm_logits"]` / `["*"]` to
-            return both optional outputs.
+            `include_fields`, and other runtime options. Request `include_fields=["lm_logits"]` for full-vocabulary
+            masked-language-model logits or `include_fields=["hidden_states", "lm_logits"]` / `["*"]` to return both
+            optional outputs.
 
         Returns
         -------
@@ -566,8 +574,7 @@ class ESM2Core(EmbeddingAlgorithm):
         with (
             Timer("Model Inference") as inference_timer,
             torch.inference_mode(),
-            _position_ids_compat_context(
-                bool(effective_config["enable_position_ids_compat"]),
+            _position_ids_routing_context(
                 tokenized.get("position_ids"),
                 tokenized.get("attention_mask"),
             ),
@@ -837,7 +844,6 @@ class ESMFoldCore(FoldingAlgorithm):
         # Chain linking and positioning config
         "glycine_linker": "",
         "position_ids_skip": 512,
-        "enable_position_ids_compat": False,
         "include_fields": None,  # Optional[List[str]] - controls which fields to include in output
     }
     # Static config keys that can only be set at initialization
@@ -900,7 +906,7 @@ class ESMFoldCore(FoldingAlgorithm):
             A single amino acid sequence or an iterable of sequences to predict.
         options : dict, optional
             Per-call configuration merged with the instance's static config (for example, `include_fields` to select which output
-            fields to return, or `enable_position_ids_compat` to route multimer `position_ids` through LM rotary embeddings).
+            fields to return).
 
         Returns
         -------
@@ -927,8 +933,7 @@ class ESMFoldCore(FoldingAlgorithm):
         with (
             Timer("Model Inference") as inference_timer,
             torch.inference_mode(),
-            _position_ids_compat_context(
-                bool(effective_config["enable_position_ids_compat"]),
+            _position_ids_routing_context(
                 tokenized_input.get("position_ids"),
                 tokenized_input.get("attention_mask"),
             ),

--- a/boileroom/models/esm/core.py
+++ b/boileroom/models/esm/core.py
@@ -3,7 +3,10 @@
 import dataclasses
 import logging
 import os
+import inspect
 from collections.abc import Sequence
+from contextlib import contextmanager
+from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 import numpy as np
@@ -23,6 +26,268 @@ from .parsing import ESMSequenceTokens, parse_esm2_sequences
 from .types import ESM2Output, ESMFoldOutput, _normalize_esmfold_plddt
 
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class _PositionIdsCompatState:
+    """Per-call state for position-id compatibility mode."""
+
+    enabled: bool
+    position_ids: torch.Tensor | None = None
+    attention_mask: torch.Tensor | None = None
+
+
+_POSITION_IDS_COMPAT_STATE: ContextVar[_PositionIdsCompatState | None] = ContextVar(
+    "boileroom_esm_position_ids_compat", default=None
+)
+_POSITION_IDS_COMPAT_PATCHES_INSTALLED = False
+_POSITION_IDS_COMPAT_WARNING_EMITTED = False
+
+
+def _position_ids_compat_state() -> _PositionIdsCompatState | None:
+    """Return the current position-id compatibility state, if active."""
+
+    return _POSITION_IDS_COMPAT_STATE.get()
+
+
+def _is_default_arange_position_ids(position_ids: torch.Tensor) -> bool:
+    """Return ``True`` when ``position_ids`` is equivalent to ``arange`` per row."""
+
+    if position_ids.ndim != 2:
+        return False
+    position_ids = position_ids.to(dtype=torch.long)
+
+    for row in position_ids:
+        non_zero_idx = torch.nonzero(row, as_tuple=False).view(-1)
+        if non_zero_idx.numel() == 0:
+            continue
+
+        last_non_zero = int(non_zero_idx[-1].item()) + 1
+        prefix = row[:last_non_zero]
+        if not torch.all(prefix == torch.arange(last_non_zero, device=row.device, dtype=row.dtype)):
+            return False
+
+        if last_non_zero < row.shape[0] and torch.any(row[last_non_zero:] != 0):
+            return False
+
+    return True
+
+
+@contextmanager
+def _position_ids_compat_context(
+    enabled: bool,
+    position_ids: torch.Tensor | None,
+    attention_mask: torch.Tensor | None,
+):
+    """Scope position-id compatibility context for a single inference call."""
+
+    if not enabled:
+        yield
+        return
+
+    state = _PositionIdsCompatState(
+        enabled=enabled,
+        position_ids=None if position_ids is None else position_ids,
+        attention_mask=None if attention_mask is None else attention_mask,
+    )
+    token = _POSITION_IDS_COMPAT_STATE.set(state)
+    try:
+        yield
+    finally:
+        _POSITION_IDS_COMPAT_STATE.reset(token)
+
+
+def _maybe_build_position_ids_rotary_cache(
+    rotary_embedding: Any,
+    k: torch.Tensor,
+    position_ids: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Build custom RoPE caches from ``position_ids`` when available."""
+
+    if _is_default_arange_position_ids(position_ids):
+        return None
+
+    if position_ids.shape[0] != k.shape[0] or position_ids.shape[1] != k.shape[-2]:
+        global _POSITION_IDS_COMPAT_WARNING_EMITTED
+        if not _POSITION_IDS_COMPAT_WARNING_EMITTED:
+            logger.warning(
+                "ESM position-id compatibility disabled for rotary embedding due to incompatible shape: "
+                "position_ids=%s, key_shape=%s",
+                tuple(position_ids.shape),
+                tuple(k.shape),
+            )
+            _POSITION_IDS_COMPAT_WARNING_EMITTED = True
+        return None
+
+    if not torch.is_floating_point(position_ids):
+        position_ids = position_ids.to(dtype=torch.long)
+    if position_ids.device != k.device:
+        position_ids = position_ids.to(device=k.device)
+
+    seq_len = k.shape[-2]
+    if seq_len <= 0:
+        return None
+
+    max_position = int(torch.max(position_ids).item()) + 1
+    max_position = max(max_position, seq_len)
+    t = torch.arange(max_position, device=k.device, dtype=rotary_embedding.inv_freq.dtype)
+    freqs = torch.outer(t, rotary_embedding.inv_freq.to(dtype=rotary_embedding.inv_freq.dtype, device=k.device))
+    emb = torch.cat((freqs, freqs), dim=-1)
+
+    cos = emb.cos()[None, :, :]
+    sin = emb.sin()[None, :, :]
+
+    indices = position_ids.reshape(-1).clamp(min=0, max=cos.shape[1] - 1).to(torch.long)
+    batch, _seq_len = position_ids.shape
+
+    cos = cos.index_select(1, indices).reshape(batch, _seq_len, -1).unsqueeze(1)
+    sin = sin.index_select(1, indices).reshape(batch, _seq_len, -1).unsqueeze(1)
+    return cos, sin
+
+
+def _compute_esmfold_position_ids(
+    esmaa: torch.Tensor,
+    state: _PositionIdsCompatState,
+) -> torch.Tensor | None:
+    """Build LM stem position ids for ESMFold from wrapped context state."""
+
+    if state.position_ids is None:
+        return None
+    position_ids = state.position_ids
+    if not torch.is_floating_point(position_ids):
+        position_ids = position_ids.to(dtype=torch.long)
+
+    if position_ids.device != esmaa.device:
+        position_ids = position_ids.to(device=esmaa.device)
+
+    if _is_default_arange_position_ids(position_ids):
+        return None
+
+    if position_ids.shape[0] != esmaa.shape[0]:
+        return None
+
+    if position_ids.shape[1] == esmaa.shape[1]:
+        return position_ids
+
+    if position_ids.shape[1] == esmaa.shape[1] - 2:
+        if state.attention_mask is not None and state.attention_mask.shape == position_ids.shape:
+            attention_mask = state.attention_mask.to(device=esmaa.device)
+            lengths = attention_mask.sum(dim=1).to(torch.long).clamp(min=1)
+            eos_position = position_ids.gather(1, (lengths - 1).unsqueeze(1)) + 1
+        else:
+            eos_position = position_ids[:, -1:].clone() + 1
+
+        bos_position = position_ids[:, :1]
+        return torch.cat([bos_position, position_ids, eos_position], dim=1)
+
+    return None
+
+
+def _install_esm_position_ids_compat_patches() -> None:
+    """Install guarded compatibility patches into Transformer ESM internals."""
+
+    global _POSITION_IDS_COMPAT_PATCHES_INSTALLED
+    if _POSITION_IDS_COMPAT_PATCHES_INSTALLED:
+        return
+    _POSITION_IDS_COMPAT_PATCHES_INSTALLED = True
+
+    try:
+        from transformers.models.esm import modeling_esm
+        from transformers.models.esm import modeling_esmfold
+    except Exception:
+        logger.debug("Skipping ESM position-id compatibility patch: transformers not importable at import-time.")
+        return
+
+    # ESM rotary compatibility layer
+    rotary_forward_sig = inspect.signature(modeling_esm.RotaryEmbedding.forward)
+    if len(rotary_forward_sig.parameters) == 3:
+        original_forward = modeling_esm.RotaryEmbedding.forward
+
+        if not hasattr(original_forward, "__wrapped__"):
+
+            def compat_rotary_forward(self: Any, q: torch.Tensor, k: torch.Tensor):
+                state = _position_ids_compat_state()
+                if state is None or not state.enabled or state.position_ids is None:
+                    return original_forward(self, q, k)
+
+                cache = _maybe_build_position_ids_rotary_cache(self, k, state.position_ids.to(device=k.device))
+                if cache is None:
+                    return original_forward(self, q, k)
+
+                cos, sin = cache
+                from transformers.models.esm.modeling_esm import apply_rotary_pos_emb
+
+                return (
+                    apply_rotary_pos_emb(q, cos, sin).to(dtype=q.dtype),
+                    apply_rotary_pos_emb(k, cos, sin).to(dtype=k.dtype),
+                )
+
+            compat_rotary_forward.__name__ = "position_ids_compat_forward"
+            modeling_esm.RotaryEmbedding._position_ids_compat_original_forward = original_forward
+            modeling_esm.RotaryEmbedding.forward = compat_rotary_forward
+    else:
+        logger.warning(
+            "Skipping ESM rotary compatibility patch: signature mismatch for "
+            "transformers.models.esm.RotaryEmbedding.forward: %s",
+            rotary_forward_sig,
+        )
+
+    # ESMFold LM stem compatibility layer
+    compute_lm_sig = inspect.signature(modeling_esmfold.EsmForProteinFolding.compute_language_model_representations)
+    if len(compute_lm_sig.parameters) == 2:
+        original_compute_language_model_representations = (
+            modeling_esmfold.EsmForProteinFolding.compute_language_model_representations
+        )
+
+        if not hasattr(original_compute_language_model_representations, "__wrapped__"):
+
+            def compat_compute_language_model_representations(self: Any, esmaa: torch.Tensor):
+                state = _position_ids_compat_state()
+                if state is None or not state.enabled or state.position_ids is None:
+                    return original_compute_language_model_representations(self, esmaa)
+
+                position_ids = _compute_esmfold_position_ids(esmaa, state)
+                if position_ids is None:
+                    return original_compute_language_model_representations(self, esmaa)
+
+                device = next(self.parameters()).device
+                B, L = esmaa.shape  # B = batch size, L = sequence length.
+
+                if self.config.esmfold_config.bypass_lm:
+                    return torch.zeros(B, L, self.esm_s_combine.size[0], -1, self.esm_feats, device=device)
+
+                bosi, eosi = self.esm_dict_cls_idx, self.esm_dict_eos_idx
+                bos = esmaa.new_full((B, 1), bosi)
+                eos = esmaa.new_full((B, 1), self.esm_dict_padding_idx)
+                esmaa = torch.cat([bos, esmaa, eos], dim=1)
+                esmaa[range(B), (esmaa != 1).sum(1)] = eosi
+
+                # position_ids is passed to the stem when compatibility mode is active.
+                esm_hidden_states = self.esm(
+                    esmaa,
+                    attention_mask=esmaa != 1,
+                    position_ids=position_ids,
+                    output_hidden_states=True,
+                )["hidden_states"]
+                esm_s = torch.stack(esm_hidden_states, dim=2)
+                esm_s = esm_s[:, 1:-1]  # B, L, nLayers, C
+                return esm_s
+
+            compat_compute_language_model_representations.__name__ = (
+                "position_ids_compat_compute_language_model_representations"
+            )
+            modeling_esmfold.EsmForProteinFolding._position_ids_compat_original_compute_language_model_representations = (
+                original_compute_language_model_representations
+            )
+            modeling_esmfold.EsmForProteinFolding.compute_language_model_representations = (
+                compat_compute_language_model_representations
+            )
+    else:
+        logger.warning(
+            "Skipping ESMFold compatibility patch: signature mismatch for "
+            "transformers.models.esmfold.EsmForProteinFolding.compute_language_model_representations: %s",
+            compute_lm_sig,
+        )
 
 
 ############################################################
@@ -100,6 +365,9 @@ def always_no_grad_forward(self, seq_feats, pair_feats, true_aa, residx, mask, n
 EsmFoldingTrunk.forward = always_no_grad_forward
 
 
+_install_esm_position_ids_compat_patches()
+
+
 class ESM2Core(EmbeddingAlgorithm):
     """ESM2 protein language model."""
 
@@ -110,6 +378,7 @@ class ESM2Core(EmbeddingAlgorithm):
         # Chain linking and positioning config
         "glycine_linker": "",
         "position_ids_skip": 512,
+        "enable_position_ids_compat": False,
     }
     # Static config keys that can only be set at initialization
     STATIC_CONFIG_KEYS: ClassVar[frozenset[str]] = frozenset({"device", "model_name"})
@@ -234,7 +503,10 @@ class ESM2Core(EmbeddingAlgorithm):
         sequences : str | Sequence[str]
             A single protein sequence string or an iterable of sequence strings. Sequence strings may contain one-letter residues, inline ``<mask>`` tokens, and optional ``:`` chain separators for multimers.
         options : dict | None, optional
-            Per-call configuration that is merged with the core config; can control glycine_linker, position_ids_skip, `include_fields`, and other runtime options. Request `include_fields=["lm_logits"]` for full-vocabulary masked-language-model logits or `include_fields=["hidden_states", "lm_logits"]` / `["*"]` to return both optional outputs.
+            Per-call configuration that is merged with the core config; can control glycine_linker, position_ids_skip,
+            `enable_position_ids_compat`, `include_fields`, and other runtime options. Request `include_fields=["lm_logits"]`
+            for full-vocabulary masked-language-model logits or `include_fields=["hidden_states", "lm_logits"]` / `["*"]` to
+            return both optional outputs.
 
         Returns
         -------
@@ -293,7 +565,11 @@ class ESM2Core(EmbeddingAlgorithm):
             tokenized = tokenized.to(self._device)
             tokenized["output_hidden_states"] = compute_hidden_states
 
-        with Timer("Model Inference") as inference_timer, torch.inference_mode():
+        with Timer("Model Inference") as inference_timer, torch.inference_mode(), _position_ids_compat_context(
+            bool(effective_config["enable_position_ids_compat"]),
+            tokenized.get("position_ids"),
+            tokenized.get("attention_mask"),
+        ):
             if self._model_mode == "masked_lm":
                 masked_lm_model = cast(EsmForMaskedLM, self.model)
                 outputs = masked_lm_model.esm(**tokenized)
@@ -559,6 +835,7 @@ class ESMFoldCore(FoldingAlgorithm):
         # Chain linking and positioning config
         "glycine_linker": "",
         "position_ids_skip": 512,
+        "enable_position_ids_compat": False,
         "include_fields": None,  # Optional[List[str]] - controls which fields to include in output
     }
     # Static config keys that can only be set at initialization
@@ -620,7 +897,8 @@ class ESMFoldCore(FoldingAlgorithm):
         sequences : str | Sequence[str]
             A single amino acid sequence or an iterable of sequences to predict.
         options : dict, optional
-            Per-call configuration merged with the instance's static config (for example, `include_fields` to select which output fields to return).
+            Per-call configuration merged with the instance's static config (for example, `include_fields` to select which output
+            fields to return, or `enable_position_ids_compat` to route multimer `position_ids` through LM rotary embeddings).
 
         Returns
         -------
@@ -644,7 +922,11 @@ class ESMFoldCore(FoldingAlgorithm):
         with Timer("ESMFold preprocessing") as preprocess_timer:
             tokenized_input, multimer_properties = self._tokenize_sequences(validated_sequences, effective_config)
 
-        with Timer("Model Inference") as inference_timer, torch.inference_mode():
+        with Timer("Model Inference") as inference_timer, torch.inference_mode(), _position_ids_compat_context(
+            bool(effective_config["enable_position_ids_compat"]),
+            tokenized_input.get("position_ids"),
+            tokenized_input.get("attention_mask"),
+        ):
             outputs = self.model(**tokenized_input)
 
         with Timer("ESMFold postprocessing") as postprocess_timer:

--- a/boileroom/models/esm/core.py
+++ b/boileroom/models/esm/core.py
@@ -1,9 +1,9 @@
 """Core ESM2 and ESMFold algorithm implementations without modal dependencies."""
 
 import dataclasses
+import inspect
 import logging
 import os
-import inspect
 from collections.abc import Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -189,12 +189,10 @@ def _install_esm_position_ids_compat_patches() -> None:
     global _POSITION_IDS_COMPAT_PATCHES_INSTALLED
     if _POSITION_IDS_COMPAT_PATCHES_INSTALLED:
         return
-    _POSITION_IDS_COMPAT_PATCHES_INSTALLED = True
 
     try:
-        from transformers.models.esm import modeling_esm
-        from transformers.models.esm import modeling_esmfold
-    except Exception:
+        from transformers.models.esm import modeling_esm, modeling_esmfold
+    except (ImportError, ModuleNotFoundError):
         logger.debug("Skipping ESM position-id compatibility patch: transformers not importable at import-time.")
         return
 
@@ -250,11 +248,10 @@ def _install_esm_position_ids_compat_patches() -> None:
                 if position_ids is None:
                     return original_compute_language_model_representations(self, esmaa)
 
-                device = next(self.parameters()).device
                 B, L = esmaa.shape  # B = batch size, L = sequence length.
 
                 if self.config.esmfold_config.bypass_lm:
-                    return torch.zeros(B, L, self.esm_s_combine.size[0], -1, self.esm_feats, device=device)
+                    return original_compute_language_model_representations(self, esmaa)
 
                 bosi, eosi = self.esm_dict_cls_idx, self.esm_dict_eos_idx
                 bos = esmaa.new_full((B, 1), bosi)
@@ -276,18 +273,19 @@ def _install_esm_position_ids_compat_patches() -> None:
             compat_compute_language_model_representations.__name__ = (
                 "position_ids_compat_compute_language_model_representations"
             )
-            modeling_esmfold.EsmForProteinFolding._position_ids_compat_original_compute_language_model_representations = (
-                original_compute_language_model_representations
-            )
+            modeling_esmfold.EsmForProteinFolding._position_ids_compat_original_compute_language_model_representations = original_compute_language_model_representations
             modeling_esmfold.EsmForProteinFolding.compute_language_model_representations = (
                 compat_compute_language_model_representations
             )
+
     else:
         logger.warning(
             "Skipping ESMFold compatibility patch: signature mismatch for "
             "transformers.models.esmfold.EsmForProteinFolding.compute_language_model_representations: %s",
             compute_lm_sig,
         )
+
+    _POSITION_IDS_COMPAT_PATCHES_INSTALLED = True
 
 
 ############################################################
@@ -565,10 +563,14 @@ class ESM2Core(EmbeddingAlgorithm):
             tokenized = tokenized.to(self._device)
             tokenized["output_hidden_states"] = compute_hidden_states
 
-        with Timer("Model Inference") as inference_timer, torch.inference_mode(), _position_ids_compat_context(
-            bool(effective_config["enable_position_ids_compat"]),
-            tokenized.get("position_ids"),
-            tokenized.get("attention_mask"),
+        with (
+            Timer("Model Inference") as inference_timer,
+            torch.inference_mode(),
+            _position_ids_compat_context(
+                bool(effective_config["enable_position_ids_compat"]),
+                tokenized.get("position_ids"),
+                tokenized.get("attention_mask"),
+            ),
         ):
             if self._model_mode == "masked_lm":
                 masked_lm_model = cast(EsmForMaskedLM, self.model)
@@ -922,10 +924,14 @@ class ESMFoldCore(FoldingAlgorithm):
         with Timer("ESMFold preprocessing") as preprocess_timer:
             tokenized_input, multimer_properties = self._tokenize_sequences(validated_sequences, effective_config)
 
-        with Timer("Model Inference") as inference_timer, torch.inference_mode(), _position_ids_compat_context(
-            bool(effective_config["enable_position_ids_compat"]),
-            tokenized_input.get("position_ids"),
-            tokenized_input.get("attention_mask"),
+        with (
+            Timer("Model Inference") as inference_timer,
+            torch.inference_mode(),
+            _position_ids_compat_context(
+                bool(effective_config["enable_position_ids_compat"]),
+                tokenized_input.get("position_ids"),
+                tokenized_input.get("attention_mask"),
+            ),
         ):
             outputs = self.model(**tokenized_input)
 

--- a/boileroom/models/esm/core.py
+++ b/boileroom/models/esm/core.py
@@ -1,12 +1,9 @@
 """Core ESM2 and ESMFold algorithm implementations without modal dependencies."""
 
 import dataclasses
-import inspect
 import logging
 import os
 from collections.abc import Sequence
-from contextlib import contextmanager
-from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 import numpy as np
@@ -23,278 +20,10 @@ if TYPE_CHECKING:
 
 from .linker import compute_position_ids, replace_glycine_linkers, store_multimer_properties
 from .parsing import ESMSequenceTokens, parse_esm2_sequences
+from .position_routing import esm_position_ids_context, install_esm_position_ids_routing
 from .types import ESM2Output, ESMFoldOutput, _normalize_esmfold_plddt
 
 logger = logging.getLogger(__name__)
-
-
-@dataclasses.dataclass(frozen=True)
-class _PositionIdsRoutingState:
-    """Per-call state for explicit ESM position-id routing."""
-
-    position_ids: torch.Tensor
-    attention_mask: torch.Tensor | None = None
-
-
-_POSITION_IDS_ROUTING_STATE: ContextVar[_PositionIdsRoutingState | None] = ContextVar(
-    "boileroom_esm_position_ids_routing", default=None
-)
-_POSITION_IDS_ROUTING_PATCHES_INSTALLED = False
-_POSITION_IDS_ROUTING_WARNING_EMITTED = False
-
-
-def _position_ids_routing_state() -> _PositionIdsRoutingState | None:
-    """Return the current explicit position-id routing state, if active."""
-
-    return _POSITION_IDS_ROUTING_STATE.get()
-
-
-def _is_default_arange_position_ids(position_ids: torch.Tensor) -> bool:
-    """Return ``True`` when ``position_ids`` is equivalent to ``arange`` per row."""
-
-    if position_ids.ndim != 2:
-        return False
-    position_ids = position_ids.to(dtype=torch.long)
-
-    for row in position_ids:
-        non_zero_idx = torch.nonzero(row, as_tuple=False).view(-1)
-        if non_zero_idx.numel() == 0:
-            continue
-
-        last_non_zero = int(non_zero_idx[-1].item()) + 1
-        prefix = row[:last_non_zero]
-        if not torch.all(prefix == torch.arange(last_non_zero, device=row.device, dtype=row.dtype)):
-            return False
-
-        if last_non_zero < row.shape[0] and torch.any(row[last_non_zero:] != 0):
-            return False
-
-    return True
-
-
-@contextmanager
-def _position_ids_routing_context(
-    position_ids: torch.Tensor | None,
-    attention_mask: torch.Tensor | None,
-):
-    """Scope explicit position-id routing for a single inference call."""
-
-    if position_ids is None:
-        yield
-        return
-
-    state = _PositionIdsRoutingState(
-        position_ids=position_ids,
-        attention_mask=None if attention_mask is None else attention_mask,
-    )
-    token = _POSITION_IDS_ROUTING_STATE.set(state)
-    try:
-        yield
-    finally:
-        _POSITION_IDS_ROUTING_STATE.reset(token)
-
-
-def _maybe_build_position_ids_rotary_cache(
-    rotary_embedding: Any,
-    k: torch.Tensor,
-    position_ids: torch.Tensor,
-) -> tuple[torch.Tensor, torch.Tensor] | None:
-    """Build custom RoPE caches from ``position_ids`` when available."""
-
-    if _is_default_arange_position_ids(position_ids):
-        return None
-
-    if position_ids.shape[0] != k.shape[0] or position_ids.shape[1] != k.shape[-2]:
-        global _POSITION_IDS_ROUTING_WARNING_EMITTED
-        if not _POSITION_IDS_ROUTING_WARNING_EMITTED:
-            logger.warning(
-                "ESM position-id routing disabled for rotary embedding due to shape mismatch: "
-                "position_ids=%s, key_shape=%s",
-                tuple(position_ids.shape),
-                tuple(k.shape),
-            )
-            _POSITION_IDS_ROUTING_WARNING_EMITTED = True
-        return None
-
-    if not torch.is_floating_point(position_ids):
-        position_ids = position_ids.to(dtype=torch.long)
-    if position_ids.device != k.device:
-        position_ids = position_ids.to(device=k.device)
-
-    seq_len = k.shape[-2]
-    if seq_len <= 0:
-        return None
-
-    max_position = int(torch.max(position_ids).item()) + 1
-    max_position = max(max_position, seq_len)
-    t = torch.arange(max_position, device=k.device, dtype=rotary_embedding.inv_freq.dtype)
-    freqs = torch.outer(t, rotary_embedding.inv_freq.to(dtype=rotary_embedding.inv_freq.dtype, device=k.device))
-    emb = torch.cat((freqs, freqs), dim=-1)
-
-    cos = emb.cos()[None, :, :]
-    sin = emb.sin()[None, :, :]
-
-    indices = position_ids.reshape(-1).clamp(min=0, max=cos.shape[1] - 1).to(torch.long)
-    batch, _seq_len = position_ids.shape
-
-    cos = cos.index_select(1, indices).reshape(batch, _seq_len, -1).unsqueeze(1)
-    sin = sin.index_select(1, indices).reshape(batch, _seq_len, -1).unsqueeze(1)
-    return cos, sin
-
-
-def _compute_esmfold_position_ids(
-    esmaa: torch.Tensor,
-    state: _PositionIdsRoutingState,
-) -> torch.Tensor | None:
-    """Build LM stem position ids for ESMFold from wrapped context state."""
-
-    position_ids = state.position_ids
-    if not torch.is_floating_point(position_ids):
-        position_ids = position_ids.to(dtype=torch.long)
-
-    if position_ids.device != esmaa.device:
-        position_ids = position_ids.to(device=esmaa.device)
-
-    if _is_default_arange_position_ids(position_ids):
-        return None
-
-    if position_ids.shape[0] != esmaa.shape[0]:
-        return None
-
-    if position_ids.shape[1] == esmaa.shape[1]:
-        return position_ids
-
-    if position_ids.shape[1] == esmaa.shape[1] - 2:
-        if state.attention_mask is not None and state.attention_mask.shape == position_ids.shape:
-            attention_mask = state.attention_mask.to(device=esmaa.device)
-            lengths = attention_mask.sum(dim=1).to(torch.long).clamp(min=1)
-            eos_position = position_ids.gather(1, (lengths - 1).unsqueeze(1)) + 1
-        else:
-            eos_position = position_ids[:, -1:].clone() + 1
-
-        bos_position = position_ids[:, :1]
-        return torch.cat([bos_position, position_ids, eos_position], dim=1)
-
-    return None
-
-
-def _install_esm_position_ids_routing_patches() -> None:
-    """Install guarded position-id routing patches into Transformer ESM internals."""
-
-    global _POSITION_IDS_ROUTING_PATCHES_INSTALLED
-    if _POSITION_IDS_ROUTING_PATCHES_INSTALLED:
-        return
-
-    try:
-        from transformers.models.esm import modeling_esm, modeling_esmfold
-    except (ImportError, ModuleNotFoundError):
-        logger.debug("Skipping ESM position-id routing patch: transformers not importable at import-time.")
-        return
-
-    # ESM rotary layer position-id routing.
-    rotary_embedding_cls = getattr(modeling_esm, "RotaryEmbedding", None) or getattr(
-        modeling_esm, "EsmRotaryEmbedding", None
-    )
-    if rotary_embedding_cls is None:
-        logger.warning("Skipping ESM rotary position-id routing patch: rotary embedding class is unavailable.")
-    else:
-        rotary_forward_sig = inspect.signature(rotary_embedding_cls.forward)
-        if len(rotary_forward_sig.parameters) == 3:
-            original_forward = rotary_embedding_cls.forward
-
-            if not hasattr(original_forward, "__wrapped__"):
-
-                def position_ids_rotary_forward(self: Any, q: torch.Tensor, k: torch.Tensor):
-                    state = _position_ids_routing_state()
-                    if state is None:
-                        return original_forward(self, q, k)
-
-                    cache = _maybe_build_position_ids_rotary_cache(self, k, state.position_ids.to(device=k.device))
-                    if cache is None:
-                        return original_forward(self, q, k)
-
-                    cos, sin = cache
-                    from transformers.models.esm.modeling_esm import apply_rotary_pos_emb
-
-                    return (
-                        apply_rotary_pos_emb(q, cos, sin).to(dtype=q.dtype),
-                        apply_rotary_pos_emb(k, cos, sin).to(dtype=k.dtype),
-                    )
-
-                position_ids_rotary_forward.__name__ = "position_ids_routing_forward"
-                position_ids_rotary_forward.__wrapped__ = original_forward
-                rotary_embedding_cls._position_ids_routing_original_forward = original_forward
-                rotary_embedding_cls.forward = position_ids_rotary_forward
-        elif "position_ids" in rotary_forward_sig.parameters:
-            logger.debug("Skipping ESM rotary position-id routing patch: native rotary embedding accepts position_ids.")
-        else:
-            logger.warning(
-                "Skipping ESM rotary position-id routing patch: signature mismatch for %s.forward: %s",
-                rotary_embedding_cls.__name__,
-                rotary_forward_sig,
-            )
-
-    # ESMFold LM stem position-id routing.
-    compute_lm_sig = inspect.signature(modeling_esmfold.EsmForProteinFolding.compute_language_model_representations)
-    if len(compute_lm_sig.parameters) == 2:
-        original_compute_language_model_representations = (
-            modeling_esmfold.EsmForProteinFolding.compute_language_model_representations
-        )
-
-        if not hasattr(original_compute_language_model_representations, "__wrapped__"):
-
-            def position_ids_compute_language_model_representations(self: Any, esmaa: torch.Tensor):
-                state = _position_ids_routing_state()
-                if state is None:
-                    return original_compute_language_model_representations(self, esmaa)
-
-                position_ids = _compute_esmfold_position_ids(esmaa, state)
-                if position_ids is None:
-                    return original_compute_language_model_representations(self, esmaa)
-
-                B, L = esmaa.shape  # B = batch size, L = sequence length.
-
-                if self.config.esmfold_config.bypass_lm:
-                    return original_compute_language_model_representations(self, esmaa)
-
-                bosi, eosi = self.esm_dict_cls_idx, self.esm_dict_eos_idx
-                bos = esmaa.new_full((B, 1), bosi)
-                eos = esmaa.new_full((B, 1), self.esm_dict_padding_idx)
-                esmaa = torch.cat([bos, esmaa, eos], dim=1)
-                esmaa[range(B), (esmaa != 1).sum(1)] = eosi
-
-                # Route explicit multimer position ids into the LM stem.
-                esm_hidden_states = self.esm(
-                    esmaa,
-                    attention_mask=esmaa != 1,
-                    position_ids=position_ids,
-                    output_hidden_states=True,
-                )["hidden_states"]
-                esm_s = torch.stack(esm_hidden_states, dim=2)
-                esm_s = esm_s[:, 1:-1]  # B, L, nLayers, C
-                return esm_s
-
-            position_ids_compute_language_model_representations.__name__ = (
-                "position_ids_routing_compute_language_model_representations"
-            )
-            position_ids_compute_language_model_representations.__wrapped__ = (
-                original_compute_language_model_representations
-            )
-            modeling_esmfold.EsmForProteinFolding._position_ids_routing_original_compute_language_model_representations = (
-                original_compute_language_model_representations
-            )
-            modeling_esmfold.EsmForProteinFolding.compute_language_model_representations = (
-                position_ids_compute_language_model_representations
-            )
-
-    else:
-        logger.warning(
-            "Skipping ESMFold position-id routing patch: signature mismatch for "
-            "transformers.models.esmfold.EsmForProteinFolding.compute_language_model_representations: %s",
-            compute_lm_sig,
-        )
-
-    _POSITION_IDS_ROUTING_PATCHES_INSTALLED = True
 
 
 ############################################################
@@ -372,7 +101,7 @@ def always_no_grad_forward(self, seq_feats, pair_feats, true_aa, residx, mask, n
 EsmFoldingTrunk.forward = always_no_grad_forward
 
 
-_install_esm_position_ids_routing_patches()
+install_esm_position_ids_routing()
 
 
 class ESM2Core(EmbeddingAlgorithm):
@@ -574,10 +303,7 @@ class ESM2Core(EmbeddingAlgorithm):
         with (
             Timer("Model Inference") as inference_timer,
             torch.inference_mode(),
-            _position_ids_routing_context(
-                tokenized.get("position_ids"),
-                tokenized.get("attention_mask"),
-            ),
+            esm_position_ids_context(tokenized.get("position_ids")),
         ):
             if self._model_mode == "masked_lm":
                 masked_lm_model = cast(EsmForMaskedLM, self.model)
@@ -930,14 +656,7 @@ class ESMFoldCore(FoldingAlgorithm):
         with Timer("ESMFold preprocessing") as preprocess_timer:
             tokenized_input, multimer_properties = self._tokenize_sequences(validated_sequences, effective_config)
 
-        with (
-            Timer("Model Inference") as inference_timer,
-            torch.inference_mode(),
-            _position_ids_routing_context(
-                tokenized_input.get("position_ids"),
-                tokenized_input.get("attention_mask"),
-            ),
-        ):
+        with Timer("Model Inference") as inference_timer, torch.inference_mode():
             outputs = self.model(**tokenized_input)
 
         with Timer("ESMFold postprocessing") as postprocess_timer:

--- a/boileroom/models/esm/position_routing.py
+++ b/boileroom/models/esm/position_routing.py
@@ -1,0 +1,177 @@
+"""ESM-2 position-id routing for HuggingFace rotary embeddings."""
+
+import dataclasses
+import inspect
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Any
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class _PositionIdsRoutingState:
+    """Per-call state for explicit ESM-2 position-id routing."""
+
+    position_ids: torch.Tensor
+
+
+_POSITION_IDS_ROUTING_STATE: ContextVar[_PositionIdsRoutingState | None] = ContextVar(
+    "boileroom_esm_position_ids_routing", default=None
+)
+_POSITION_IDS_ROUTING_PATCHES_INSTALLED = False
+_POSITION_IDS_ROUTING_WARNING_EMITTED = False
+
+
+def _position_ids_routing_state() -> _PositionIdsRoutingState | None:
+    """Return the current explicit position-id routing state, if active."""
+
+    return _POSITION_IDS_ROUTING_STATE.get()
+
+
+def _is_default_arange_position_ids(position_ids: torch.Tensor) -> bool:
+    """Return ``True`` when ``position_ids`` is equivalent to ``arange`` per row."""
+
+    if position_ids.ndim != 2:
+        return False
+    position_ids = position_ids.to(dtype=torch.long)
+
+    for row in position_ids:
+        non_zero_idx = torch.nonzero(row, as_tuple=False).view(-1)
+        if non_zero_idx.numel() == 0:
+            continue
+
+        last_non_zero = int(non_zero_idx[-1].item()) + 1
+        prefix = row[:last_non_zero]
+        if not torch.all(prefix == torch.arange(last_non_zero, device=row.device, dtype=row.dtype)):
+            return False
+
+        if last_non_zero < row.shape[0] and torch.any(row[last_non_zero:] != 0):
+            return False
+
+    return True
+
+
+@contextmanager
+def esm_position_ids_context(position_ids: torch.Tensor | None):
+    """Route explicit ESM-2 position ids for a single inference call."""
+
+    if position_ids is None:
+        yield
+        return
+
+    token = _POSITION_IDS_ROUTING_STATE.set(_PositionIdsRoutingState(position_ids=position_ids))
+    try:
+        yield
+    finally:
+        _POSITION_IDS_ROUTING_STATE.reset(token)
+
+
+def _maybe_build_position_ids_rotary_cache(
+    rotary_embedding: Any,
+    k: torch.Tensor,
+    position_ids: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor] | None:
+    """Build custom RoPE caches from ``position_ids`` when available."""
+
+    if _is_default_arange_position_ids(position_ids):
+        return None
+
+    if position_ids.shape[0] != k.shape[0] or position_ids.shape[1] != k.shape[-2]:
+        global _POSITION_IDS_ROUTING_WARNING_EMITTED
+        if not _POSITION_IDS_ROUTING_WARNING_EMITTED:
+            logger.warning(
+                "ESM position-id routing disabled for rotary embedding due to shape mismatch: "
+                "position_ids=%s, key_shape=%s",
+                tuple(position_ids.shape),
+                tuple(k.shape),
+            )
+            _POSITION_IDS_ROUTING_WARNING_EMITTED = True
+        return None
+
+    if not torch.is_floating_point(position_ids):
+        position_ids = position_ids.to(dtype=torch.long)
+    if position_ids.device != k.device:
+        position_ids = position_ids.to(device=k.device)
+
+    seq_len = k.shape[-2]
+    if seq_len <= 0:
+        return None
+
+    max_position = int(torch.max(position_ids).item()) + 1
+    max_position = max(max_position, seq_len)
+    t = torch.arange(max_position, device=k.device, dtype=rotary_embedding.inv_freq.dtype)
+    freqs = torch.outer(t, rotary_embedding.inv_freq.to(device=k.device))
+    emb = torch.cat((freqs, freqs), dim=-1)
+
+    cos = emb.cos()[None, :, :]
+    sin = emb.sin()[None, :, :]
+
+    indices = position_ids.reshape(-1).clamp(min=0, max=cos.shape[1] - 1).to(torch.long)
+    batch, _seq_len = position_ids.shape
+
+    cos = cos.index_select(1, indices).reshape(batch, _seq_len, -1).unsqueeze(1)
+    sin = sin.index_select(1, indices).reshape(batch, _seq_len, -1).unsqueeze(1)
+    return cos, sin
+
+
+def install_esm_position_ids_routing() -> None:
+    """Install guarded position-id routing into Transformer ESM-2 rotary embeddings."""
+
+    global _POSITION_IDS_ROUTING_PATCHES_INSTALLED
+    if _POSITION_IDS_ROUTING_PATCHES_INSTALLED:
+        return
+
+    try:
+        from transformers.models.esm import modeling_esm
+    except (ImportError, ModuleNotFoundError):
+        logger.debug("Skipping ESM position-id routing patch: transformers not importable at import-time.")
+        return
+
+    rotary_embedding_cls = getattr(modeling_esm, "RotaryEmbedding", None) or getattr(
+        modeling_esm, "EsmRotaryEmbedding", None
+    )
+    if rotary_embedding_cls is None:
+        logger.warning("Skipping ESM rotary position-id routing patch: rotary embedding class is unavailable.")
+        return
+
+    rotary_forward_sig = inspect.signature(rotary_embedding_cls.forward)
+    if len(rotary_forward_sig.parameters) == 3:
+        original_forward = rotary_embedding_cls.forward
+
+        if not hasattr(original_forward, "__wrapped__"):
+
+            def position_ids_rotary_forward(self: Any, q: torch.Tensor, k: torch.Tensor):
+                state = _position_ids_routing_state()
+                if state is None:
+                    return original_forward(self, q, k)
+
+                cache = _maybe_build_position_ids_rotary_cache(self, k, state.position_ids.to(device=k.device))
+                if cache is None:
+                    return original_forward(self, q, k)
+
+                cos, sin = cache
+                from transformers.models.esm.modeling_esm import apply_rotary_pos_emb
+
+                return (
+                    apply_rotary_pos_emb(q, cos, sin).to(dtype=q.dtype),
+                    apply_rotary_pos_emb(k, cos, sin).to(dtype=k.dtype),
+                )
+
+            position_ids_rotary_forward.__name__ = "position_ids_routing_forward"
+            position_ids_rotary_forward.__wrapped__ = original_forward
+            rotary_embedding_cls._position_ids_routing_original_forward = original_forward
+            rotary_embedding_cls.forward = position_ids_rotary_forward
+    elif "position_ids" in rotary_forward_sig.parameters:
+        logger.debug("Skipping ESM rotary position-id routing patch: native rotary embedding accepts position_ids.")
+    else:
+        logger.warning(
+            "Skipping ESM rotary position-id routing patch: signature mismatch for %s.forward: %s",
+            rotary_embedding_cls.__name__,
+            rotary_forward_sig,
+        )
+
+    _POSITION_IDS_ROUTING_PATCHES_INSTALLED = True

--- a/boileroom/models/esm/position_routing.py
+++ b/boileroom/models/esm/position_routing.py
@@ -92,10 +92,8 @@ def _maybe_build_position_ids_rotary_cache(
             _POSITION_IDS_ROUTING_WARNING_EMITTED = True
         return None
 
-    if not torch.is_floating_point(position_ids):
-        position_ids = position_ids.to(dtype=torch.long)
-    if position_ids.device != k.device:
-        position_ids = position_ids.to(device=k.device)
+    if position_ids.device != k.device or position_ids.dtype != torch.long:
+        position_ids = position_ids.to(device=k.device, dtype=torch.long)
 
     seq_len = k.shape[-2]
     if seq_len <= 0:

--- a/boileroom/models/esm/position_routing.py
+++ b/boileroom/models/esm/position_routing.py
@@ -1,4 +1,18 @@
-"""ESM-2 position-id routing for HuggingFace rotary embeddings."""
+"""Route Boileroom's ESM-2 multimer ``position_ids`` into rotary embeddings.
+
+HuggingFace's ESM-2 model accepts ``position_ids`` at the model-call boundary,
+but older Transformer releases do not pass those ids down into the rotary
+embedding helper. The helper instead rebuilds contiguous token positions from
+the query/key tensor shape. That is fine for ordinary monomers, but it erases
+Boileroom's deliberate multimer position gaps, so ``position_ids_skip`` changes
+the bookkeeping tensors while the attention layers still see vanilla contiguous
+rotary positions.
+
+This module installs a narrow ESM-2 patch that keeps the public model call the
+same while routing the current call's explicit ``position_ids`` into RoPE cache
+construction. Default arange-style ids fall back to the native Transformer path;
+non-contiguous multimer ids use the patched cache by default.
+"""
 
 import dataclasses
 import inspect
@@ -117,7 +131,14 @@ def _maybe_build_position_ids_rotary_cache(
 
 
 def install_esm_position_ids_routing() -> None:
-    """Install guarded position-id routing into Transformer ESM-2 rotary embeddings."""
+    """Install default ESM-2 RoPE routing for explicit multimer position ids.
+
+    The patch is intentionally scoped to Transformer ESM rotary embedding
+    classes whose ``forward`` method still takes only ``q`` and ``k``. Newer
+    Transformer versions that natively accept ``position_ids`` are left
+    untouched. This makes the corrected multimer behavior the default while
+    avoiding a compatibility flag or a fork of the surrounding ESM-2 model code.
+    """
 
     global _POSITION_IDS_ROUTING_PATCHES_INSTALLED
     if _POSITION_IDS_ROUTING_PATCHES_INSTALLED:

--- a/boileroom/models/esm/position_routing.py
+++ b/boileroom/models/esm/position_routing.py
@@ -5,7 +5,7 @@ import inspect
 import logging
 from contextlib import contextmanager
 from contextvars import ContextVar
-from typing import Any
+from typing import Any, cast
 
 import torch
 
@@ -160,8 +160,8 @@ def install_esm_position_ids_routing() -> None:
                 )
 
             position_ids_rotary_forward.__name__ = "position_ids_routing_forward"
-            position_ids_rotary_forward.__wrapped__ = original_forward
-            rotary_embedding_cls._position_ids_routing_original_forward = original_forward
+            cast(Any, position_ids_rotary_forward).__wrapped__ = original_forward
+            cast(Any, rotary_embedding_cls)._position_ids_routing_original_forward = original_forward
             rotary_embedding_cls.forward = position_ids_rotary_forward
     elif "position_ids" in rotary_forward_sig.parameters:
         logger.debug("Skipping ESM rotary position-id routing patch: native rotary embedding accepts position_ids.")

--- a/tests/esm/test_esm2.py
+++ b/tests/esm/test_esm2.py
@@ -241,16 +241,6 @@ def test_esm2_embed_with_hidden_states_and_lm_logits(esm2_model_factory):
     del model
 
 
-def test_esm2_position_ids_are_not_user_configurable():
-    """Position-id routing is the default multimer behavior, not a user-facing flag."""
-    pytest.importorskip("transformers", reason="requires transformers")
-    from boileroom.models.esm.core import ESM2Core
-
-    core = ESM2Core(config={"device": "cpu", "model_name": "esm2_t6_8M_UR50D"})
-    assert "enable_position_ids_compat" not in core.DEFAULT_CONFIG
-    assert "enable_position_ids_compat" not in core.config
-
-
 def test_esm2_arange_position_ids_match_monomer_outputs(esm2_model_factory, mocker):
     """Arange-equivalent multimer ids match equivalent monomer outputs."""
     pytest.importorskip("transformers", reason="requires transformers")

--- a/tests/esm/test_esm2.py
+++ b/tests/esm/test_esm2.py
@@ -1,7 +1,9 @@
 import numpy as np
 import pytest
+import torch
 
 from boileroom import ESM2
+from boileroom.models.esm.parsing import parse_esm2_sequences
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.gpu, pytest.mark.xdist_group("esm2")]
 
@@ -57,6 +59,26 @@ def esm2_model_factory(backend_option: str, gpu_device: str | None, device_optio
         return ESM2(backend=backend_option, device=device, config=config)
 
     return _make_model
+
+
+def _make_arange_position_ids(sequences, glycine_linker: str, add_special_tokens: bool) -> torch.Tensor:
+    parsed_sequences = parse_esm2_sequences(sequences)
+    lengths = []
+    for parsed_sequence in parsed_sequences:
+        base_length = sum(len(chain.tokens) for chain in parsed_sequence.chains)
+        base_length += max(len(parsed_sequence.chains) - 1, 0) * len(glycine_linker)
+        if add_special_tokens:
+            base_length += 2
+        lengths.append(base_length)
+
+    max_length = max(lengths)
+    position_ids = []
+    for length in lengths:
+        row = torch.arange(length, dtype=torch.long)
+        if length < max_length:
+            row = torch.cat([row, torch.zeros(max_length - length, dtype=torch.long)])
+        position_ids.append(row)
+    return torch.stack(position_ids, dim=0)
 
 
 @pytest.mark.parametrize(
@@ -199,6 +221,56 @@ def test_esm2_embed_with_hidden_states_and_lm_logits(esm2_model_factory):
     assert result.lm_logits is not None
     assert result.lm_logits.shape == (1, len(sequence), 33)
     del model
+
+
+def test_esm2_position_ids_compat_default_is_false():
+    """The compatibility flag must remain opt-in by default."""
+    pytest.importorskip("transformers", reason="requires transformers")
+    from boileroom.models.esm.core import ESM2Core
+
+    core = ESM2Core(config={"device": "cpu", "model_name": "esm2_t6_8M_UR50D"})
+    assert core.config["enable_position_ids_compat"] is False
+
+
+def test_esm2_position_ids_compat_arange_is_noop(esm2_model_factory, mocker):
+    """When callers provide arange-compatible ids, compatibility mode keeps outputs unchanged."""
+    pytest.importorskip("transformers", reason="requires transformers")
+    from boileroom.models.esm import core as esm_core
+
+    mocker.patch.object(
+        esm_core,
+        "compute_position_ids",
+        side_effect=lambda sequences, glycine_linker, position_ids_skip, add_special_tokens=False: _make_arange_position_ids(
+            sequences, glycine_linker, add_special_tokens
+        ),
+    )
+
+    model = esm2_model_factory(model_name="esm2_t6_8M_UR50D", include_fields=["hidden_states"])
+    sequence = "AC:DEFG"
+
+    result_without = model.embed([sequence], options={"enable_position_ids_compat": False})
+    result_with = model.embed([sequence], options={"enable_position_ids_compat": True})
+
+    assert np.array_equal(result_without.embeddings, result_with.embeddings)
+    assert np.array_equal(result_without.hidden_states, result_with.hidden_states)
+
+
+def test_esm2_position_ids_compat_skip_change(esm2_model_factory):
+    """Compatibility mode wires custom multimer position ids for non-default skips."""
+    sequence = "AC:DEFG"
+    model = esm2_model_factory(
+        model_name="esm2_t6_8M_UR50D", include_fields=["hidden_states"], enable_position_ids_compat=True
+    )
+
+    result_skip0 = model.embed([sequence], options={"enable_position_ids_compat": True, "position_ids_skip": 0})
+    result_skip1024 = model.embed(
+        [sequence], options={"enable_position_ids_compat": True, "position_ids_skip": 1024}
+    )
+
+    max_diff = np.max(np.abs(result_skip0.embeddings - result_skip1024.embeddings))
+    assert max_diff > 0.0
+    max_hidden_diff = np.max(np.abs(result_skip0.hidden_states - result_skip1024.hidden_states))
+    assert max_hidden_diff > 0.0
 
 
 def test_esm2_embed_with_all_optional_fields(esm2_model_factory):

--- a/tests/esm/test_esm2.py
+++ b/tests/esm/test_esm2.py
@@ -1,11 +1,8 @@
-from collections.abc import Sequence
-
 import numpy as np
 import pytest
 import torch
 
 from boileroom import ESM2
-from boileroom.models.esm.parsing import parse_esm2_sequences
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.gpu, pytest.mark.xdist_group("esm2")]
 
@@ -61,42 +58,6 @@ def esm2_model_factory(backend_option: str, gpu_device: str | None, device_optio
         return ESM2(backend=backend_option, device=device, config=config)
 
     return _make_model
-
-
-def _make_arange_position_ids(sequences: Sequence[str], glycine_linker: str, add_special_tokens: bool) -> torch.Tensor:
-    """Return padded arange-style position ids for each parsed sequence input.
-
-    Parameters
-    ----------
-    sequences : Sequence[str]
-        Input sequences passed to ``parse_esm2_sequences``.
-    glycine_linker : str
-        Linker inserted when replacing chain separators.
-    add_special_tokens : bool
-        Whether tokenizer special tokens are accounted for in the position count.
-
-    Returns
-    -------
-    torch.Tensor
-        Padded position-id tensor with shape ``(batch, max_length)``.
-    """
-    parsed_sequences = parse_esm2_sequences(sequences)
-    lengths = []
-    for parsed_sequence in parsed_sequences:
-        base_length = sum(len(chain.tokens) for chain in parsed_sequence.chains)
-        base_length += max(len(parsed_sequence.chains) - 1, 0) * len(glycine_linker)
-        if add_special_tokens:
-            base_length += 2
-        lengths.append(base_length)
-
-    max_length = max(lengths)
-    position_ids = []
-    for length in lengths:
-        row = torch.arange(length, dtype=torch.long)
-        if length < max_length:
-            row = torch.cat([row, torch.zeros(max_length - length, dtype=torch.long)])
-        position_ids.append(row)
-    return torch.stack(position_ids, dim=0)
 
 
 @pytest.mark.parametrize(
@@ -239,31 +200,6 @@ def test_esm2_embed_with_hidden_states_and_lm_logits(esm2_model_factory):
     assert result.lm_logits is not None
     assert result.lm_logits.shape == (1, len(sequence), 33)
     del model
-
-
-def test_esm2_arange_position_ids_match_monomer_outputs(esm2_model_factory, mocker):
-    """Arange-equivalent multimer ids match equivalent monomer outputs."""
-    pytest.importorskip("transformers", reason="requires transformers")
-    from boileroom.models.esm import core as esm_core
-
-    mocker.patch.object(
-        esm_core,
-        "compute_position_ids",
-        side_effect=lambda sequences,
-        glycine_linker,
-        position_ids_skip,
-        add_special_tokens=False: _make_arange_position_ids(sequences, glycine_linker, add_special_tokens),
-    )
-
-    model = esm2_model_factory(model_name="esm2_t6_8M_UR50D", include_fields=["hidden_states"])
-    monomer_sequence = "ACDEFG"
-    multimer_sequence = "AC:DEFG"
-
-    result_monomer = model.embed([monomer_sequence])
-    result_multimer = model.embed([multimer_sequence], options={"glycine_linker": ""})
-
-    assert np.array_equal(result_monomer.embeddings, result_multimer.embeddings)
-    assert np.array_equal(result_monomer.hidden_states, result_multimer.hidden_states)
 
 
 def test_esm2_position_id_skip_changes_embeddings(esm2_model_factory):

--- a/tests/esm/test_esm2.py
+++ b/tests/esm/test_esm2.py
@@ -241,17 +241,18 @@ def test_esm2_embed_with_hidden_states_and_lm_logits(esm2_model_factory):
     del model
 
 
-def test_esm2_position_ids_compat_default_is_false():
-    """The compatibility flag must remain opt-in by default."""
+def test_esm2_position_ids_are_not_user_configurable():
+    """Position-id routing is the default multimer behavior, not a user-facing flag."""
     pytest.importorskip("transformers", reason="requires transformers")
     from boileroom.models.esm.core import ESM2Core
 
     core = ESM2Core(config={"device": "cpu", "model_name": "esm2_t6_8M_UR50D"})
-    assert core.config["enable_position_ids_compat"] is False
+    assert "enable_position_ids_compat" not in core.DEFAULT_CONFIG
+    assert "enable_position_ids_compat" not in core.config
 
 
-def test_esm2_position_ids_compat_arange_is_noop(esm2_model_factory, mocker):
-    """When callers provide arange-compatible ids, compatibility mode keeps outputs unchanged."""
+def test_esm2_arange_position_ids_match_monomer_outputs(esm2_model_factory, mocker):
+    """Arange-equivalent multimer ids match equivalent monomer outputs."""
     pytest.importorskip("transformers", reason="requires transformers")
     from boileroom.models.esm import core as esm_core
 
@@ -265,24 +266,23 @@ def test_esm2_position_ids_compat_arange_is_noop(esm2_model_factory, mocker):
     )
 
     model = esm2_model_factory(model_name="esm2_t6_8M_UR50D", include_fields=["hidden_states"])
+    monomer_sequence = "ACDEFG"
+    multimer_sequence = "AC:DEFG"
+
+    result_monomer = model.embed([monomer_sequence])
+    result_multimer = model.embed([multimer_sequence], options={"glycine_linker": ""})
+
+    assert np.array_equal(result_monomer.embeddings, result_multimer.embeddings)
+    assert np.array_equal(result_monomer.hidden_states, result_multimer.hidden_states)
+
+
+def test_esm2_position_id_skip_changes_embeddings(esm2_model_factory):
+    """Custom multimer position skips are wired into rotary embeddings by default."""
     sequence = "AC:DEFG"
+    model = esm2_model_factory(model_name="esm2_t6_8M_UR50D", include_fields=["hidden_states"])
 
-    result_without = model.embed([sequence], options={"enable_position_ids_compat": False})
-    result_with = model.embed([sequence], options={"enable_position_ids_compat": True})
-
-    assert np.array_equal(result_without.embeddings, result_with.embeddings)
-    assert np.array_equal(result_without.hidden_states, result_with.hidden_states)
-
-
-def test_esm2_position_ids_compat_skip_change(esm2_model_factory):
-    """Compatibility mode wires custom multimer position ids for non-default skips."""
-    sequence = "AC:DEFG"
-    model = esm2_model_factory(
-        model_name="esm2_t6_8M_UR50D", include_fields=["hidden_states"], enable_position_ids_compat=True
-    )
-
-    result_skip0 = model.embed([sequence], options={"enable_position_ids_compat": True, "position_ids_skip": 0})
-    result_skip1024 = model.embed([sequence], options={"enable_position_ids_compat": True, "position_ids_skip": 1024})
+    result_skip0 = model.embed([sequence], options={"position_ids_skip": 0})
+    result_skip1024 = model.embed([sequence], options={"position_ids_skip": 1024})
 
     max_diff = np.max(np.abs(result_skip0.embeddings - result_skip1024.embeddings))
     assert max_diff > 0.0

--- a/tests/esm/test_esm2.py
+++ b/tests/esm/test_esm2.py
@@ -283,16 +283,16 @@ def test_esm2_position_id_skip_changes_embeddings(esm2_model_factory):
 def test_esm2_maybe_build_position_ids_rotary_cache_shape_mismatch_noop():
     """Shape-mismatched position ids must skip custom RoPE cache generation."""
     pytest.importorskip("transformers", reason="requires transformers")
-    from boileroom.models.esm import core as esm_core
+    from boileroom.models.esm import position_routing
 
     class _DummyRotary:
         inv_freq = torch.tensor([0.1, 0.2], dtype=torch.float32)
 
     dummy = _DummyRotary()
-    k = torch.zeros(1, 3, 4, dtype=torch.float32)
-    malformed_position_ids = torch.tensor([[0, 1, 0, 2]], dtype=torch.long)
+    k = torch.zeros(1, 2, 3, 4, dtype=torch.float32)
+    shape_mismatched_position_ids = torch.tensor([[0, 1, 0, 2]], dtype=torch.long)
 
-    cache = esm_core._maybe_build_position_ids_rotary_cache(dummy, k, malformed_position_ids)
+    cache = position_routing._maybe_build_position_ids_rotary_cache(dummy, k, shape_mismatched_position_ids)
     assert cache is None
 
 

--- a/tests/esm/test_esm2.py
+++ b/tests/esm/test_esm2.py
@@ -1,3 +1,5 @@
+from collections.abc import Sequence
+
 import numpy as np
 import pytest
 import torch
@@ -61,7 +63,23 @@ def esm2_model_factory(backend_option: str, gpu_device: str | None, device_optio
     return _make_model
 
 
-def _make_arange_position_ids(sequences, glycine_linker: str, add_special_tokens: bool) -> torch.Tensor:
+def _make_arange_position_ids(sequences: Sequence[str], glycine_linker: str, add_special_tokens: bool) -> torch.Tensor:
+    """Return padded arange-style position ids for each parsed sequence input.
+
+    Parameters
+    ----------
+    sequences : Sequence[str]
+        Input sequences passed to ``parse_esm2_sequences``.
+    glycine_linker : str
+        Linker inserted when replacing chain separators.
+    add_special_tokens : bool
+        Whether tokenizer special tokens are accounted for in the position count.
+
+    Returns
+    -------
+    torch.Tensor
+        Padded position-id tensor with shape ``(batch, max_length)``.
+    """
     parsed_sequences = parse_esm2_sequences(sequences)
     lengths = []
     for parsed_sequence in parsed_sequences:
@@ -240,9 +258,10 @@ def test_esm2_position_ids_compat_arange_is_noop(esm2_model_factory, mocker):
     mocker.patch.object(
         esm_core,
         "compute_position_ids",
-        side_effect=lambda sequences, glycine_linker, position_ids_skip, add_special_tokens=False: _make_arange_position_ids(
-            sequences, glycine_linker, add_special_tokens
-        ),
+        side_effect=lambda sequences,
+        glycine_linker,
+        position_ids_skip,
+        add_special_tokens=False: _make_arange_position_ids(sequences, glycine_linker, add_special_tokens),
     )
 
     model = esm2_model_factory(model_name="esm2_t6_8M_UR50D", include_fields=["hidden_states"])
@@ -263,14 +282,28 @@ def test_esm2_position_ids_compat_skip_change(esm2_model_factory):
     )
 
     result_skip0 = model.embed([sequence], options={"enable_position_ids_compat": True, "position_ids_skip": 0})
-    result_skip1024 = model.embed(
-        [sequence], options={"enable_position_ids_compat": True, "position_ids_skip": 1024}
-    )
+    result_skip1024 = model.embed([sequence], options={"enable_position_ids_compat": True, "position_ids_skip": 1024})
 
     max_diff = np.max(np.abs(result_skip0.embeddings - result_skip1024.embeddings))
     assert max_diff > 0.0
     max_hidden_diff = np.max(np.abs(result_skip0.hidden_states - result_skip1024.hidden_states))
     assert max_hidden_diff > 0.0
+
+
+def test_esm2_maybe_build_position_ids_rotary_cache_shape_mismatch_noop():
+    """Shape-mismatched position ids must skip custom RoPE cache generation."""
+    pytest.importorskip("transformers", reason="requires transformers")
+    from boileroom.models.esm import core as esm_core
+
+    class _DummyRotary:
+        inv_freq = torch.tensor([0.1, 0.2], dtype=torch.float32)
+
+    dummy = _DummyRotary()
+    k = torch.zeros(1, 3, 4, dtype=torch.float32)
+    malformed_position_ids = torch.tensor([[0, 1, 0, 2]], dtype=torch.long)
+
+    cache = esm_core._maybe_build_position_ids_rotary_cache(dummy, k, malformed_position_ids)
+    assert cache is None
 
 
 def test_esm2_embed_with_all_optional_fields(esm2_model_factory):

--- a/tests/esm/test_esmfold.py
+++ b/tests/esm/test_esmfold.py
@@ -317,8 +317,8 @@ def test_tokenize_sequences_with_mocker(mocker):
     assert multimer_properties is not None
 
 
-def test_esmfold_position_ids_compat_arange_is_noop(test_sequences, esmfold_model, mocker):
-    """Default-arange position ids remain a strict no-op in compatibility mode."""
+def test_esmfold_arange_position_ids_match_monomer_lm_outputs(test_sequences, esmfold_model, mocker):
+    """Arange-equivalent multimer ids match equivalent monomer LM outputs."""
     pytest.importorskip("transformers", reason="requires transformers")
     from boileroom.models.esm import core as esm_core
 
@@ -331,31 +331,28 @@ def test_esmfold_position_ids_compat_arange_is_noop(test_sequences, esmfold_mode
         add_special_tokens=False: _make_arange_position_ids(sequences, glycine_linker, add_special_tokens),
     )
 
-    sequence = test_sequences["multimer"]
+    multimer_sequence = test_sequences["multimer"]
+    monomer_sequence = multimer_sequence.replace(":", "")
 
-    result_without = esmfold_model.fold(
-        sequence, options={"include_fields": ["lm_logits"], "enable_position_ids_compat": False}
-    )
-    result_with = esmfold_model.fold(
-        sequence, options={"include_fields": ["lm_logits"], "enable_position_ids_compat": True}
-    )
+    result_monomer = esmfold_model.fold(monomer_sequence, options={"include_fields": ["lm_logits"]})
+    result_multimer = esmfold_model.fold(multimer_sequence, options={"include_fields": ["lm_logits"]})
 
-    assert result_without.lm_logits is not None
-    assert result_with.lm_logits is not None
-    assert np.array_equal(result_without.lm_logits, result_with.lm_logits)
+    assert result_monomer.lm_logits is not None
+    assert result_multimer.lm_logits is not None
+    assert np.array_equal(result_monomer.lm_logits, result_multimer.lm_logits)
 
 
-def test_esmfold_position_ids_compat_skip_change(test_sequences, esmfold_model):
-    """Compatibility mode routes multimer skips to different LM representations."""
+def test_esmfold_position_id_skip_changes_lm_outputs(test_sequences, esmfold_model):
+    """Multimer position skips are routed to different LM representations by default."""
     sequence = test_sequences["multimer"]
 
     result_skip0 = esmfold_model.fold(
         sequence,
-        options={"include_fields": ["lm_logits"], "enable_position_ids_compat": True, "position_ids_skip": 0},
+        options={"include_fields": ["lm_logits"], "position_ids_skip": 0},
     )
     result_skip1024 = esmfold_model.fold(
         sequence,
-        options={"include_fields": ["lm_logits"], "enable_position_ids_compat": True, "position_ids_skip": 1024},
+        options={"include_fields": ["lm_logits"], "position_ids_skip": 1024},
     )
 
     assert result_skip0.lm_logits is not None
@@ -368,8 +365,7 @@ def test_esmfold_position_ids_shape_mismatch_noop_fallback():
     pytest.importorskip("transformers", reason="requires transformers")
     from boileroom.models.esm import core as esm_core
 
-    state = esm_core._PositionIdsCompatState(
-        enabled=True,
+    state = esm_core._PositionIdsRoutingState(
         position_ids=torch.tensor([[0, 1, 0, 2]], dtype=torch.long),
         attention_mask=None,
     )

--- a/tests/esm/test_esmfold.py
+++ b/tests/esm/test_esmfold.py
@@ -13,6 +13,7 @@ from boileroom import ESMFold
 from boileroom.constants import restype_3to1
 from boileroom.convert import pdb_string_to_atomarray
 from boileroom.models.esm.linker import store_multimer_properties
+from boileroom.models.esm.parsing import parse_esm2_sequences
 from boileroom.models.esm.types import ESMFoldOutput
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.gpu, pytest.mark.xdist_group("esmfold")]
@@ -40,6 +41,26 @@ def esmfold_model(backend_option: str, device_option: str | None, output_ctx) ->
     model_config: dict[str, object] = {}
     with output_ctx():
         yield ESMFold(backend=backend_option, device=device_option, config=model_config)
+
+
+def _make_arange_position_ids(sequences, glycine_linker: str, add_special_tokens: bool) -> torch.Tensor:
+    parsed_sequences = parse_esm2_sequences(sequences)
+    lengths = []
+    for parsed_sequence in parsed_sequences:
+        base_length = sum(len(chain.tokens) for chain in parsed_sequence.chains)
+        base_length += max(len(parsed_sequence.chains) - 1, 0) * len(glycine_linker)
+        if add_special_tokens:
+            base_length += 2
+        lengths.append(base_length)
+
+    max_length = max(lengths)
+    position_ids = []
+    for length in lengths:
+        row = torch.arange(length, dtype=torch.long)
+        if length < max_length:
+            row = torch.cat([row, torch.zeros(max_length - length, dtype=torch.long)])
+        position_ids.append(row)
+    return torch.stack(position_ids, dim=0)
 
 
 def test_esmfold_basic(test_sequences: dict[str, str], esmfold_model: ESMFold):
@@ -278,6 +299,47 @@ def test_tokenize_sequences_with_mocker(mocker):
     # Verify the output contains the expected keys
     assert set(tokenized_input.keys()) >= {"input_ids", "attention_mask", "position_ids"}
     assert multimer_properties is not None
+
+
+def test_esmfold_position_ids_compat_arange_is_noop(test_sequences, esmfold_model, mocker):
+    """Default-arange position ids remain a strict no-op in compatibility mode."""
+    pytest.importorskip("transformers", reason="requires transformers")
+    from boileroom.models.esm import core as esm_core
+
+    mocker.patch.object(
+        esm_core,
+        "compute_position_ids",
+        side_effect=lambda sequences, glycine_linker, position_ids_skip, add_special_tokens=False: _make_arange_position_ids(
+            sequences, glycine_linker, add_special_tokens
+        ),
+    )
+
+    sequence = test_sequences["multimer"]
+
+    result_without = esmfold_model.fold(sequence, options={"include_fields": ["lm_logits"], "enable_position_ids_compat": False})
+    result_with = esmfold_model.fold(sequence, options={"include_fields": ["lm_logits"], "enable_position_ids_compat": True})
+
+    assert result_without.lm_logits is not None
+    assert result_with.lm_logits is not None
+    assert np.array_equal(result_without.lm_logits, result_with.lm_logits)
+
+
+def test_esmfold_position_ids_compat_skip_change(test_sequences, esmfold_model):
+    """Compatibility mode routes multimer skips to different LM representations."""
+    sequence = test_sequences["multimer"]
+
+    result_skip0 = esmfold_model.fold(
+        sequence,
+        options={"include_fields": ["lm_logits"], "enable_position_ids_compat": True, "position_ids_skip": 0},
+    )
+    result_skip1024 = esmfold_model.fold(
+        sequence,
+        options={"include_fields": ["lm_logits"], "enable_position_ids_compat": True, "position_ids_skip": 1024},
+    )
+
+    assert result_skip0.lm_logits is not None
+    assert result_skip1024.lm_logits is not None
+    assert np.max(np.abs(result_skip0.lm_logits - result_skip1024.lm_logits)) > 0.0
 
 
 def test_esmfold_rejects_empty_chain_multimer():

--- a/tests/esm/test_esmfold.py
+++ b/tests/esm/test_esmfold.py
@@ -1,5 +1,5 @@
 import pathlib
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Sequence
 from io import StringIO
 from typing import Any
 
@@ -43,7 +43,23 @@ def esmfold_model(backend_option: str, device_option: str | None, output_ctx) ->
         yield ESMFold(backend=backend_option, device=device_option, config=model_config)
 
 
-def _make_arange_position_ids(sequences, glycine_linker: str, add_special_tokens: bool) -> torch.Tensor:
+def _make_arange_position_ids(sequences: Sequence[str], glycine_linker: str, add_special_tokens: bool) -> torch.Tensor:
+    """Return padded arange-style position ids for mocked multimer tokenization.
+
+    Parameters
+    ----------
+    sequences : Sequence[str]
+        Input sequences parsed by ``parse_esm2_sequences``.
+    glycine_linker : str
+        Linker inserted when replacing chain separators.
+    add_special_tokens : bool
+        Whether special tokens should be counted in the generated sequence length.
+
+    Returns
+    -------
+    torch.Tensor
+        Padded position-id tensor with shape ``(batch, max_length)``.
+    """
     parsed_sequences = parse_esm2_sequences(sequences)
     lengths = []
     for parsed_sequence in parsed_sequences:
@@ -309,15 +325,20 @@ def test_esmfold_position_ids_compat_arange_is_noop(test_sequences, esmfold_mode
     mocker.patch.object(
         esm_core,
         "compute_position_ids",
-        side_effect=lambda sequences, glycine_linker, position_ids_skip, add_special_tokens=False: _make_arange_position_ids(
-            sequences, glycine_linker, add_special_tokens
-        ),
+        side_effect=lambda sequences,
+        glycine_linker,
+        position_ids_skip,
+        add_special_tokens=False: _make_arange_position_ids(sequences, glycine_linker, add_special_tokens),
     )
 
     sequence = test_sequences["multimer"]
 
-    result_without = esmfold_model.fold(sequence, options={"include_fields": ["lm_logits"], "enable_position_ids_compat": False})
-    result_with = esmfold_model.fold(sequence, options={"include_fields": ["lm_logits"], "enable_position_ids_compat": True})
+    result_without = esmfold_model.fold(
+        sequence, options={"include_fields": ["lm_logits"], "enable_position_ids_compat": False}
+    )
+    result_with = esmfold_model.fold(
+        sequence, options={"include_fields": ["lm_logits"], "enable_position_ids_compat": True}
+    )
 
     assert result_without.lm_logits is not None
     assert result_with.lm_logits is not None
@@ -340,6 +361,22 @@ def test_esmfold_position_ids_compat_skip_change(test_sequences, esmfold_model):
     assert result_skip0.lm_logits is not None
     assert result_skip1024.lm_logits is not None
     assert np.max(np.abs(result_skip0.lm_logits - result_skip1024.lm_logits)) > 0.0
+
+
+def test_esmfold_position_ids_shape_mismatch_noop_fallback():
+    """Shape-mismatched position ids should fall back instead of forcing custom LM ids."""
+    pytest.importorskip("transformers", reason="requires transformers")
+    from boileroom.models.esm import core as esm_core
+
+    state = esm_core._PositionIdsCompatState(
+        enabled=True,
+        position_ids=torch.tensor([[0, 1, 0, 2]], dtype=torch.long),
+        attention_mask=None,
+    )
+    esmaa = torch.ones((1, 3), dtype=torch.long)
+
+    computed = esm_core._compute_esmfold_position_ids(esmaa, state)
+    assert computed is None
 
 
 def test_esmfold_rejects_empty_chain_multimer():

--- a/tests/esm/test_esmfold.py
+++ b/tests/esm/test_esmfold.py
@@ -1,5 +1,5 @@
 import pathlib
-from collections.abc import Callable, Generator, Sequence
+from collections.abc import Callable, Generator
 from io import StringIO
 from typing import Any
 
@@ -13,7 +13,6 @@ from boileroom import ESMFold
 from boileroom.constants import restype_3to1
 from boileroom.convert import pdb_string_to_atomarray
 from boileroom.models.esm.linker import store_multimer_properties
-from boileroom.models.esm.parsing import parse_esm2_sequences
 from boileroom.models.esm.types import ESMFoldOutput
 
 pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.gpu, pytest.mark.xdist_group("esmfold")]
@@ -41,42 +40,6 @@ def esmfold_model(backend_option: str, device_option: str | None, output_ctx) ->
     model_config: dict[str, object] = {}
     with output_ctx():
         yield ESMFold(backend=backend_option, device=device_option, config=model_config)
-
-
-def _make_arange_position_ids(sequences: Sequence[str], glycine_linker: str, add_special_tokens: bool) -> torch.Tensor:
-    """Return padded arange-style position ids for mocked multimer tokenization.
-
-    Parameters
-    ----------
-    sequences : Sequence[str]
-        Input sequences parsed by ``parse_esm2_sequences``.
-    glycine_linker : str
-        Linker inserted when replacing chain separators.
-    add_special_tokens : bool
-        Whether special tokens should be counted in the generated sequence length.
-
-    Returns
-    -------
-    torch.Tensor
-        Padded position-id tensor with shape ``(batch, max_length)``.
-    """
-    parsed_sequences = parse_esm2_sequences(sequences)
-    lengths = []
-    for parsed_sequence in parsed_sequences:
-        base_length = sum(len(chain.tokens) for chain in parsed_sequence.chains)
-        base_length += max(len(parsed_sequence.chains) - 1, 0) * len(glycine_linker)
-        if add_special_tokens:
-            base_length += 2
-        lengths.append(base_length)
-
-    max_length = max(lengths)
-    position_ids = []
-    for length in lengths:
-        row = torch.arange(length, dtype=torch.long)
-        if length < max_length:
-            row = torch.cat([row, torch.zeros(max_length - length, dtype=torch.long)])
-        position_ids.append(row)
-    return torch.stack(position_ids, dim=0)
 
 
 def test_esmfold_basic(test_sequences: dict[str, str], esmfold_model: ESMFold):
@@ -315,64 +278,6 @@ def test_tokenize_sequences_with_mocker(mocker):
     # Verify the output contains the expected keys
     assert set(tokenized_input.keys()) >= {"input_ids", "attention_mask", "position_ids"}
     assert multimer_properties is not None
-
-
-def test_esmfold_arange_position_ids_match_monomer_lm_outputs(test_sequences, esmfold_model, mocker):
-    """Arange-equivalent multimer ids match equivalent monomer LM outputs."""
-    pytest.importorskip("transformers", reason="requires transformers")
-    from boileroom.models.esm import core as esm_core
-
-    mocker.patch.object(
-        esm_core,
-        "compute_position_ids",
-        side_effect=lambda sequences,
-        glycine_linker,
-        position_ids_skip,
-        add_special_tokens=False: _make_arange_position_ids(sequences, glycine_linker, add_special_tokens),
-    )
-
-    multimer_sequence = test_sequences["multimer"]
-    monomer_sequence = multimer_sequence.replace(":", "")
-
-    result_monomer = esmfold_model.fold(monomer_sequence, options={"include_fields": ["lm_logits"]})
-    result_multimer = esmfold_model.fold(multimer_sequence, options={"include_fields": ["lm_logits"]})
-
-    assert result_monomer.lm_logits is not None
-    assert result_multimer.lm_logits is not None
-    assert np.array_equal(result_monomer.lm_logits, result_multimer.lm_logits)
-
-
-def test_esmfold_position_id_skip_changes_lm_outputs(test_sequences, esmfold_model):
-    """Multimer position skips are routed to different LM representations by default."""
-    sequence = test_sequences["multimer"]
-
-    result_skip0 = esmfold_model.fold(
-        sequence,
-        options={"include_fields": ["lm_logits"], "position_ids_skip": 0},
-    )
-    result_skip1024 = esmfold_model.fold(
-        sequence,
-        options={"include_fields": ["lm_logits"], "position_ids_skip": 1024},
-    )
-
-    assert result_skip0.lm_logits is not None
-    assert result_skip1024.lm_logits is not None
-    assert np.max(np.abs(result_skip0.lm_logits - result_skip1024.lm_logits)) > 0.0
-
-
-def test_esmfold_position_ids_shape_mismatch_noop_fallback():
-    """Shape-mismatched position ids should fall back instead of forcing custom LM ids."""
-    pytest.importorskip("transformers", reason="requires transformers")
-    from boileroom.models.esm import core as esm_core
-
-    state = esm_core._PositionIdsRoutingState(
-        position_ids=torch.tensor([[0, 1, 0, 2]], dtype=torch.long),
-        attention_mask=None,
-    )
-    esmaa = torch.ones((1, 3), dtype=torch.long)
-
-    computed = esm_core._compute_esmfold_position_ids(esmaa, state)
-    assert computed is None
 
 
 def test_esmfold_rejects_empty_chain_multimer():


### PR DESCRIPTION
## Summary
- Route Boileroom-generated multimer `position_ids` through ESM-2 rotary embeddings by default when multimer inputs are tokenized.
- Treat this as normal ESM-2 behavior rather than an opt-in compatibility mode or user-facing switch.
- Keep vanilla Transformers behavior for monomers and arange-equivalent position IDs, while using the patched Transformers path when multimer position skips are present.
- Move the ESM-2 routing patch into `boileroom.models.esm.position_routing` and leave ESMFold out of this PR scope.

## Testing
- `uv run python -m py_compile boileroom/models/esm/core.py boileroom/models/esm/position_routing.py tests/esm/test_esm2.py tests/esm/test_esmfold.py`
- `uv run --with ruff ruff check boileroom/models/esm/core.py boileroom/models/esm/position_routing.py tests/esm/test_esm2.py tests/esm/test_esmfold.py`
- `uv run --extra dev --with transformers python -m pytest tests/esm/test_esm2.py::test_esm2_maybe_build_position_ids_rotary_cache_shape_mismatch_noop tests/esm/test_esmfold.py::test_tokenize_sequences_with_mocker tests/esm/test_esmfold.py::test_esmfold_rejects_empty_chain_multimer tests/esm/test_esm2.py::test_esm2_mask_linker_region_pads_hidden_states_on_sequence_axis`
- Result: `4 passed`

## Notes
- The backend integration path is still blocked before model execution by missing Docker tag `docker.io/jakublala/boileroom-esm:0.3.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved position ID handling for multimer protein complexes, ensuring position ID parameters correctly affect model embeddings.

* **Tests**
  * Added validation tests for position ID behavior across multimer protein inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softnanolab/boileroom/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->