### PR TITLE
fix: address esmfold2 review feedback

### DIFF
--- a/boileroom/images/import_checks.py
+++ b/boileroom/images/import_checks.py
@@ -49,7 +49,19 @@ def package_name_to_import_name(package_name: str) -> str | None:
 
 
 def requirement_line_to_package_name(requirement: str) -> str:
-    """Extract the package name from a requirements.txt line."""
+    """Extract the package name from a requirements.txt line.
+
+    Parameters
+    ----------
+    requirement : str
+        Requirements.txt-style line, such as ``package>=1.0``, ``pkg @ url``,
+        or ``url#egg=pkg``.
+
+    Returns
+    -------
+    str
+        Extracted package or distribution name.
+    """
     stripped = requirement.strip()
     if "#egg=" in stripped:
         return stripped.rsplit("#egg=", 1)[1].split("&", 1)[0].strip()

--- a/boileroom/inputs.py
+++ b/boileroom/inputs.py
@@ -1,0 +1,39 @@
+"""Shared lightweight input dataclasses for BoilerRoom model adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class MSAInput:
+    """Portable multiple-sequence-alignment input.
+
+    Parameters
+    ----------
+    sequences
+        In-memory MSA rows for models that accept sequence-list MSAs directly.
+    path
+        File-backed MSA location for models that consume MSA files. Model adapters
+        may support only one representation; unsupported representations should
+        fail with a clear model-specific error.
+    remove_insertions
+        Whether supported adapters should strip insertion columns from sequence
+        rows before constructing the model-native MSA object.
+    """
+
+    sequences: list[str] | None = None
+    path: str | Path | None = None
+    remove_insertions: bool = False
+
+    def __post_init__(self) -> None:
+        """Validate that the MSA points to exactly one source."""
+        has_sequences = self.sequences is not None
+        has_path = self.path is not None
+        if has_sequences == has_path:
+            raise ValueError("MSAInput requires exactly one of sequences or path.")
+        if self.sequences is not None and not all(isinstance(sequence, str) for sequence in self.sequences):
+            raise TypeError("MSAInput sequences must be a list of strings.")
+        if self.path is not None and not isinstance(self.path, str | Path):
+            raise TypeError("MSAInput path must be a string or pathlib.Path.")

--- a/boileroom/inputs.py
+++ b/boileroom/inputs.py
@@ -37,3 +37,5 @@ class MSAInput:
             raise TypeError("MSAInput sequences must be a list of strings.")
         if self.path is not None and not isinstance(self.path, str | Path):
             raise TypeError("MSAInput path must be a string or pathlib.Path.")
+        if not isinstance(self.remove_insertions, bool):
+            raise TypeError("MSAInput remove_insertions must be a bool.")

--- a/boileroom/models/esmfold2/Dockerfile
+++ b/boileroom/models/esmfold2/Dockerfile
@@ -19,3 +19,11 @@ ENV PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
 RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv \
     uv pip install --system -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt
+
+RUN groupadd --gid 10001 boileroom \
+    && useradd --uid 10001 --gid boileroom --create-home --home-dir /home/boileroom --shell /usr/sbin/nologin boileroom \
+    && mkdir -p /mnt/models \
+    && chown -R boileroom:boileroom /home/boileroom /mnt/models
+
+WORKDIR /home/boileroom
+USER boileroom

--- a/boileroom/models/esmfold2/core.py
+++ b/boileroom/models/esmfold2/core.py
@@ -402,12 +402,19 @@ class ESMFold2Core(FoldingAlgorithm):
         """Convert lightweight or native MSA inputs to Biohub's MSA object."""
         if msa is None:
             return None
+        if isinstance(msa, MSAInput):
+            if msa.sequences is None:
+                raise ValueError(
+                    "ESMFold2 currently requires in-memory MSA sequences; "
+                    "file-backed MSA paths are reserved for other model adapters."
+                )
+            from esm.models.esmfold2 import MSA
+
+            return MSA.from_sequences(msa.sequences, remove_insertions=msa.remove_insertions)
         from esm.models.esmfold2 import MSA
 
         if isinstance(msa, MSA):
             return msa
-        if isinstance(msa, MSAInput):
-            return MSA.from_sequences(msa.sequences, remove_insertions=msa.remove_insertions)
         if isinstance(msa, list):
             return MSA.from_sequences(msa)
         return msa

--- a/boileroom/models/esmfold2/payloads.py
+++ b/boileroom/models/esmfold2/payloads.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
+from pathlib import Path
 from typing import Any, cast
 
 import numpy as np
@@ -131,28 +132,28 @@ def decode_sequence_input(value: Mapping[str, Any]) -> SequenceInput:
     if kind == _PROTEIN_KIND:
         return ProteinInput(
             id=_decode_id(value.get("id")),
-            sequence=str(value.get("sequence", "")),
+            sequence=_decode_sequence(value.get("sequence"), "protein.sequence"),
             modifications=decode_modifications(value.get("modifications")),
             msa=decode_msa(value.get("msa")),
         )
     if kind == _RNA_KIND:
         return RNAInput(
             id=_decode_id(value.get("id")),
-            sequence=str(value.get("sequence", "")),
+            sequence=_decode_sequence(value.get("sequence"), "rna.sequence"),
             modifications=decode_modifications(value.get("modifications")),
         )
     if kind == _DNA_KIND:
         return DNAInput(
             id=_decode_id(value.get("id")),
-            sequence=str(value.get("sequence", "")),
+            sequence=_decode_sequence(value.get("sequence"), "dna.sequence"),
             modifications=decode_modifications(value.get("modifications")),
         )
     if kind == _LIGAND_KIND:
         ccd = value.get("ccd")
         return LigandInput(
             id=_decode_id(value.get("id")),
-            smiles=cast(str | None, value.get("smiles")),
-            ccd=[str(item) for item in ccd] if isinstance(ccd, list) else None,
+            smiles=_decode_optional_str(value.get("smiles"), "ligand.smiles"),
+            ccd=_decode_optional_str_list(ccd, "ligand.ccd"),
         )
     raise ValueError(f"Unsupported ESMFold2 sequence payload kind: {kind!r}")
 
@@ -181,12 +182,19 @@ def encode_msa(value: MSAInput | Any | None) -> dict[str, Any] | list[str] | Non
     """Encode lightweight MSA inputs.
 
     Biohub-native MSA objects are Modal-only because the Apptainer bridge uses
-    JSON. Use ``MSAInput`` for portable Modal/Apptainer calls.
+    JSON. Use ``MSAInput`` for portable Modal/Apptainer calls. ESMFold2 currently
+    consumes in-memory MSA sequences; path-backed MSA values are preserved in the
+    payload so model adapters can reject unsupported sources clearly.
     """
     if value is None:
         return None
     if isinstance(value, MSAInput):
-        return {"sequences": value.sequences, "remove_insertions": value.remove_insertions}
+        payload: dict[str, Any] = {"remove_insertions": value.remove_insertions}
+        if value.sequences is not None:
+            payload["sequences"] = value.sequences
+        if value.path is not None:
+            payload["path"] = str(value.path)
+        return payload
     if isinstance(value, list) and all(isinstance(item, str) for item in value):
         return [cast(str, item) for item in value]
     raise TypeError("Apptainer ESMFold2 inputs must use MSAInput or list[str] for protein MSA values.")
@@ -198,9 +206,21 @@ def decode_msa(value: Any) -> MSAInput | list[str] | None:
         return None
     if isinstance(value, Mapping):
         sequences = value.get("sequences")
-        if not isinstance(sequences, list) or not all(isinstance(item, str) for item in sequences):
-            raise TypeError("Encoded ESMFold2 MSA payload requires a string sequence list.")
-        return MSAInput(sequences=sequences, remove_insertions=bool(value.get("remove_insertions", False)))
+        path = value.get("path")
+        remove_insertions = value.get("remove_insertions", False)
+        if sequences is not None and (
+            not isinstance(sequences, list) or not all(isinstance(item, str) for item in sequences)
+        ):
+            raise TypeError("Encoded ESMFold2 MSA payload sequences must be a string sequence list.")
+        if path is not None and not isinstance(path, str | Path):
+            raise TypeError("Encoded ESMFold2 MSA payload path must be a string path.")
+        if not isinstance(remove_insertions, bool):
+            raise TypeError("Encoded ESMFold2 MSA payload remove_insertions must be a boolean.")
+        return MSAInput(
+            sequences=[cast(str, item) for item in sequences] if sequences is not None else None,
+            path=cast(str | Path | None, path),
+            remove_insertions=remove_insertions,
+        )
     if isinstance(value, list) and all(isinstance(item, str) for item in value):
         return [cast(str, item) for item in value]
     raise TypeError("Encoded ESMFold2 MSA payload must be a mapping, list[str], or None.")
@@ -223,7 +243,7 @@ def decode_pocket_conditioning(value: Any) -> PocketConditioning | None:
     if not isinstance(contacts, list):
         raise TypeError("Encoded ESMFold2 pocket contacts must be a list.")
     return PocketConditioning(
-        binder_chain_id=str(value["binder_chain_id"]),
+        binder_chain_id=_decode_sequence(value.get("binder_chain_id"), "pocket.binder_chain_id"),
         contacts=[_decode_pocket_contact(contact) for contact in contacts],
     )
 
@@ -264,16 +284,47 @@ def decode_covalent_bond(value: Mapping[str, Any]) -> CovalentBond:
 
 def _decode_id(value: Any) -> str | list[str]:
     """Decode a chain identifier that may name one or many copies."""
-    if isinstance(value, list):
-        return [str(item) for item in value]
-    return str(value)
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return [cast(str, item) for item in value]
+    raise TypeError("Encoded ESMFold2 id must be str or list[str].")
+
+
+def _decode_sequence(value: Any, field_name: str) -> str:
+    """Decode a required string field."""
+    if not isinstance(value, str):
+        raise TypeError(f"Encoded ESMFold2 {field_name} must be a string.")
+    return value
+
+
+def _decode_optional_str(value: Any, field_name: str) -> str | None:
+    """Decode an optional string field."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"Encoded ESMFold2 {field_name} must be a string or None.")
+    return value
+
+
+def _decode_optional_str_list(value: Any, field_name: str) -> list[str] | None:
+    """Decode an optional list of strings."""
+    if value is None:
+        return None
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        raise TypeError(f"Encoded ESMFold2 {field_name} must be a list of strings or None.")
+    return [cast(str, item) for item in value]
 
 
 def _decode_pocket_contact(value: Any) -> tuple[str, int]:
     """Decode one pocket contact pair as ``(chain_id, residue_index)``."""
     if not isinstance(value, Sequence) or isinstance(value, str) or len(value) != 2:
         raise TypeError("Encoded ESMFold2 pocket contacts must be [chain_id, residue_index] pairs.")
-    return str(value[0]), int(value[1])
+    chain_id = _decode_sequence(value[0], "pocket.contacts.chain_id")
+    residue_index = value[1]
+    if not isinstance(residue_index, int) or isinstance(residue_index, bool):
+        raise TypeError("Encoded ESMFold2 pocket contact residue index must be an integer.")
+    return chain_id, residue_index
 
 
 def _mapping_sequence(value: Any, field_name: str) -> list[Mapping[str, Any]]:

--- a/boileroom/models/esmfold2/requirements.txt
+++ b/boileroom/models/esmfold2/requirements.txt
@@ -1,6 +1,6 @@
-numpy
+numpy==2.4.6
 torch>=2.6.0,<2.7.0
 esm @ git+https://github.com/Biohub/esm.git@c94ed8d
-fastapi
-uvicorn
-pydantic
+fastapi==0.136.3
+uvicorn==0.48.0
+pydantic==2.13.4

--- a/boileroom/models/esmfold2/types.py
+++ b/boileroom/models/esmfold2/types.py
@@ -9,17 +9,10 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 from ...base import PredictionMetadata, StructurePrediction
+from ...inputs import MSAInput
 
 if TYPE_CHECKING:
     from biotite.structure import AtomArray
-
-
-@dataclass(frozen=True)
-class MSAInput:
-    """Lightweight MSA specification for ESMFold2 protein inputs."""
-
-    sequences: list[str]
-    remove_insertions: bool = False
 
 
 @dataclass(frozen=True)

--- a/docs/models.md
+++ b/docs/models.md
@@ -62,10 +62,12 @@ top_tokens = [id_to_token[token_id] for token_id in top_token_ids]
 - ESMFold2 uses Biohub's ESMFold2 model family through the `esm` package and Biohub's Transformers fork, so it has its own runtime image instead of sharing the ESMFold/ESM-2 image.
 - String inputs follow the existing BoilerRoom convention: `model.fold("AAA:BBB")` predicts one multichain complex, while `model.fold(["AAA", "BBB"])` predicts a batch of independent proteins.
 - For all-atom complexes, pass lightweight input dataclasses from `boileroom.models.esmfold2.types` such as `ProteinInput`, `DNAInput`, `RNAInput`, `LigandInput`, and `StructurePredictionInput`.
+- For explicit in-memory MSAs, use the shared `boileroom.inputs.MSAInput` abstraction; ESMFold2 also re-exports it from `boileroom.models.esmfold2` for compatibility. File-backed MSA paths are reserved for adapters such as Boltz-2 and are not consumed by ESMFold2 yet.
 
 Example usage:
 ```python
 from boileroom import ESMFold2
+from boileroom.inputs import MSAInput
 from boileroom.models.esmfold2.types import DNAInput, LigandInput, ProteinInput, StructurePredictionInput
 
 model = ESMFold2(
@@ -87,6 +89,7 @@ result.cif[0]
 complex_input = StructurePredictionInput(
     sequences=[
         ProteinInput(id="A", sequence="MIEIKDKQLTGLRFIDLFAGLGGFRLALESCGAECVYSNEWDKYAQEVYEMNFGEKPEG"),
+        ProteinInput(id="M", sequence="ACD", msa=MSAInput(sequences=["ACD", "ACE"])),
         DNAInput(id="B", sequence="GATAGCGCTATC"),
         LigandInput(id="L", ccd=["SAH"]),
     ]

--- a/harness/model_family_contract.yaml
+++ b/harness/model_family_contract.yaml
@@ -21,6 +21,7 @@ model_family:
       - typing
     allowed_import_modules:
       - boileroom.base
+      - boileroom.inputs
     forbidden_import_roots:
       - biotite
       - boltz

--- a/tests/esmfold2/test_esmfold2.py
+++ b/tests/esmfold2/test_esmfold2.py
@@ -131,6 +131,28 @@ def test_esmfold2_msa_input_uses_shared_type_and_round_trips() -> None:
     assert decoded.sequences[0].msa == MSAInput(sequences=["ACD", "ACE"], remove_insertions=True)
 
 
+def test_esmfold2_path_msa_input_round_trips_through_payloads() -> None:
+    """Path-backed MSA payloads should round-trip before model-specific rejection."""
+    payloads = _payloads()
+    structure_input = StructurePredictionInput(
+        sequences=[ProteinInput(id="A", sequence="ACD", msa=MSAInput(path="some/path"))]
+    )
+
+    payload = payloads.encode_fold_input(structure_input)
+
+    assert isinstance(payload, dict)
+    assert payload["sequences"][0]["msa"] == {"path": "some/path", "remove_insertions": False}
+    decoded = payloads.decode_structure_input(payload)
+    assert isinstance(decoded.sequences[0], ProteinInput)
+    assert decoded.sequences[0].msa == MSAInput(path="some/path")
+
+
+def test_shared_msa_input_rejects_non_boolean_remove_insertions() -> None:
+    """The shared MSAInput should reject ambiguous truthy/falsy flag values."""
+    with pytest.raises(TypeError, match="remove_insertions"):
+        MSAInput(sequences=["ACD"], remove_insertions="false")  # type: ignore[arg-type]
+
+
 def test_esmfold2_payload_decode_rejects_silent_coercions() -> None:
     """Encoded Apptainer payloads should reject malformed scalar types."""
     payloads = _payloads()
@@ -167,6 +189,21 @@ def test_esmfold2_payload_decode_rejects_silent_coercions() -> None:
     }
     with pytest.raises(TypeError, match="remove_insertions"):
         payloads.decode_structure_input(invalid_msa_payload)
+
+    invalid_msa_path_payload = {
+        **base_payload,
+        "sequences": [
+            {
+                "kind": "protein",
+                "id": "A",
+                "sequence": "ACD",
+                "modifications": None,
+                "msa": {"path": 123, "remove_insertions": False},
+            }
+        ],
+    }
+    with pytest.raises(TypeError, match="path"):
+        payloads.decode_structure_input(invalid_msa_path_payload)
 
 
 def test_esmfold2_rejects_file_backed_msa_until_supported() -> None:

--- a/tests/esmfold2/test_esmfold2.py
+++ b/tests/esmfold2/test_esmfold2.py
@@ -1,11 +1,12 @@
 """Fast ESMFold2 unit tests that do not import Biohub runtime dependencies."""
 
+from typing import Any
+
 import pytest
 
 from boileroom.base import ModelWrapper
-from boileroom.models.esmfold2.core import ESMFold2Core
-from boileroom.models.esmfold2.esmfold2 import ESMFold2
-from boileroom.models.esmfold2.payloads import decode_structure_input, encode_fold_input
+from boileroom.inputs import MSAInput
+from boileroom.models.esmfold2 import MSAInput as ESMFold2MSAInput
 from boileroom.models.esmfold2.types import (
     DNAInput,
     LigandInput,
@@ -17,9 +18,24 @@ from boileroom.models.esmfold2.types import (
 pytestmark = pytest.mark.contract
 
 
+def _core_cls() -> Any:
+    """Import the ESMFold2 core only inside tests that need it."""
+    return pytest.importorskip("boileroom.models.esmfold2.core").ESMFold2Core
+
+
+def _wrapper_cls() -> Any:
+    """Import the Modal wrapper module only inside tests that need it."""
+    return pytest.importorskip("boileroom.models.esmfold2.esmfold2").ESMFold2
+
+
+def _payloads() -> Any:
+    """Import ESMFold2 payload helpers only inside tests that need them."""
+    return pytest.importorskip("boileroom.models.esmfold2.payloads")
+
+
 def test_esmfold2_string_multimer_becomes_one_complex() -> None:
     """Colon-separated protein strings should represent one multichain complex."""
-    core = ESMFold2Core(config={"device": "cpu"})
+    core = _core_cls()(config={"device": "cpu"})
 
     requests = core._coerce_requests("ACD:EFG")
 
@@ -31,7 +47,7 @@ def test_esmfold2_string_multimer_becomes_one_complex() -> None:
 
 def test_esmfold2_string_list_is_batch() -> None:
     """A list of strings should remain a batch of independent proteins."""
-    core = ESMFold2Core(config={"device": "cpu"})
+    core = _core_cls()(config={"device": "cpu"})
 
     requests = core._coerce_requests(["ACD", "EFGH"])
 
@@ -44,7 +60,7 @@ def test_esmfold2_string_list_is_batch() -> None:
 
 def test_esmfold2_molecule_inputs_become_one_structure_input() -> None:
     """A list of molecule input dataclasses should describe one all-atom complex."""
-    core = ESMFold2Core(config={"device": "cpu"})
+    core = _core_cls()(config={"device": "cpu"})
     inputs: list[ProteinInput | DNAInput | LigandInput] = [
         ProteinInput(id="A", sequence="ACD"),
         DNAInput(id="B", sequence="GATA"),
@@ -60,18 +76,19 @@ def test_esmfold2_molecule_inputs_become_one_structure_input() -> None:
 
 def test_esmfold2_encoded_structure_input_round_trips() -> None:
     """Apptainer payload encoding should preserve all-atom molecule inputs."""
-    payload = encode_fold_input([ProteinInput(id="A", sequence="ACD"), LigandInput(id="L", ccd=["SAH"])])
+    payloads = _payloads()
+    payload = payloads.encode_fold_input([ProteinInput(id="A", sequence="ACD"), LigandInput(id="L", ccd=["SAH"])])
 
     assert isinstance(payload, dict)
-    decoded = decode_structure_input(payload)
+    decoded = payloads.decode_structure_input(payload)
 
     assert list(decoded.sequences) == [ProteinInput(id="A", sequence="ACD"), LigandInput(id="L", ccd=["SAH"])]
 
 
 def test_esmfold2_core_accepts_encoded_structure_payload() -> None:
     """The core should accept the JSON payload shape used by Apptainer."""
-    core = ESMFold2Core(config={"device": "cpu"})
-    payload = encode_fold_input([ProteinInput(id="A", sequence="ACD"), DNAInput(id="B", sequence="GATA")])
+    core = _core_cls()(config={"device": "cpu"})
+    payload = _payloads().encode_fold_input([ProteinInput(id="A", sequence="ACD"), DNAInput(id="B", sequence="GATA")])
 
     requests = core._coerce_requests(payload)
 
@@ -81,21 +98,86 @@ def test_esmfold2_core_accepts_encoded_structure_payload() -> None:
 
 def test_esmfold2_encoded_structure_input_preserves_pocket_conditioning() -> None:
     """Apptainer payload encoding should preserve ESMFold2 pocket conditioning."""
+    payloads = _payloads()
     structure_input = StructurePredictionInput(
         sequences=[ProteinInput(id="A", sequence="ACD"), ProteinInput(id="B", sequence="EFG")],
         pocket=PocketConditioning(binder_chain_id="A", contacts=[("B", 1)]),
     )
 
-    payload = encode_fold_input(structure_input)
+    payload = payloads.encode_fold_input(structure_input)
 
     assert isinstance(payload, dict)
     assert payload["pocket"] == {"binder_chain_id": "A", "contacts": [["B", 1]]}
-    assert decode_structure_input(payload).pocket == structure_input.pocket
+    assert payloads.decode_structure_input(payload).pocket == structure_input.pocket
+
+
+def test_esmfold2_msa_input_uses_shared_type_and_round_trips() -> None:
+    """ESMFold2 should re-export and serialize the shared MSAInput abstraction."""
+    payloads = _payloads()
+    assert ESMFold2MSAInput is MSAInput
+    structure_input = StructurePredictionInput(
+        sequences=[ProteinInput(id="A", sequence="ACD", msa=MSAInput(sequences=["ACD", "ACE"], remove_insertions=True))]
+    )
+
+    payload = payloads.encode_fold_input(structure_input)
+
+    assert isinstance(payload, dict)
+    assert payload["sequences"][0]["msa"] == {
+        "sequences": ["ACD", "ACE"],
+        "remove_insertions": True,
+    }
+    decoded = payloads.decode_structure_input(payload)
+    assert isinstance(decoded.sequences[0], ProteinInput)
+    assert decoded.sequences[0].msa == MSAInput(sequences=["ACD", "ACE"], remove_insertions=True)
+
+
+def test_esmfold2_payload_decode_rejects_silent_coercions() -> None:
+    """Encoded Apptainer payloads should reject malformed scalar types."""
+    payloads = _payloads()
+    base_payload = {
+        "kind": "structure_prediction_input",
+        "sequences": [{"kind": "protein", "id": "A", "sequence": "ACD", "modifications": None, "msa": None}],
+    }
+
+    invalid_id_payload = {
+        **base_payload,
+        "sequences": [{"kind": "protein", "id": 1, "sequence": "ACD", "modifications": None, "msa": None}],
+    }
+    with pytest.raises(TypeError, match="id"):
+        payloads.decode_structure_input(invalid_id_payload)
+
+    invalid_sequence_payload = {
+        **base_payload,
+        "sequences": [{"kind": "protein", "id": "A", "sequence": None, "modifications": None, "msa": None}],
+    }
+    with pytest.raises(TypeError, match="protein.sequence"):
+        payloads.decode_structure_input(invalid_sequence_payload)
+
+    invalid_msa_payload = {
+        **base_payload,
+        "sequences": [
+            {
+                "kind": "protein",
+                "id": "A",
+                "sequence": "ACD",
+                "modifications": None,
+                "msa": {"sequences": ["ACD"], "remove_insertions": "false"},
+            }
+        ],
+    }
+    with pytest.raises(TypeError, match="remove_insertions"):
+        payloads.decode_structure_input(invalid_msa_payload)
+
+
+def test_esmfold2_rejects_file_backed_msa_until_supported() -> None:
+    """Shared path-backed MSA inputs should fail clearly for ESMFold2 for now."""
+    with pytest.raises(ValueError, match="requires in-memory MSA sequences"):
+        _core_cls()._to_esm_msa(MSAInput(path="/tmp/example.a3m"))
 
 
 def test_esmfold2_rejects_invalid_dynamic_options() -> None:
     """Invalid dynamic inference options should fail before remote execution."""
-    core = ESMFold2Core(config={"device": "cpu"})
+    core = _core_cls()(config={"device": "cpu"})
 
     with pytest.raises(ValueError, match="num_diffusion_samples"):
         core.fold("ACD", options={"num_diffusion_samples": 0})
@@ -109,6 +191,7 @@ def test_esmfold2_rejects_invalid_dynamic_options() -> None:
 
 def test_esmfold2_apptainer_wrapper_encodes_rich_inputs(monkeypatch: pytest.MonkeyPatch) -> None:
     """The public wrapper should keep rich input handling out of the shared Apptainer transport."""
+    ESMFold2 = _wrapper_cls()
     model = ESMFold2.__new__(ESMFold2)
     ModelWrapper.__init__(model, backend="apptainer:test", device="cuda:0", config={})
     captured: dict[str, object] = {}
@@ -132,7 +215,7 @@ def test_esmfold2_apptainer_wrapper_encodes_rich_inputs(monkeypatch: pytest.Monk
 
 def test_esmfold2_rejects_empty_chain() -> None:
     """Empty chains should fail before reaching the Biohub tokenizer."""
-    core = ESMFold2Core(config={"device": "cpu"})
+    core = _core_cls()(config={"device": "cpu"})
 
     with pytest.raises(ValueError, match="empty chain"):
         core._coerce_requests("A::B")


### PR DESCRIPTION
## Summary
- Address CodeRabbit review threads from #103: NumPy-style docstring, strict ESMFold2 payload decoding, boolean MSA decoding, pinned ESMFold2 runtime dependencies, non-root ESMFold2 Docker runtime, and test import gating.
- Add shared lightweight `boileroom.inputs.MSAInput` and keep ESMFold2's MSA support explicitly sequence-backed for now.
- Preserve/reuse the existing ESMFold2 pocket-conditioning additions while tightening payload validation around scalar fields.

## Validation
- Rebuilt and pushed temporary validation tags:
  - `docker.io/jakublala/boileroom-esmfold2:cuda12.6-sha-esmfold2-review-test`
  - `docker.io/jakublala/boileroom-esmfold2:sha-esmfold2-review-test`
- `uv run pytest tests/esmfold2/test_esmfold2_integration.py --backend modal --gpu L4 --image-tag sha-esmfold2-review-test -q`
  - `1 passed in 379.17s`
- `uv run pytest -m 'not integration' -q`
  - `121 passed, 3 skipped, 46 deselected`
- `uv run python scripts/harness/check_repo.py`
  - passed
- `uv run --extra dev pre-commit run --all-files`
  - passed

## Notes
- This is a stacked PR into `feat/esmfold2` so the review fixes stay isolated from the original ESMFold2 feature PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `MSAInput` support for providing in-memory multiple-sequence-alignment data to ESMFold2.

* **Documentation**
  * Updated ESMFold2 documentation with MSA input examples and usage guidance.

* **Chores**
  * Enhanced Docker security and configuration.
  * Pinned dependency versions for improved stability.
  * Refactored tests for better maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/softnanolab/boileroom/pull/104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->