### PR TITLE
Add Protenix and AlphaFold2-Multimer wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ In `0.3.1`, this replaces ESMFold's old padded pLDDT batch array and moves Boltz
 | ESM-2    | ✅      | MSA-free embedding model   | [Facebook (now Meta)](https://github.com/facebookresearch/esm)     |
 | Chai-1    | ✅      | Protein design and structure prediction model | [Chai Discovery](https://github.com/chaidiscovery/chai-lab) |
 | Boltz-2   | ✅      | Diffusion-based protein structure prediction | [Boltz / MIT](https://github.com/jwohlwend/boltz) |
+| Protenix  | 🍊      | CLI-backed biomolecular structure prediction | [ByteDance](https://github.com/bytedance/Protenix) |
+| AlphaFold2-Multimer | 🍊 | CLI-backed protein complex prediction | [Google DeepMind](https://github.com/google-deepmind/alphafold) |
 
 ## Development
 

--- a/boileroom/__init__.py
+++ b/boileroom/__init__.py
@@ -17,7 +17,15 @@ def __getattr__(name: str):
         from .models import Boltz2
 
         return Boltz2
+    if name == "Protenix":
+        from .models import Protenix
+
+        return Protenix
+    if name == "AlphaFold2Multimer":
+        from .models import AlphaFold2Multimer
+
+        return AlphaFold2Multimer
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["ESMFold", "ESM2", "Chai1", "Boltz2"]
+__all__ = ["ESMFold", "ESM2", "Chai1", "Boltz2", "Protenix", "AlphaFold2Multimer"]

--- a/boileroom/base.py
+++ b/boileroom/base.py
@@ -7,14 +7,16 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any, ClassVar, Literal, Protocol, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Protocol, cast
 
 import numpy as np
-import torch
 
 from .images.metadata import format_image_reference, get_image_tag
 from .models.registry import ModelSpec, resolve_object
 from .utils import validate_sequence
+
+if TYPE_CHECKING:
+    import torch
 
 logger = logging.getLogger(__name__)
 
@@ -117,7 +119,7 @@ class Algorithm(ABC):
         # updating the model if anything has changed
         self.config = {**self.config, **config}
 
-    def _resolve_device(self) -> torch.device:
+    def _resolve_device(self) -> "torch.device":
         """Select the computation device based on instance configuration and system capability.
 
         If the instance config contains a "device" entry, that device is returned; otherwise return "cuda:0" when CUDA is available, falling back to "cpu" when not.
@@ -127,6 +129,8 @@ class Algorithm(ABC):
         torch.device
             The resolved device.
         """
+        import torch
+
         requested = self.config.get("device")
         if requested is not None:
             return torch.device(requested)

--- a/boileroom/images/import_checks.py
+++ b/boileroom/images/import_checks.py
@@ -22,6 +22,11 @@ from .metadata import (
 _CUDA_TAG_PATTERN = re.compile(r"^cuda\d+\.\d+(?:-.+)?$")
 
 IMPORT_NAME_OVERRIDES: Final[dict[str, str | None]] = {
+    "absl-py": "absl",
+    "biopython": "Bio",
+    "dm-haiku": "haiku",
+    "ml-collections": "ml_collections",
+    "tensorflow-cpu": "tensorflow",
     "pytorch-lightning": "pytorch_lightning",
     "torch-tensorrt": None,
     "hf-transfer": None,
@@ -46,6 +51,28 @@ def compute_cuda_versions(requested: list[str] | None, all_cuda: bool) -> list[s
 def package_name_to_import_name(package_name: str) -> str | None:
     """Return the importable module name for a dependency string."""
     return IMPORT_NAME_OVERRIDES.get(package_name, package_name.replace("-", "_"))
+
+
+def requirement_line_to_package_name(line: str) -> str | None:
+    """Return the package name from one requirements.txt line, or None for pip options."""
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#") or stripped.startswith("-"):
+        return None
+    return re.split(r"[>=<!=;\[]", stripped, maxsplit=1)[0].strip() or None
+
+
+def requirement_import_names(requirements_path: Path) -> list[str]:
+    """Return import names represented by a requirements.txt file."""
+    import_names = []
+    with requirements_path.open(encoding="utf-8") as handle:
+        for line in handle:
+            package_name = requirement_line_to_package_name(line)
+            if package_name is None:
+                continue
+            import_name = package_name_to_import_name(package_name)
+            if import_name:
+                import_names.append(import_name)
+    return import_names
 
 
 def iter_image_targets(

--- a/boileroom/images/import_checks.py
+++ b/boileroom/images/import_checks.py
@@ -14,9 +14,11 @@ from .metadata import (
     RuntimeImageSpec,
     format_image_reference,
     get_supported_cuda,
+    get_supported_platforms,
     normalize_cuda_version,
     normalize_requested_tag,
     published_image_references,
+    split_platforms,
 )
 
 _CUDA_TAG_PATTERN = re.compile(r"^cuda\d+\.\d+(?:-.+)?$")
@@ -81,6 +83,7 @@ def iter_image_targets(
     *,
     docker_repository: str = DEFAULT_DOCKER_REPOSITORY,
     image_specs: Sequence[RuntimeImageSpec] | None = None,
+    platform: str | None = None,
 ) -> list[tuple[str, str, str, Path, Path]]:
     """Return model-image targets for smoke checks.
 
@@ -91,8 +94,12 @@ def iter_image_targets(
         raise ValueError("Do not combine --all-cuda/--cuda-version with an already CUDA-qualified --tag.")
 
     specs = MODEL_IMAGE_SPECS if image_specs is None else image_specs
+    requested_platforms = set(split_platforms(platform)) if platform is not None else None
     targets: list[tuple[str, str, str, Path, Path]] = []
     for spec in specs:
+        if requested_platforms is not None and not requested_platforms.issubset(get_supported_platforms(spec)):
+            continue
+
         requirements_path = spec.context_path / "requirements.txt"
         core_path = spec.context_path / "core.py"
         if cuda_versions:

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import os
+import platform as platform_module
 import re
 import tomllib
 from dataclasses import dataclass
@@ -18,6 +19,7 @@ DOCKER_REPOSITORY_ENV: Final = "BOILEROOM_DOCKER_REPOSITORY"
 IMAGE_TAG_ENV: Final = "BOILEROOM_IMAGE_TAG"
 
 SUPPORTED_CUDA_VERSIONS: Final[tuple[str, ...]] = ("11.8", "12.6")
+SUPPORTED_PLATFORMS: Final[tuple[str, ...]] = ("linux/amd64", "linux/arm64")
 
 CUDA_TORCH_WHEEL_INDEX: Final[dict[str, str]] = {
     "11.8": "https://download.pytorch.org/whl/cu118",
@@ -142,6 +144,37 @@ def normalize_cuda_version(cuda_version: str) -> str:
     return normalized
 
 
+def normalize_platform(platform: str) -> str:
+    """Return a normalized Docker platform string."""
+    normalized = platform.strip().lower()
+    if not normalized:
+        raise ValueError("Platform must not be empty.")
+    aliases = {
+        "amd64": "linux/amd64",
+        "x86_64": "linux/amd64",
+        "arm64": "linux/arm64",
+        "aarch64": "linux/arm64",
+    }
+    return aliases.get(normalized, normalized)
+
+
+def split_platforms(platforms: str) -> tuple[str, ...]:
+    """Return normalized Docker platforms from a comma-separated buildx value."""
+    normalized = tuple(normalize_platform(platform) for platform in platforms.split(",") if platform.strip())
+    if not normalized:
+        raise ValueError("Platform selection must not be empty.")
+    return normalized
+
+
+def current_docker_platform() -> str:
+    """Return the Docker Linux platform matching the current host architecture."""
+    machine = platform_module.machine().lower()
+    normalized = normalize_platform(machine)
+    if "/" in normalized:
+        return normalized
+    return f"linux/{normalized}"
+
+
 def canonical_image_tag(cuda_version: str, tag: str | None) -> str:
     """Return the canonical CUDA-qualified tag."""
     normalized_cuda = normalize_cuda_version(cuda_version)
@@ -251,18 +284,24 @@ def get_model_image_spec(identifier: str) -> RuntimeImageSpec:
 
 
 @cache
-def get_supported_cuda(spec: RuntimeImageSpec) -> tuple[str, ...]:
-    """Return supported CUDA versions for a runtime image spec."""
-    if spec.config_relative_path is None:
-        return SUPPORTED_CUDA_VERSIONS
+def _load_image_config(config_relative_path: str | None) -> dict[str, object]:
+    """Return the YAML config for a runtime image spec."""
+    if config_relative_path is None:
+        return {}
 
-    config_path = get_repo_root() / spec.config_relative_path
+    config_path = get_repo_root() / config_relative_path
     if not config_path.exists():
-        return SUPPORTED_CUDA_VERSIONS
+        return {}
 
     import yaml
 
-    config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    return yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+
+
+@cache
+def get_supported_cuda(spec: RuntimeImageSpec) -> tuple[str, ...]:
+    """Return supported CUDA versions for a runtime image spec."""
+    config = _load_image_config(spec.config_relative_path)
     raw_supported_cuda = config.get("supported_cuda", [])
     if isinstance(raw_supported_cuda, list):
         supported_cuda = [normalize_cuda_version(str(value)) for value in raw_supported_cuda]
@@ -274,6 +313,23 @@ def get_supported_cuda(spec: RuntimeImageSpec) -> tuple[str, ...]:
     if not supported_cuda:
         return SUPPORTED_CUDA_VERSIONS
     return tuple(supported_cuda)
+
+
+@cache
+def get_supported_platforms(spec: RuntimeImageSpec) -> tuple[str, ...]:
+    """Return supported Docker platforms for a runtime image spec."""
+    config = _load_image_config(spec.config_relative_path)
+    raw_supported_platforms = config.get("supported_platforms", [])
+    if isinstance(raw_supported_platforms, list):
+        supported_platforms = [normalize_platform(str(value)) for value in raw_supported_platforms]
+    elif raw_supported_platforms:
+        supported_platforms = [normalize_platform(str(raw_supported_platforms))]
+    else:
+        supported_platforms = []
+
+    if not supported_platforms:
+        return SUPPORTED_PLATFORMS
+    return tuple(supported_platforms)
 
 
 def render_modal_runtime_env(spec: RuntimeImageSpec, model_dir: str) -> dict[str, str]:

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -94,6 +94,7 @@ MODEL_IMAGE_SPECS: Final[tuple[RuntimeImageSpec, ...]] = (
         dockerfile_relative_path="boileroom/models/protenix/Dockerfile",
         context_relative_path="boileroom/models/protenix",
         config_relative_path="boileroom/models/protenix/config.yaml",
+        modal_runtime_env=(("LAYERNORM_TYPE", "openfold"),),
     ),
 )
 

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -58,6 +58,13 @@ BASE_IMAGE_SPEC: Final = RuntimeImageSpec(
 
 MODEL_IMAGE_SPECS: Final[tuple[RuntimeImageSpec, ...]] = (
     RuntimeImageSpec(
+        key="alphafold",
+        image_name="boileroom-alphafold2-multimer",
+        dockerfile_relative_path="boileroom/models/alphafold/Dockerfile",
+        context_relative_path="boileroom/models/alphafold",
+        config_relative_path="boileroom/models/alphafold/config.yaml",
+    ),
+    RuntimeImageSpec(
         key="boltz",
         image_name="boileroom-boltz",
         dockerfile_relative_path="boileroom/models/boltz/Dockerfile",
@@ -78,6 +85,13 @@ MODEL_IMAGE_SPECS: Final[tuple[RuntimeImageSpec, ...]] = (
         dockerfile_relative_path="boileroom/models/esm/Dockerfile",
         context_relative_path="boileroom/models/esm",
         config_relative_path="boileroom/models/esm/config.yaml",
+    ),
+    RuntimeImageSpec(
+        key="protenix",
+        image_name="boileroom-protenix",
+        dockerfile_relative_path="boileroom/models/protenix/Dockerfile",
+        context_relative_path="boileroom/models/protenix",
+        config_relative_path="boileroom/models/protenix/config.yaml",
     ),
 )
 

--- a/boileroom/models/__init__.py
+++ b/boileroom/models/__init__.py
@@ -17,6 +17,14 @@ def __getattr__(name: str):
         from .boltz.boltz2 import Boltz2
 
         return Boltz2
+    if name == "Protenix":
+        from .protenix.protenix import Protenix
+
+        return Protenix
+    if name == "AlphaFold2Multimer":
+        from .alphafold.alphafold2_multimer import AlphaFold2Multimer
+
+        return AlphaFold2Multimer
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -25,4 +33,6 @@ __all__ = [
     "ESM2",
     "Chai1",
     "Boltz2",
+    "Protenix",
+    "AlphaFold2Multimer",
 ]

--- a/boileroom/models/alphafold/Dockerfile
+++ b/boileroom/models/alphafold/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.7
+ARG TARGETPLATFORM
+ARG TARGETARCH
+ARG TARGETOS
+ARG BUILDPLATFORM
+
+ARG BASE_IMAGE=docker.io/jakublala/boileroom-base:local
+FROM ${BASE_IMAGE}
+
+COPY requirements.txt /tmp/requirements.txt
+
+ARG ALPHAFOLD_REF=c77e5d2a8961d1a353632c462914ff0a32a950f6
+ARG TORCH_WHEEL_INDEX=https://download.pytorch.org/whl/cu126
+ARG UV_CACHE_ID=boileroom-uv
+ENV PIP_EXTRA_INDEX_URL=${TORCH_WHEEL_INDEX}
+ENV UV_INDEX=${TORCH_WHEEL_INDEX}
+ENV UV_INDEX_STRATEGY=unsafe-best-match
+
+RUN apt-get update --quiet \
+    && apt-get install --no-install-recommends --yes --quiet \
+        build-essential \
+        cmake \
+        git \
+        hmmer \
+        hhsuite \
+        kalign \
+        wget \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN git init /app/alphafold \
+    && git -C /app/alphafold remote add origin https://github.com/google-deepmind/alphafold.git \
+    && git -C /app/alphafold fetch --depth 1 origin ${ALPHAFOLD_REF} \
+    && git -C /app/alphafold checkout --detach FETCH_HEAD \
+    && wget -q -P /app/alphafold/alphafold/common/ \
+        https://git.scicore.unibas.ch/schwede/openstructure/-/raw/7102c63615b64735c4941278d92b554ec94415f8/modules/mol/alg/src/stereo_chemical_props.txt
+
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv \
+    uv pip install --system -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
+
+RUN echo '#!/usr/bin/env bash\nset -euo pipefail\npython /app/alphafold/run_alphafold.py "$@"' > /app/run_alphafold.sh \
+    && chmod +x /app/run_alphafold.sh
+
+ENV PYTHONPATH=/app/alphafold

--- a/boileroom/models/alphafold/__init__.py
+++ b/boileroom/models/alphafold/__init__.py
@@ -1,0 +1,21 @@
+"""AlphaFold model package."""
+
+
+def __getattr__(name: str):
+    """Lazy imports avoid importing Modal when only core.py is needed."""
+    if name == "AlphaFold2Multimer":
+        from .alphafold2_multimer import AlphaFold2Multimer
+
+        return AlphaFold2Multimer
+    if name == "ModalAlphaFold2Multimer":
+        from .alphafold2_multimer import ModalAlphaFold2Multimer
+
+        return ModalAlphaFold2Multimer
+    if name == "AlphaFold2MultimerOutput":
+        from .types import AlphaFold2MultimerOutput
+
+        return AlphaFold2MultimerOutput
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["AlphaFold2Multimer", "AlphaFold2MultimerOutput", "ModalAlphaFold2Multimer"]

--- a/boileroom/models/alphafold/alphafold2_multimer.py
+++ b/boileroom/models/alphafold/alphafold2_multimer.py
@@ -1,0 +1,72 @@
+"""Public and Modal wrappers for AlphaFold2-Multimer."""
+
+import json
+import logging
+from collections.abc import Sequence
+
+import modal
+
+from ...backend.modal import get_modal_app
+from ...base import ModelWrapper
+from ...images.volumes import model_weights
+from ...utils import HOURS, MINUTES, MODAL_MODEL_DIR
+from ..registry import ALPHAFOLD2_MULTIMER_SPEC
+from .image import alphafold2_multimer_image
+from .types import AlphaFold2MultimerOutput
+
+logger = logging.getLogger(__name__)
+app = get_modal_app("alphafold2_multimer")
+
+
+@app.cls(
+    image=alphafold2_multimer_image,
+    gpu="A100-80GB",
+    timeout=6 * HOURS,
+    scaledown_window=10 * MINUTES,
+    volumes={MODAL_MODEL_DIR: model_weights},
+)
+class ModalAlphaFold2Multimer:
+    """Modal entrypoint for AlphaFold2-Multimer."""
+
+    config: bytes = modal.parameter(default=b"{}")
+
+    @modal.enter()
+    def _initialize(self) -> None:
+        from .core import AlphaFold2MultimerCore
+
+        self._core = AlphaFold2MultimerCore(json.loads(self.config.decode("utf-8")))
+        self._core._initialize()
+
+    @modal.method()
+    def fold(self, sequences: str | Sequence[str], options: dict | None = None) -> "AlphaFold2MultimerOutput":
+        return self._core.fold(sequences, options=options)
+
+
+class AlphaFold2Multimer(ModelWrapper):
+    """Interface for AlphaFold2-Multimer structure prediction."""
+
+    MODEL_SPEC = ALPHAFOLD2_MULTIMER_SPEC
+
+    def __init__(self, backend: str = "modal", device: str | None = None, config: dict | None = None) -> None:
+        """Create an AlphaFold2-Multimer model wrapper."""
+        super().__init__(backend=backend, device=device, config=config)
+        self._initialize_backend_from_spec(self.MODEL_SPEC, backend=backend, device=device, config=config)
+
+    def fold(self, sequences: str | Sequence[str], options: dict | None = None) -> "AlphaFold2MultimerOutput":
+        """Run AlphaFold2-Multimer for a single sequence entry.
+
+        Use ``:`` inside a sequence string to define multiple chains.
+        """
+        validated_sequences = [sequences] if isinstance(sequences, str) else list(sequences)
+        if len(validated_sequences) != 1:
+            raise ValueError(
+                "AlphaFold2-Multimer currently supports exactly one top-level sequence per call; use ':' to join chains."
+            )
+        if options is not None:
+            static_keys = self.MODEL_SPEC.contract.static_config_keys & set(options)
+            if static_keys:
+                raise ValueError(
+                    "The following config keys can only be set at initialization and cannot be overridden per-call: "
+                    f"{sorted(static_keys)}"
+                )
+        return self._call_backend_method("fold", sequences, options=options)

--- a/boileroom/models/alphafold/config.yaml
+++ b/boileroom/models/alphafold/config.yaml
@@ -1,0 +1,2 @@
+supported_cuda:
+  - "12.6"

--- a/boileroom/models/alphafold/config.yaml
+++ b/boileroom/models/alphafold/config.yaml
@@ -1,2 +1,4 @@
 supported_cuda:
   - "12.6"
+supported_platforms:
+  - "linux/amd64"

--- a/boileroom/models/alphafold/core.py
+++ b/boileroom/models/alphafold/core.py
@@ -1,0 +1,325 @@
+"""Core AlphaFold2-Multimer implementation backed by the official runner."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import os
+import pickle
+import subprocess
+from collections.abc import Sequence
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, ClassVar, cast
+
+import numpy as np
+from biotite.structure.io.pdb import PDBFile
+from biotite.structure.io.pdb import get_structure as get_pdb_structure
+from biotite.structure.io.pdbx import CIFFile
+from biotite.structure.io.pdbx import get_structure as get_cif_structure
+
+from ...base import FoldingAlgorithm, PredictionMetadata
+from ...utils import MODAL_MODEL_DIR, Timer
+from .types import AlphaFold2MultimerOutput
+
+logger = logging.getLogger(__name__)
+
+
+class AlphaFold2MultimerCore(FoldingAlgorithm):
+    """AlphaFold2-Multimer structure prediction model."""
+
+    DEFAULT_CONFIG: ClassVar[dict[str, Any]] = {
+        "device": None,
+        "alphafold_command": "/app/run_alphafold.sh",
+        "data_dir": None,
+        "max_template_date": "2022-01-01",
+        "db_preset": "full_dbs",
+        "num_multimer_predictions_per_model": 5,
+        "models_to_relax": "none",
+        "use_gpu_relax": False,
+        "use_precomputed_msas": False,
+        "benchmark": False,
+        "random_seed": None,
+        "jackhmmer_binary_path": None,
+        "hhblits_binary_path": None,
+        "hhsearch_binary_path": None,
+        "hmmsearch_binary_path": None,
+        "hmmbuild_binary_path": None,
+        "kalign_binary_path": None,
+        "uniref90_database_path": None,
+        "mgnify_database_path": None,
+        "bfd_database_path": None,
+        "small_bfd_database_path": None,
+        "uniref30_database_path": None,
+        "uniprot_database_path": None,
+        "pdb_seqres_database_path": None,
+        "template_mmcif_dir": None,
+        "obsolete_pdbs_path": None,
+        "include_fields": None,
+        "timeout_seconds": None,
+    }
+    STATIC_CONFIG_KEYS: ClassVar[frozenset[str]] = frozenset({"device", "alphafold_command", "data_dir"})
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        """Create an AlphaFold2-Multimer CLI-backed core instance."""
+        super().__init__(config or {})
+        self._metadata_template = self._initialize_metadata(
+            model_name="AlphaFold2-Multimer",
+            model_version="v2",
+        )
+
+    def _initialize(self) -> None:
+        """Mark the CLI-backed core ready."""
+        self._load()
+
+    def _load(self) -> None:
+        """Validate static configuration and mark the core ready."""
+        if not str(self.config.get("alphafold_command", "")).strip():
+            raise ValueError("alphafold_command must not be empty")
+        self.ready = True
+
+    def fold(self, sequences: str | Sequence[str], options: dict | None = None) -> AlphaFold2MultimerOutput:
+        """Run AlphaFold2-Multimer for one sequence entry.
+
+        Use ``:`` inside a sequence string to define multiple protein chains.
+        """
+        effective_config = self._merge_options(options)
+        validated_sequences = self._validate_sequences(sequences)
+        if len(validated_sequences) != 1:
+            raise ValueError(
+                "AlphaFold2-Multimer currently supports exactly one top-level sequence per call; use ':' to join chains."
+            )
+
+        metadata = dataclasses.replace(
+            self._metadata_template,
+            sequence_lengths=self._compute_sequence_lengths(validated_sequences),
+        )
+
+        with TemporaryDirectory() as buffer_dir:
+            buffer_path = Path(buffer_dir)
+            with Timer("AlphaFold2-Multimer preprocessing") as preprocess_timer:
+                fasta_path = self._write_fasta(validated_sequences[0], buffer_path)
+                output_dir = buffer_path / "outputs"
+                output_dir.mkdir(parents=True, exist_ok=True)
+                command = self._build_command(fasta_path, output_dir, effective_config)
+
+            with Timer("AlphaFold2-Multimer inference") as inference_timer:
+                self._run_command(command, effective_config)
+
+            with Timer("AlphaFold2-Multimer postprocessing") as postprocess_timer:
+                output = self._collect_outputs(output_dir / fasta_path.stem, metadata, effective_config)
+
+        output.metadata.preprocessing_time = preprocess_timer.duration
+        output.metadata.inference_time = inference_timer.duration
+        output.metadata.postprocessing_time = postprocess_timer.duration
+        return output
+
+    def _write_fasta(self, sequence_entry: str, buffer_path: Path) -> Path:
+        chains = [part.strip() for part in sequence_entry.split(":") if part.strip()]
+        if not chains:
+            raise ValueError("AlphaFold2-Multimer input must contain at least one chain")
+
+        fasta_path = buffer_path / "target.fasta"
+        fasta_lines = []
+        for index, sequence in enumerate(chains):
+            fasta_lines.extend([f">chain_{index}", sequence])
+        fasta_path.write_text("\n".join(fasta_lines) + "\n", encoding="utf-8")
+        return fasta_path
+
+    def _build_command(self, fasta_path: Path, output_dir: Path, config: dict[str, Any]) -> list[str]:
+        data_dir = config.get("data_dir")
+        if data_dir is None:
+            data_dir = str(Path(os.environ.get("MODEL_DIR", MODAL_MODEL_DIR)) / "alphafold")
+
+        database_paths = _resolve_multimer_database_paths(Path(str(data_dir)), config)
+        command = [
+            str(config["alphafold_command"]),
+            f"--fasta_paths={fasta_path}",
+            f"--output_dir={output_dir}",
+            f"--data_dir={data_dir}",
+            f"--max_template_date={config['max_template_date']}",
+            f"--db_preset={config['db_preset']}",
+            "--model_preset=multimer",
+            f"--num_multimer_predictions_per_model={int(config['num_multimer_predictions_per_model'])}",
+            f"--models_to_relax={config['models_to_relax']}",
+            f"--use_gpu_relax={_bool_arg(config['use_gpu_relax'])}",
+            f"--use_precomputed_msas={_bool_arg(config['use_precomputed_msas'])}",
+            f"--benchmark={_bool_arg(config['benchmark'])}",
+            "--logtostderr",
+        ]
+        for flag_name, path in database_paths.items():
+            command.append(f"--{flag_name}={path}")
+        for flag_name in (
+            "jackhmmer_binary_path",
+            "hhblits_binary_path",
+            "hhsearch_binary_path",
+            "hmmsearch_binary_path",
+            "hmmbuild_binary_path",
+            "kalign_binary_path",
+        ):
+            if config.get(flag_name) is not None:
+                command.append(f"--{flag_name}={config[flag_name]}")
+        if config.get("random_seed") is not None:
+            command.append(f"--random_seed={int(config['random_seed'])}")
+        return command
+
+    def _run_command(self, command: list[str], config: dict[str, Any]) -> None:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=_command_env(config),
+            timeout=config.get("timeout_seconds"),
+        )
+        if result.returncode != 0:
+            tail = "\n".join((result.stdout + "\n" + result.stderr).splitlines()[-80:])
+            raise RuntimeError(f"AlphaFold2-Multimer command failed with exit code {result.returncode}:\n{tail}")
+
+    def _collect_outputs(
+        self,
+        target_dir: Path,
+        metadata: PredictionMetadata,
+        config: dict[str, Any],
+    ) -> AlphaFold2MultimerOutput:
+        if not target_dir.exists():
+            raise RuntimeError(f"AlphaFold2-Multimer output directory not found: {target_dir}")
+
+        ranking_path = target_dir / "ranking_debug.json"
+        ranking = json.loads(ranking_path.read_text(encoding="utf-8")) if ranking_path.exists() else {}
+        order = [str(item) for item in ranking.get("order", [])]
+
+        pdb_paths = sorted(target_dir.glob("ranked_*.pdb"), key=_rank_from_ranked_path)
+        cif_paths = {path.stem: path for path in target_dir.glob("ranked_*.cif")}
+        if not pdb_paths and not cif_paths:
+            raise RuntimeError(f"AlphaFold2-Multimer produced no ranked structures under {target_dir}")
+
+        include_fields = config.get("include_fields")
+        atom_arrays = []
+        pdb_strings: list[str] | None = [] if _include_field(include_fields, "pdb") else None
+        cif_strings: list[str] | None = [] if _include_field(include_fields, "cif") else None
+        plddt_values: list[np.ndarray | None] = []
+        ptm_values: list[np.ndarray | None] = []
+        iptm_values: list[np.ndarray | None] = []
+        pae_values: list[np.ndarray | None] = []
+
+        ranked_indices = sorted(
+            {_rank_from_ranked_path(path) for path in pdb_paths}
+            | {_rank_from_ranked_path(path) for path in cif_paths.values()}
+        )
+        for rank in ranked_indices:
+            stem = f"ranked_{rank}"
+            cif_path = cif_paths.get(stem)
+            pdb_path = target_dir / f"{stem}.pdb"
+            if cif_path is not None and cif_path.exists():
+                atom_arrays.append(get_cif_structure(CIFFile.read(str(cif_path)), model=1))
+                if cif_strings is not None:
+                    cif_strings.append(cif_path.read_text(encoding="utf-8"))
+                if pdb_strings is not None and pdb_path.exists():
+                    pdb_strings.append(pdb_path.read_text(encoding="utf-8"))
+            elif pdb_path.exists():
+                atom_arrays.append(get_pdb_structure(PDBFile.read(str(pdb_path)), model=1))
+                if pdb_strings is not None:
+                    pdb_strings.append(pdb_path.read_text(encoding="utf-8"))
+            else:
+                continue
+
+            model_name = order[rank] if rank < len(order) else None
+            result = _load_result_pickle(target_dir, model_name)
+            plddt_values.append(_optional_array(result, "plddt"))
+            ptm_values.append(_optional_scalar(result, "ptm"))
+            iptm_values.append(_optional_scalar(result, "iptm"))
+            pae_values.append(_optional_array(result, "predicted_aligned_error"))
+
+        output = AlphaFold2MultimerOutput(
+            metadata=metadata,
+            atom_array=atom_arrays,
+            ranking=ranking or None,
+            plddt=plddt_values if any(value is not None for value in plddt_values) else None,
+            ptm=ptm_values if any(value is not None for value in ptm_values) else None,
+            iptm=iptm_values if any(value is not None for value in iptm_values) else None,
+            pae=pae_values if any(value is not None for value in pae_values) else None,
+            pdb=pdb_strings,
+            cif=cif_strings,
+        )
+        return cast(AlphaFold2MultimerOutput, self._filter_include_fields(output, include_fields))
+
+
+def _bool_arg(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _extract_device_number(device: str) -> str | None:
+    if device.startswith("cuda:"):
+        return device.split(":", 1)[1]
+    return None
+
+
+def _command_env(config: dict[str, Any]) -> dict[str, str]:
+    env = os.environ.copy()
+    device = config.get("device")
+    if device is None:
+        return env
+    device_name = str(device)
+    device_number = _extract_device_number(device_name)
+    if device_number is not None:
+        env["CUDA_VISIBLE_DEVICES"] = device_number
+    elif device_name == "cpu":
+        env["CUDA_VISIBLE_DEVICES"] = ""
+    return env
+
+
+def _resolve_multimer_database_paths(data_dir: Path, config: dict[str, Any]) -> dict[str, Path | str]:
+    paths: dict[str, Path | str] = {
+        "uniref90_database_path": data_dir / "uniref90" / "uniref90.fasta",
+        "mgnify_database_path": data_dir / "mgnify" / "mgy_clusters_2022_05.fa",
+        "template_mmcif_dir": data_dir / "pdb_mmcif" / "mmcif_files",
+        "obsolete_pdbs_path": data_dir / "pdb_mmcif" / "obsolete.dat",
+        "uniprot_database_path": data_dir / "uniprot" / "uniprot.fasta",
+        "pdb_seqres_database_path": data_dir / "pdb_seqres" / "pdb_seqres.txt",
+    }
+    if config["db_preset"] == "reduced_dbs":
+        paths["small_bfd_database_path"] = data_dir / "small_bfd" / "bfd-first_non_consensus_sequences.fasta"
+    else:
+        paths["bfd_database_path"] = data_dir / "bfd" / "bfd_metaclust_clu_complete_id30_c90_final_seq.sorted_opt"
+        paths["uniref30_database_path"] = data_dir / "uniref30" / "UniRef30_2021_03"
+
+    for key in tuple(paths):
+        if config.get(key) is not None:
+            paths[key] = str(config[key])
+    return paths
+
+
+def _rank_from_ranked_path(path: Path) -> int:
+    try:
+        return int(path.stem.rsplit("_", 1)[1])
+    except ValueError:
+        return 0
+
+
+def _load_result_pickle(target_dir: Path, model_name: str | None) -> dict[str, Any]:
+    if model_name is None:
+        return {}
+    result_path = target_dir / f"result_{model_name}.pkl"
+    if not result_path.exists():
+        return {}
+    with result_path.open("rb") as handle:
+        result = pickle.load(handle)
+    return result if isinstance(result, dict) else {}
+
+
+def _optional_array(result: dict[str, Any], key: str) -> np.ndarray | None:
+    if key not in result or result[key] is None:
+        return None
+    return np.asarray(result[key], dtype=np.float32)
+
+
+def _optional_scalar(result: dict[str, Any], key: str) -> np.ndarray | None:
+    if key not in result or result[key] is None:
+        return None
+    return np.asarray(result[key], dtype=np.float32).reshape(1)
+
+
+def _include_field(include_fields: list[str] | None, field: str) -> bool:
+    return include_fields is not None and ("*" in include_fields or field in include_fields)

--- a/boileroom/models/alphafold/image.py
+++ b/boileroom/models/alphafold/image.py
@@ -1,0 +1,5 @@
+"""Modal image definition for AlphaFold2-Multimer."""
+
+from ...images.modal import get_modal_image
+
+alphafold2_multimer_image = get_modal_image("alphafold")

--- a/boileroom/models/alphafold/requirements.txt
+++ b/boileroom/models/alphafold/requirements.txt
@@ -1,6 +1,6 @@
 -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
 absl-py==1.0.0
-biopython==1.79
+biopython==1.83
 biotite>=1.0.1
 dm-haiku==0.0.12
 docker==5.0.0

--- a/boileroom/models/alphafold/requirements.txt
+++ b/boileroom/models/alphafold/requirements.txt
@@ -1,0 +1,18 @@
+-f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html
+absl-py==1.0.0
+biopython==1.79
+biotite>=1.0.1
+dm-haiku==0.0.12
+docker==5.0.0
+fastapi
+jax==0.4.26
+jaxlib==0.4.26+cuda12.cudnn89
+matplotlib==3.8.0
+ml-collections==0.1.0
+numpy==1.26.4
+openmm[cuda12]==8.2.0
+pdbfixer==1.12.0
+pydantic
+setuptools<72.0.0
+tensorflow-cpu==2.16.1
+uvicorn

--- a/boileroom/models/alphafold/types.py
+++ b/boileroom/models/alphafold/types.py
@@ -1,0 +1,69 @@
+"""Type definitions for AlphaFold2-Multimer outputs."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from ...base import PredictionMetadata, StructurePrediction
+
+
+@dataclass
+class AlphaFold2MultimerOutput(StructurePrediction):
+    """Output from AlphaFold2-Multimer prediction."""
+
+    metadata: PredictionMetadata
+    atom_array: list[Any] | None = None
+
+    ranking: dict[str, Any] | None = None
+    plddt: list[np.ndarray | None] | None = None
+    ptm: list[np.ndarray | None] | None = None
+    iptm: list[np.ndarray | None] | None = None
+    pae: list[np.ndarray | None] | None = None
+    pdb: list[str] | None = None
+    cif: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize confidence arrays to stable shapes."""
+        self.ptm = _normalize_scalar_scores(self.ptm, "AlphaFold2-Multimer pTM")
+        self.iptm = _normalize_scalar_scores(self.iptm, "AlphaFold2-Multimer iPTM")
+        if self.plddt is not None:
+            self.plddt = [_normalize_vector(value, "AlphaFold2-Multimer pLDDT") for value in self.plddt]
+        if self.pae is not None:
+            self.pae = [_normalize_matrix(value, "AlphaFold2-Multimer PAE") for value in self.pae]
+
+
+def _normalize_scalar_scores(values: list[np.ndarray | None] | None, label: str) -> list[np.ndarray | None] | None:
+    if values is None:
+        return None
+
+    scores: list[np.ndarray | None] = []
+    for value in values:
+        if value is None:
+            scores.append(None)
+            continue
+        score = np.asarray(value, dtype=np.float32).squeeze()
+        if score.ndim != 0:
+            raise ValueError(f"{label} expected a scalar score; got {score.shape}")
+        scores.append(score.reshape(1))
+    return scores if any(score is not None for score in scores) else None
+
+
+def _normalize_vector(value: np.ndarray | None, label: str) -> np.ndarray | None:
+    if value is None:
+        return None
+    arr = np.asarray(value, dtype=np.float32).squeeze()
+    if arr.ndim != 1:
+        raise ValueError(f"{label} expected a 1D array; got {arr.shape}")
+    if arr.size and np.nanmax(arr) > 1.0:
+        arr = arr / 100.0
+    return arr
+
+
+def _normalize_matrix(value: np.ndarray | None, label: str) -> np.ndarray | None:
+    if value is None:
+        return None
+    arr = np.asarray(value, dtype=np.float32).squeeze()
+    if arr.ndim != 2 or arr.shape[0] != arr.shape[1]:
+        raise ValueError(f"{label} expected a square matrix; got {arr.shape}")
+    return arr

--- a/boileroom/models/protenix/Dockerfile
+++ b/boileroom/models/protenix/Dockerfile
@@ -1,0 +1,27 @@
+# syntax=docker/dockerfile:1.7
+ARG TARGETPLATFORM
+ARG TARGETARCH
+ARG TARGETOS
+ARG BUILDPLATFORM
+
+ARG BASE_IMAGE=docker.io/jakublala/boileroom-base:local
+FROM ${BASE_IMAGE}
+
+COPY requirements.txt /tmp/requirements.txt
+
+ARG TORCH_WHEEL_INDEX=https://download.pytorch.org/whl/cu126
+ARG UV_CACHE_ID=boileroom-uv
+ENV PIP_EXTRA_INDEX_URL=${TORCH_WHEEL_INDEX}
+ENV UV_INDEX=${TORCH_WHEEL_INDEX}
+ENV UV_INDEX_STRATEGY=unsafe-best-match
+
+RUN apt-get update --quiet \
+    && apt-get install --no-install-recommends --yes --quiet hmmer kalign git \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv \
+    uv pip install --system -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt
+
+ENV HF_HUB_ENABLE_HF_TRANSFER=1 \
+    DISABLE_PANDERA_IMPORT_WARNING=True

--- a/boileroom/models/protenix/Dockerfile
+++ b/boileroom/models/protenix/Dockerfile
@@ -24,4 +24,5 @@ RUN --mount=type=cache,id=${UV_CACHE_ID},target=/root/.cache/uv \
     && rm /tmp/requirements.txt
 
 ENV HF_HUB_ENABLE_HF_TRANSFER=1 \
-    DISABLE_PANDERA_IMPORT_WARNING=True
+    DISABLE_PANDERA_IMPORT_WARNING=True \
+    LAYERNORM_TYPE=openfold

--- a/boileroom/models/protenix/__init__.py
+++ b/boileroom/models/protenix/__init__.py
@@ -1,0 +1,21 @@
+"""Protenix model package."""
+
+
+def __getattr__(name: str):
+    """Lazy imports avoid importing Modal when only core.py is needed."""
+    if name == "Protenix":
+        from .protenix import Protenix
+
+        return Protenix
+    if name == "ModalProtenix":
+        from .protenix import ModalProtenix
+
+        return ModalProtenix
+    if name == "ProtenixOutput":
+        from .types import ProtenixOutput
+
+        return ProtenixOutput
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = ["ModalProtenix", "Protenix", "ProtenixOutput"]

--- a/boileroom/models/protenix/config.yaml
+++ b/boileroom/models/protenix/config.yaml
@@ -1,0 +1,2 @@
+supported_cuda:
+  - "12.6"

--- a/boileroom/models/protenix/config.yaml
+++ b/boileroom/models/protenix/config.yaml
@@ -1,2 +1,4 @@
 supported_cuda:
   - "12.6"
+supported_platforms:
+  - "linux/amd64"

--- a/boileroom/models/protenix/core.py
+++ b/boileroom/models/protenix/core.py
@@ -1,0 +1,276 @@
+"""Core Protenix implementation backed by the official CLI."""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import logging
+import os
+import subprocess
+from collections.abc import Iterable, Sequence
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, ClassVar, cast
+
+from biotite.structure.io.pdbx import CIFFile, get_structure
+
+from ...base import FoldingAlgorithm, PredictionMetadata
+from ...utils import Timer
+from .types import ProtenixOutput
+
+logger = logging.getLogger(__name__)
+
+
+class ProtenixCore(FoldingAlgorithm):
+    """Protenix structure prediction model."""
+
+    DEFAULT_CONFIG: ClassVar[dict[str, Any]] = {
+        "device": None,
+        "protenix_command": "protenix",
+        "model_name": "protenix_base_default_v1.0.0",
+        "seeds": "101",
+        "cycle": 10,
+        "step": 200,
+        "sample": 5,
+        "dtype": "bf16",
+        "use_msa": True,
+        "use_template": False,
+        "use_default_params": False,
+        "trimul_kernel": "cuequivariance",
+        "triatt_kernel": "cuequivariance",
+        "enable_cache": True,
+        "enable_fusion": True,
+        "enable_tf32": True,
+        "use_seeds_in_json": False,
+        "use_tfg_guidance": False,
+        "include_fields": None,
+        "timeout_seconds": None,
+    }
+    STATIC_CONFIG_KEYS: ClassVar[frozenset[str]] = frozenset({"device", "protenix_command"})
+
+    def __init__(self, config: dict[str, Any] | None = None) -> None:
+        """Create a Protenix CLI-backed core instance."""
+        super().__init__(config or {})
+        self._metadata_template = self._initialize_metadata(
+            model_name="Protenix",
+            model_version=str(self.config["model_name"]),
+        )
+
+    def _initialize(self) -> None:
+        """Mark the CLI-backed core ready."""
+        self._load()
+
+    def _load(self) -> None:
+        """Validate static configuration and mark the core ready."""
+        if not str(self.config.get("protenix_command", "")).strip():
+            raise ValueError("protenix_command must not be empty")
+        self.ready = True
+
+    def fold(self, sequences: str | Sequence[str], options: dict | None = None) -> ProtenixOutput:
+        """Run Protenix prediction for one sequence entry.
+
+        Use ``:`` inside a sequence string to define multiple protein chains.
+        """
+        effective_config = self._merge_options(options)
+        validated_sequences = self._validate_sequences(sequences)
+        if len(validated_sequences) != 1:
+            raise ValueError(
+                "Protenix currently supports exactly one top-level sequence per call; use ':' to join chains."
+            )
+
+        metadata = dataclasses.replace(
+            self._metadata_template,
+            model_version=str(effective_config["model_name"]),
+            sequence_lengths=self._compute_sequence_lengths(validated_sequences),
+        )
+
+        with TemporaryDirectory() as buffer_dir:
+            buffer_path = Path(buffer_dir)
+            with Timer("Protenix preprocessing") as preprocess_timer:
+                input_json = self._write_input_json(validated_sequences[0], buffer_path)
+                output_dir = buffer_path / "outputs"
+                output_dir.mkdir(parents=True, exist_ok=True)
+                command = self._build_command(input_json, output_dir, effective_config)
+
+            with Timer("Protenix inference") as inference_timer:
+                self._run_command(command, effective_config)
+
+            with Timer("Protenix postprocessing") as postprocess_timer:
+                output = self._collect_outputs(output_dir, metadata, effective_config)
+
+        output.metadata.preprocessing_time = preprocess_timer.duration
+        output.metadata.inference_time = inference_timer.duration
+        output.metadata.postprocessing_time = postprocess_timer.duration
+        return output
+
+    def _write_input_json(self, sequence_entry: str, buffer_path: Path) -> Path:
+        chains = [part.strip() for part in sequence_entry.split(":") if part.strip()]
+        if not chains:
+            raise ValueError("Protenix input must contain at least one chain")
+
+        sequence_records = []
+        for index, sequence in enumerate(chains):
+            sequence_records.append(
+                {
+                    "proteinChain": {
+                        "sequence": sequence,
+                        "count": 1,
+                        "id": [chr(65 + index)],
+                        "modifications": [],
+                    }
+                }
+            )
+
+        payload = [{"name": "boileroom_target", "sequences": sequence_records, "covalent_bonds": []}]
+        input_json = buffer_path / "input.json"
+        input_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+        return input_json
+
+    def _build_command(self, input_json: Path, output_dir: Path, config: dict[str, Any]) -> list[str]:
+        command = [
+            str(config["protenix_command"]),
+            "pred",
+            "--input",
+            str(input_json),
+            "--out_dir",
+            str(output_dir),
+            "--seeds",
+            str(config["seeds"]),
+            "--model_name",
+            str(config["model_name"]),
+            "--cycle",
+            str(int(config["cycle"])),
+            "--step",
+            str(int(config["step"])),
+            "--sample",
+            str(int(config["sample"])),
+            "--dtype",
+            str(config["dtype"]),
+            "--use_msa",
+            _bool_arg(config["use_msa"]),
+            "--use_template",
+            _bool_arg(config["use_template"]),
+            "--use_default_params",
+            _bool_arg(config["use_default_params"]),
+            "--trimul_kernel",
+            str(config["trimul_kernel"]),
+            "--triatt_kernel",
+            str(config["triatt_kernel"]),
+            "--enable_cache",
+            _bool_arg(config["enable_cache"]),
+            "--enable_fusion",
+            _bool_arg(config["enable_fusion"]),
+            "--enable_tf32",
+            _bool_arg(config["enable_tf32"]),
+        ]
+        if config.get("use_seeds_in_json"):
+            command.extend(["--use_seeds_in_json", "true"])
+        if config.get("use_tfg_guidance"):
+            command.extend(["--use_tfg_guidance", "true"])
+        return command
+
+    def _run_command(self, command: list[str], config: dict[str, Any]) -> None:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=_command_env(config),
+            timeout=config.get("timeout_seconds"),
+        )
+        if result.returncode != 0:
+            tail = "\n".join((result.stdout + "\n" + result.stderr).splitlines()[-80:])
+            raise RuntimeError(f"Protenix command failed with exit code {result.returncode}:\n{tail}")
+
+    def _collect_outputs(
+        self,
+        output_dir: Path,
+        metadata: PredictionMetadata,
+        config: dict[str, Any],
+    ) -> ProtenixOutput:
+        prediction_dirs = _find_prediction_dirs(output_dir)
+        cif_paths = sorted(_sample_cif_paths(prediction_dirs), key=_sample_sort_key)
+        if not cif_paths:
+            raise RuntimeError(f"Protenix produced no sample CIF files under {output_dir}")
+
+        include_fields = config.get("include_fields")
+        atom_arrays = []
+        cif_strings: list[str] | None = [] if _include_field(include_fields, "cif") else None
+        confidence: list[dict[str, Any] | None] = []
+        for cif_path in cif_paths:
+            cif_file = CIFFile.read(str(cif_path))
+            atom_arrays.append(get_structure(cif_file, model=1))
+            if cif_strings is not None:
+                cif_strings.append(cif_path.read_text(encoding="utf-8"))
+
+            confidence_path = _confidence_path_for_cif(cif_path)
+            item = json.loads(confidence_path.read_text(encoding="utf-8")) if confidence_path.exists() else None
+            confidence.append(item)
+
+        output = ProtenixOutput(
+            metadata=metadata,
+            atom_array=atom_arrays,
+            confidence=confidence if any(item is not None for item in confidence) else None,
+            cif=cif_strings,
+        )
+        return cast(ProtenixOutput, self._filter_include_fields(output, include_fields))
+
+
+def _bool_arg(value: Any) -> str:
+    return "true" if bool(value) else "false"
+
+
+def _extract_device_number(device: str) -> str | None:
+    if device.startswith("cuda:"):
+        return device.split(":", 1)[1]
+    return None
+
+
+def _command_env(config: dict[str, Any]) -> dict[str, str]:
+    env = os.environ.copy()
+    device = config.get("device")
+    if device is None:
+        return env
+    device_name = str(device)
+    device_number = _extract_device_number(device_name)
+    if device_number is not None:
+        env["CUDA_VISIBLE_DEVICES"] = device_number
+    elif device_name == "cpu":
+        env["CUDA_VISIBLE_DEVICES"] = ""
+    return env
+
+
+def _find_prediction_dirs(output_dir: Path) -> list[Path]:
+    prediction_dirs = sorted(path for path in output_dir.glob("**/predictions") if path.is_dir())
+    if not prediction_dirs:
+        raise RuntimeError(f"Could not find Protenix predictions directory under {output_dir}")
+    return prediction_dirs
+
+
+def _sample_cif_paths(prediction_dirs: Iterable[Path]) -> Iterable[Path]:
+    for prediction_dir in prediction_dirs:
+        yield from prediction_dir.glob("*_sample_*.cif")
+
+
+def _sample_sort_key(path: Path) -> tuple[str, int]:
+    return (str(path.parent), _rank_from_sample_path(path))
+
+
+def _rank_from_sample_path(path: Path) -> int:
+    stem = path.stem
+    marker = "_sample_"
+    if marker not in stem:
+        return 0
+    try:
+        return int(stem.rsplit(marker, 1)[1])
+    except ValueError:
+        return 0
+
+
+def _confidence_path_for_cif(cif_path: Path) -> Path:
+    sample_name, rank = cif_path.stem.rsplit("_sample_", 1)
+    return cif_path.with_name(f"{sample_name}_summary_confidence_sample_{rank}.json")
+
+
+def _include_field(include_fields: list[str] | None, field: str) -> bool:
+    return include_fields is not None and ("*" in include_fields or field in include_fields)

--- a/boileroom/models/protenix/image.py
+++ b/boileroom/models/protenix/image.py
@@ -1,0 +1,5 @@
+"""Modal image definition for Protenix."""
+
+from ...images.modal import get_modal_image
+
+protenix_image = get_modal_image("protenix")

--- a/boileroom/models/protenix/protenix.py
+++ b/boileroom/models/protenix/protenix.py
@@ -1,0 +1,72 @@
+"""Public and Modal wrappers for Protenix."""
+
+import json
+import logging
+from collections.abc import Sequence
+
+import modal
+
+from ...backend.modal import get_modal_app
+from ...base import ModelWrapper
+from ...images.volumes import model_weights
+from ...utils import MINUTES, MODAL_MODEL_DIR
+from ..registry import PROTENIX_SPEC
+from .image import protenix_image
+from .types import ProtenixOutput
+
+logger = logging.getLogger(__name__)
+app = get_modal_app("protenix")
+
+
+@app.cls(
+    image=protenix_image,
+    gpu="A100-40GB",
+    timeout=60 * MINUTES,
+    scaledown_window=10 * MINUTES,
+    volumes={MODAL_MODEL_DIR: model_weights},
+)
+class ModalProtenix:
+    """Modal entrypoint for Protenix."""
+
+    config: bytes = modal.parameter(default=b"{}")
+
+    @modal.enter()
+    def _initialize(self) -> None:
+        from .core import ProtenixCore
+
+        self._core = ProtenixCore(json.loads(self.config.decode("utf-8")))
+        self._core._initialize()
+
+    @modal.method()
+    def fold(self, sequences: str | Sequence[str], options: dict | None = None) -> "ProtenixOutput":
+        return self._core.fold(sequences, options=options)
+
+
+class Protenix(ModelWrapper):
+    """Interface for Protenix structure prediction."""
+
+    MODEL_SPEC = PROTENIX_SPEC
+
+    def __init__(self, backend: str = "modal", device: str | None = None, config: dict | None = None) -> None:
+        """Create a Protenix model wrapper."""
+        super().__init__(backend=backend, device=device, config=config)
+        self._initialize_backend_from_spec(self.MODEL_SPEC, backend=backend, device=device, config=config)
+
+    def fold(self, sequences: str | Sequence[str], options: dict | None = None) -> "ProtenixOutput":
+        """Run Protenix for a single sequence entry.
+
+        Use ``:`` inside a sequence string to define multiple chains.
+        """
+        validated_sequences = [sequences] if isinstance(sequences, str) else list(sequences)
+        if len(validated_sequences) != 1:
+            raise ValueError(
+                "Protenix currently supports exactly one top-level sequence per call; use ':' to join chains."
+            )
+        if options is not None:
+            static_keys = self.MODEL_SPEC.contract.static_config_keys & set(options)
+            if static_keys:
+                raise ValueError(
+                    "The following config keys can only be set at initialization and cannot be overridden per-call: "
+                    f"{sorted(static_keys)}"
+                )
+        return self._call_backend_method("fold", sequences, options=options)

--- a/boileroom/models/protenix/requirements.txt
+++ b/boileroom/models/protenix/requirements.txt
@@ -1,0 +1,4 @@
+protenix==2.0.0
+fastapi
+pydantic
+uvicorn

--- a/boileroom/models/protenix/types.py
+++ b/boileroom/models/protenix/types.py
@@ -1,0 +1,75 @@
+"""Type definitions for Protenix outputs without heavy runtime dependencies."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from ...base import PredictionMetadata, StructurePrediction
+
+
+@dataclass
+class ProtenixOutput(StructurePrediction):
+    """Output from Protenix structure prediction."""
+
+    metadata: PredictionMetadata
+    atom_array: list[Any] | None = None
+
+    confidence: list[dict[str, Any] | None] | None = None
+    plddt: list[np.ndarray | None] | None = None
+    ptm: list[np.ndarray | None] | None = None
+    iptm: list[np.ndarray | None] | None = None
+    pdb: list[str] | None = None
+    cif: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize common confidence scalars to the public output contract."""
+        self.ptm = _normalize_scalar_scores(self.ptm, "Protenix pTM") or _extract_scalar(self.confidence, "ptm")
+        self.iptm = _normalize_scalar_scores(self.iptm, "Protenix iPTM") or _extract_scalar(self.confidence, "iptm")
+
+        if self.plddt is not None:
+            normalized: list[np.ndarray | None] = []
+            for value in self.plddt:
+                if value is None:
+                    normalized.append(None)
+                    continue
+                arr = np.asarray(value, dtype=np.float32).squeeze()
+                if arr.size and np.isfinite(arr).any() and np.nanmax(arr) > 1.0:
+                    arr = arr / 100.0
+                normalized.append(arr.reshape(1) if arr.ndim == 0 else arr)
+            self.plddt = normalized if any(value is not None for value in normalized) else None
+
+
+def _normalize_scalar_scores(values: list[np.ndarray | None] | None, label: str) -> list[np.ndarray | None] | None:
+    if values is None:
+        return None
+
+    scores: list[np.ndarray | None] = []
+    for value in values:
+        if value is None:
+            scores.append(None)
+            continue
+        score = np.asarray(value, dtype=np.float32).squeeze()
+        if score.ndim != 0:
+            raise ValueError(f"{label} expected a scalar score; got {score.shape}")
+        scores.append(score.reshape(1))
+    return scores if any(score is not None for score in scores) else None
+
+
+def _extract_scalar(
+    confidence: list[dict[str, Any] | None] | None,
+    key: str,
+) -> list[np.ndarray | None] | None:
+    if confidence is None:
+        return None
+
+    scores: list[np.ndarray | None] = []
+    for item in confidence:
+        if item is None or key not in item:
+            scores.append(None)
+            continue
+        score = np.asarray(item[key], dtype=np.float32).squeeze()
+        if score.ndim != 0:
+            raise ValueError(f"Protenix {key} expected a scalar score; got {score.shape}")
+        scores.append(score.reshape(1))
+    return scores if any(score is not None for score in scores) else None

--- a/boileroom/models/registry.py
+++ b/boileroom/models/registry.py
@@ -12,6 +12,8 @@ TaskKind = Literal["structure", "embedding"]
 ESM_IMAGE_NAME = get_model_image_spec("esm").image_name
 CHAI_IMAGE_NAME = get_model_image_spec("chai").image_name
 BOLTZ_IMAGE_NAME = get_model_image_spec("boltz").image_name
+PROTENIX_IMAGE_NAME = get_model_image_spec("protenix").image_name
+ALPHAFOLD2_MULTIMER_IMAGE_NAME = get_model_image_spec("alphafold").image_name
 
 
 @dataclass(frozen=True)
@@ -172,7 +174,47 @@ BOLTZ2_SPEC = ModelSpec(
     ),
 )
 
-MODEL_SPECS = (ESMFOLD_SPEC, ESM2_SPEC, CHAI1_SPEC, BOLTZ2_SPEC)
+PROTENIX_SPEC = ModelSpec(
+    key="protenix",
+    public_name="Protenix",
+    family="protenix",
+    wrapper_class_path="boileroom.models.protenix.protenix.Protenix",
+    modal_class_path="boileroom.models.protenix.protenix.ModalProtenix",
+    apptainer_core_class_path="boileroom.models.protenix.core.ProtenixCore",
+    apptainer_image_name=PROTENIX_IMAGE_NAME,
+    supported_backends=("modal", "apptainer"),
+    contract=ModelContract(
+        task_method="fold",
+        task_kind="structure",
+        static_config_keys=frozenset({"device", "protenix_command"}),
+        minimal_output_fields=("metadata", "atom_array"),
+        optional_output_fields=("confidence", "ptm", "iptm", "pdb", "cif"),
+        supports_batch=False,
+        supports_multimer=True,
+    ),
+)
+
+ALPHAFOLD2_MULTIMER_SPEC = ModelSpec(
+    key="alphafold2_multimer",
+    public_name="AlphaFold2Multimer",
+    family="alphafold",
+    wrapper_class_path="boileroom.models.alphafold.alphafold2_multimer.AlphaFold2Multimer",
+    modal_class_path="boileroom.models.alphafold.alphafold2_multimer.ModalAlphaFold2Multimer",
+    apptainer_core_class_path="boileroom.models.alphafold.core.AlphaFold2MultimerCore",
+    apptainer_image_name=ALPHAFOLD2_MULTIMER_IMAGE_NAME,
+    supported_backends=("modal", "apptainer"),
+    contract=ModelContract(
+        task_method="fold",
+        task_kind="structure",
+        static_config_keys=frozenset({"device", "alphafold_command", "data_dir"}),
+        minimal_output_fields=("metadata", "atom_array"),
+        optional_output_fields=("ranking", "plddt", "ptm", "iptm", "pae", "pdb", "cif"),
+        supports_batch=False,
+        supports_multimer=True,
+    ),
+)
+
+MODEL_SPECS = (ESMFOLD_SPEC, ESM2_SPEC, CHAI1_SPEC, BOLTZ2_SPEC, PROTENIX_SPEC, ALPHAFOLD2_MULTIMER_SPEC)
 MODEL_SPECS_BY_KEY = {spec.key: spec for spec in MODEL_SPECS}
 MODEL_SPECS_BY_PUBLIC_NAME = {spec.public_name: spec for spec in MODEL_SPECS}
 
@@ -188,6 +230,7 @@ def get_model_spec(identifier: str) -> ModelSpec:
 
 
 __all__ = [
+    "ALPHAFOLD2_MULTIMER_SPEC",
     "BOLTZ2_SPEC",
     "CHAI1_SPEC",
     "ESM2_SPEC",
@@ -197,6 +240,7 @@ __all__ = [
     "MODEL_SPECS_BY_PUBLIC_NAME",
     "ModelContract",
     "ModelSpec",
+    "PROTENIX_SPEC",
     "get_model_spec",
     "resolve_object",
 ]

--- a/docs/backend_support_matrix.md
+++ b/docs/backend_support_matrix.md
@@ -12,9 +12,11 @@ Legend:
 
 | Model      | 🟢 Modal | 🐧 Apptainer |
 |------------|:--------:|:------------:|
+| AlphaFold2-Multimer | 🍊 | 🍊 |
 | Boltz-2    | 🍊       | 🍊           |
 | Chai-1     | 🍊       | 🍊           |
 | ESMFold    | ✅       | 🍊           |
+| Protenix   | 🍊       | 🍊           |
 
 ### Embedding Algorithms
 

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -2,9 +2,11 @@
 
 ### What exists today
 - **base**: `boileroom/images/Dockerfile` → Python 3.12 slim base with shared OS build/runtime tools. Tag: `docker.io/jakublala/boileroom-base`.
+- **alphafold**: `boileroom/models/alphafold/Dockerfile` → installs the official AlphaFold runner, HMMER, HH-suite, Kalign, and exposes `/app/run_alphafold.sh`. Tag: `docker.io/jakublala/boileroom-alphafold2-multimer`.
 - **boltz**: `boileroom/models/boltz/Dockerfile` → installs Boltz runtime dependencies from `requirements.txt`. Tag: `docker.io/jakublala/boileroom-boltz`.
 - **chai1**: `boileroom/models/chai/Dockerfile` → installs Chai runtime dependencies from `requirements.txt`, sets HF env vars. Tag: `docker.io/jakublala/boileroom-chai1`.
 - **esm**: `boileroom/models/esm/Dockerfile` → installs ESM runtime dependencies from `requirements.txt` shared by esm2/esmfold. Tag: `docker.io/jakublala/boileroom-esm`.
+- **protenix**: `boileroom/models/protenix/Dockerfile` → installs Protenix plus HMMER/Kalign CLI dependencies. Tag: `docker.io/jakublala/boileroom-protenix`.
 
 Dockerfiles are the canonical image definition for all runtimes. Docker/Apptainer images are built from these Dockerfiles, and Modal pulls the corresponding published model image from Docker Hub instead of maintaining a separate handwritten dependency stack. CUDA variants select the PyTorch wheel index; the runtime images rely on PyTorch/NVIDIA wheels for user-space CUDA libraries and on Docker/Apptainer GPU integration for host driver libraries.
 

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -2,11 +2,11 @@
 
 ### What exists today
 - **base**: `boileroom/images/Dockerfile` → Python 3.12 slim base with shared OS build/runtime tools. Tag: `docker.io/jakublala/boileroom-base`.
-- **alphafold**: `boileroom/models/alphafold/Dockerfile` → installs the official AlphaFold runner, HMMER, HH-suite, Kalign, and exposes `/app/run_alphafold.sh`. Tag: `docker.io/jakublala/boileroom-alphafold2-multimer`.
+- **alphafold**: `boileroom/models/alphafold/Dockerfile` → installs the official AlphaFold runner, HMMER, HH-suite, Kalign, and exposes `/app/run_alphafold.sh`. Tag: `docker.io/jakublala/boileroom-alphafold2-multimer`. Platform: `linux/amd64`.
 - **boltz**: `boileroom/models/boltz/Dockerfile` → installs Boltz runtime dependencies from `requirements.txt`. Tag: `docker.io/jakublala/boileroom-boltz`.
 - **chai1**: `boileroom/models/chai/Dockerfile` → installs Chai runtime dependencies from `requirements.txt`, sets HF env vars. Tag: `docker.io/jakublala/boileroom-chai1`.
 - **esm**: `boileroom/models/esm/Dockerfile` → installs ESM runtime dependencies from `requirements.txt` shared by esm2/esmfold. Tag: `docker.io/jakublala/boileroom-esm`.
-- **protenix**: `boileroom/models/protenix/Dockerfile` → installs Protenix plus HMMER/Kalign CLI dependencies. Tag: `docker.io/jakublala/boileroom-protenix`.
+- **protenix**: `boileroom/models/protenix/Dockerfile` → installs Protenix plus HMMER/Kalign CLI dependencies. Tag: `docker.io/jakublala/boileroom-protenix`. Platform: `linux/amd64`.
 
 Dockerfiles are the canonical image definition for all runtimes. Docker/Apptainer images are built from these Dockerfiles, and Modal pulls the corresponding published model image from Docker Hub instead of maintaining a separate handwritten dependency stack. CUDA variants select the PyTorch wheel index; the runtime images rely on PyTorch/NVIDIA wheels for user-space CUDA libraries and on Docker/Apptainer GPU integration for host driver libraries.
 
@@ -74,6 +74,8 @@ For single-platform publishing, pass `--local-base` to build and tag images with
 The `.github/workflows/arm64-image-smoke.yml` workflow runs on pull requests to `main` and on manual dispatch. It uses an `ubuntu-24.04-arm` runner, builds the image set for `linux/arm64` with the `arm64-ci` tag, and then runs the import and server-health smoke checks. It is informational and does not push images.
 
 The workflow does not install the full project dependency set on the host runner. Host-side image scripts run with `uv run --no-project --with pyyaml`, while heavy model dependencies such as PyTorch and SciPy are validated inside the Docker images themselves.
+
+Image configs can restrict supported platforms. AlphaFold2-Multimer and Protenix currently advertise `linux/amd64` only, so ARM64 smoke builds and checks skip those images while still validating the ARM64-compatible model images.
 
 On `main`, ARM64 image smoke is folded into the Docker publishing workflow instead of running as a second separate workflow. That keeps the branch smoke path fast and local while making release promotion wait for the same ARM64 smoke coverage.
 

--- a/docs/models.md
+++ b/docs/models.md
@@ -26,6 +26,75 @@ per-residue array on `[0, 1]` per sample, while scalar scores such as `ptm` and 
 In `0.3.1`, this replaces ESMFold's old padded pLDDT batch array and moves Boltz `ptm`/`iptm` from nested
 `confidence` dictionaries to top-level fields.
 
+### Protenix
+`Protenix` wraps the official `protenix pred` CLI. A single `fold()` call accepts one sequence entry; use `:` to
+join multiple protein chains.
+
+Example usage:
+```python
+from boileroom import Protenix
+
+model = Protenix(
+    backend="apptainer",
+    device="cuda:0",
+    config={
+        "model_name": "protenix_base_default_v1.0.0",
+        "use_msa": True,
+        "use_template": False,
+        "sample": 1,
+        "step": 200,
+    },
+)
+
+result = model.fold(
+    "MLKNVHVLVLGAGDVGSVVVRLLEK:MLKNVHVLVLGAGDVGSVVVRLLEK",
+    options={"include_fields": ["confidence", "cif"]},
+)
+
+result.atom_array
+result.confidence
+result.cif
+```
+
+Set `use_msa=False` for single-sequence inference. Template and RNA-MSA searches require the external tools and
+databases expected by Protenix; the runtime image installs `hmmer` and `kalign`, but database paths still need to
+be available inside the container when those features are enabled.
+
+### AlphaFold2-Multimer
+`AlphaFold2Multimer` wraps the official DeepMind AlphaFold runner with `--model_preset=multimer`. It requires the
+AlphaFold databases and model parameters in `data_dir`; by default this is `${MODEL_DIR}/alphafold` inside the
+runtime. The wrapper accepts one top-level sequence entry and uses `:` to split chains into a multi-record FASTA.
+
+Example usage:
+```python
+from boileroom import AlphaFold2Multimer
+
+model = AlphaFold2Multimer(
+    backend="apptainer",
+    device="cuda:0",
+    config={
+        "max_template_date": "2022-01-01",
+        "db_preset": "full_dbs",
+        "models_to_relax": "none",
+    },
+)
+
+result = model.fold(
+    "MLKNVHVLVLGAGDVGSVVVRLLEK:MLKNVHVLVLGAGDVGSVVVRLLEK",
+    options={"include_fields": ["ranking", "plddt", "iptm", "pdb"]},
+)
+
+result.atom_array
+result.ranking
+result.plddt
+result.iptm
+```
+
+AlphaFold2-Multimer does not download the genetic databases automatically. Use `data_dir` for a bind-mounted
+database tree containing the official AlphaFold data layout, including UniProt and PDB seqres for multimer runs.
+With Apptainer, the default `data_dir` is `${MODEL_DIR}/alphafold` inside the container, so place the databases
+under `$MODEL_DIR/alphafold` on the host or pass another container-visible path.
+
 ### ESM-2
 - A fresh `ESM2` instance starts on the backbone-only fast path and automatically switches to an internal masked-LM variant when `include_fields` requests `lm_logits` or `["*"]`; after that first upgrade, the instance keeps the MLM-capable model resident for later calls.
 - Inline `<mask>` tokens are supported directly in sequence strings for both monomers and multimers, and returned logits stay aligned to the residue axis rather than raw tokenizer positions.

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -24,10 +24,12 @@ from boileroom.images.metadata import (  # noqa: E402
     RuntimeImageSpec,
     SUPPORTED_CUDA_VERSIONS,
     get_supported_cuda,
+    get_supported_platforms,
     normalize_docker_repository,
     normalize_cuda_version,
     normalize_requested_tag,
     published_image_references,
+    split_platforms,
 )
 from scripts.cli_utils import CONTEXT_SETTINGS, all_cuda_option, cuda_version_option, none_if_empty  # noqa: E402
 
@@ -441,12 +443,14 @@ def run_build(options: BuildOptions) -> None:
         tag = resolve_publish_tag(options.tag)
         docker_repository = normalize_docker_repository(options.docker_user)
         cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
-        output_flag = resolve_output_flag(options.push, options.load, options.platform)
-        use_local_docker_build = should_use_local_docker_build(options.push, options.platform)
+        requested_platforms = split_platforms(options.platform)
+        platform = ",".join(requested_platforms)
+        output_flag = resolve_output_flag(options.push, options.load, platform)
+        use_local_docker_build = should_use_local_docker_build(options.push, platform)
         if options.local_base:
             if not options.push:
                 raise ValueError("--local-base only applies to pushed builds.")
-            if "," in options.platform:
+            if "," in platform:
                 raise ValueError("--local-base requires a single --platform value.")
             use_local_docker_build = False
         ensure_docker()
@@ -473,7 +477,7 @@ def run_build(options: BuildOptions) -> None:
     log_info(f"Docker repository: {docker_repository}")
     log_info(f"Model images: {', '.join(spec.image_name for spec in MODEL_IMAGE_SPECS)}")
     log_info(f"CUDA versions: {', '.join(cuda_versions)}")
-    log_info(f"Platforms: {options.platform}")
+    log_info(f"Platforms: {platform}")
     if options.verbose:
         if options.local_base:
             output_mode = "load into local Docker then push"
@@ -509,7 +513,7 @@ def run_build(options: BuildOptions) -> None:
                     cuda_version,
                     tag,
                     docker_repository,
-                    options.platform,
+                    platform,
                     output_flag,
                     options.no_cache,
                     use_local_docker_build,
@@ -528,6 +532,13 @@ def run_build(options: BuildOptions) -> None:
                 log_warn(
                     f"Skipping {image_spec.image_name} for CUDA {cuda_version} "
                     f"(supported CUDA variants: {', '.join(supported_cuda)})"
+                )
+                continue
+            supported_platforms = get_supported_platforms(image_spec)
+            if not set(requested_platforms).issubset(supported_platforms):
+                log_warn(
+                    f"Skipping {image_spec.image_name} for platforms {', '.join(requested_platforms)} "
+                    f"(supported platforms: {', '.join(supported_platforms)})"
                 )
                 continue
             target_reference = published_image_references(image_spec.image_name, cuda_version, tag, docker_repository)[0]
@@ -556,7 +567,7 @@ def run_build(options: BuildOptions) -> None:
                 published_references.extend(
                     build_model(
                         task,
-                        options.platform,
+                        platform,
                         output_flag,
                         options.no_cache,
                         use_local_docker_build,
@@ -574,7 +585,7 @@ def run_build(options: BuildOptions) -> None:
                 executor.submit(
                     build_model,
                     task,
-                    options.platform,
+                    platform,
                     output_flag,
                     options.no_cache,
                     use_local_docker_build,

--- a/scripts/images/check_model_imports.py
+++ b/scripts/images/check_model_imports.py
@@ -20,6 +20,7 @@ from boileroom.images.import_checks import (  # noqa: E402
 )
 from boileroom.images.metadata import (  # noqa: E402
     DEFAULT_DOCKER_REPOSITORY,
+    current_docker_platform,
     normalize_docker_repository,
     normalize_requested_tag,
 )
@@ -159,7 +160,12 @@ def run_import_checks(options: ImportCheckOptions) -> None:
     ensure_docker()
     docker_repository = normalize_docker_repository(options.docker_user)
     cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
-    targets = iter_image_targets(options.tag, cuda_versions, docker_repository=docker_repository)
+    targets = iter_image_targets(
+        options.tag,
+        cuda_versions,
+        docker_repository=docker_repository,
+        platform=current_docker_platform(),
+    )
     if not targets:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 

--- a/scripts/images/check_model_imports.py
+++ b/scripts/images/check_model_imports.py
@@ -14,9 +14,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from boileroom.images.import_checks import (  # noqa: E402
-    IMPORT_NAME_OVERRIDES,
     compute_cuda_versions,
     iter_image_targets,
+    requirement_import_names,
 )
 from boileroom.images.metadata import (  # noqa: E402
     DEFAULT_DOCKER_REPOSITORY,
@@ -105,29 +105,16 @@ def check_image(
         check=True,
     )
 
+    deps = [*requirement_import_names(requirements_path), "numpy"]
+
     script = f"""
 import ast
 import importlib
-import re
 import sys
 from pathlib import Path
 
-requirements_txt = Path({str(requirements_path)!r})
 core_file = Path({str(core_path)!r})
-import_name_overrides = {IMPORT_NAME_OVERRIDES!r}
-
-deps = []
-with requirements_txt.open(encoding="utf-8") as handle:
-    for line in handle:
-        stripped = line.strip()
-        if not stripped or stripped.startswith('#'):
-            continue
-        pkg_name = re.split(r'[>=<!=;\\[]', stripped)[0].strip()
-        import_name = import_name_overrides.get(pkg_name, pkg_name.replace('-', '_'))
-        if import_name:
-            deps.append(import_name)
-
-deps.append('numpy')
+deps = {deps!r}
 
 try:
     ast.parse(core_file.read_text(encoding='utf-8'), filename=str(core_file))

--- a/scripts/images/check_model_server_health.py
+++ b/scripts/images/check_model_server_health.py
@@ -20,6 +20,7 @@ from boileroom.backend.transport import TRANSPORT_HMAC_KEY_ENV  # noqa: E402
 from boileroom.images.import_checks import compute_cuda_versions, iter_image_targets  # noqa: E402
 from boileroom.images.metadata import (  # noqa: E402
     DEFAULT_DOCKER_REPOSITORY,
+    current_docker_platform,
     normalize_docker_repository,
     normalize_requested_tag,
 )
@@ -180,7 +181,12 @@ def run_server_health_checks(options: HealthCheckOptions) -> None:
     ensure_docker()
     docker_repository = normalize_docker_repository(options.docker_user)
     cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
-    targets = iter_image_targets(options.tag, cuda_versions, docker_repository=docker_repository)
+    targets = iter_image_targets(
+        options.tag,
+        cuda_versions,
+        docker_repository=docker_repository,
+        platform=current_docker_platform(),
+    )
     if not targets:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 

--- a/tests/alphafold/test_alphafold2_multimer_core.py
+++ b/tests/alphafold/test_alphafold2_multimer_core.py
@@ -1,0 +1,114 @@
+import json
+import pickle
+from pathlib import Path
+
+import numpy as np
+
+from boileroom.base import PredictionMetadata
+from boileroom.models.alphafold.core import AlphaFold2MultimerCore, _command_env
+from boileroom.models.alphafold.types import AlphaFold2MultimerOutput
+
+
+def test_alphafold2_multimer_writes_multichain_fasta(tmp_path: Path) -> None:
+    """AlphaFold2-Multimer should encode colon-joined chains as a multi-record FASTA."""
+    core = AlphaFold2MultimerCore()
+
+    fasta_path = core._write_fasta("AAAA:CCCC", tmp_path)
+
+    assert fasta_path.read_text(encoding="utf-8").splitlines() == [">chain_0", "AAAA", ">chain_1", "CCCC"]
+
+
+def test_alphafold2_multimer_builds_official_runner_command(tmp_path: Path) -> None:
+    """The core should map boileroom config to DeepMind's `run_alphafold.py` flags."""
+    core = AlphaFold2MultimerCore({"alphafold_command": "/bin/run_af2", "data_dir": "/data/af2"})
+
+    command = core._build_command(
+        tmp_path / "target.fasta",
+        tmp_path / "out",
+        {
+            **core.config,
+            "max_template_date": "2021-09-30",
+            "db_preset": "reduced_dbs",
+            "num_multimer_predictions_per_model": 1,
+            "models_to_relax": "best",
+            "use_gpu_relax": True,
+            "use_precomputed_msas": True,
+            "benchmark": True,
+            "random_seed": 7,
+        },
+    )
+
+    assert command[0] == "/bin/run_af2"
+    assert "--model_preset=multimer" in command
+    assert "--data_dir=/data/af2" in command
+    assert "--max_template_date=2021-09-30" in command
+    assert "--db_preset=reduced_dbs" in command
+    assert "--num_multimer_predictions_per_model=1" in command
+    assert "--models_to_relax=best" in command
+    assert "--use_gpu_relax=true" in command
+    assert "--use_precomputed_msas=true" in command
+    assert "--benchmark=true" in command
+    assert "--small_bfd_database_path=/data/af2/small_bfd/bfd-first_non_consensus_sequences.fasta" in command
+    assert "--uniref90_database_path=/data/af2/uniref90/uniref90.fasta" in command
+    assert "--uniprot_database_path=/data/af2/uniprot/uniprot.fasta" in command
+    assert "--pdb_seqres_database_path=/data/af2/pdb_seqres/pdb_seqres.txt" in command
+    assert "--random_seed=7" in command
+
+
+def test_alphafold2_multimer_collects_ranked_outputs(tmp_path: Path) -> None:
+    """Postprocessing should collect ranked PDB outputs and model pickle confidence."""
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    pdb_text = (Path(__file__).resolve().parents[1] / "data" / "multimer-check.pdb").read_text(encoding="utf-8")
+    (target_dir / "ranked_0.pdb").write_text(pdb_text, encoding="utf-8")
+    (target_dir / "ranking_debug.json").write_text(
+        json.dumps({"iptm+ptm": {"model_1_multimer_v3_pred_0": 0.9}, "order": ["model_1_multimer_v3_pred_0"]}),
+        encoding="utf-8",
+    )
+    with (target_dir / "result_model_1_multimer_v3_pred_0.pkl").open("wb") as handle:
+        pickle.dump(
+            {
+                "plddt": np.asarray([90.0, 80.0], dtype=np.float32),
+                "ptm": np.asarray(0.7, dtype=np.float32),
+                "iptm": np.asarray(0.8, dtype=np.float32),
+                "predicted_aligned_error": np.eye(2, dtype=np.float32),
+            },
+            handle,
+        )
+
+    core = AlphaFold2MultimerCore()
+    output = core._collect_outputs(
+        target_dir,
+        PredictionMetadata("AlphaFold2-Multimer", "test", [8]),
+        {"include_fields": ["*"]},
+    )
+
+    assert isinstance(output, AlphaFold2MultimerOutput)
+    assert output.atom_array is not None and len(output.atom_array) == 1
+    assert output.pdb is not None and output.pdb[0].startswith("ATOM")
+    assert output.ranking is not None and output.ranking["order"] == ["model_1_multimer_v3_pred_0"]
+    assert output.plddt is not None
+    plddt = output.plddt[0]
+    assert plddt is not None
+    assert np.allclose(plddt, [0.9, 0.8])
+    assert output.ptm is not None
+    ptm = output.ptm[0]
+    assert ptm is not None
+    assert ptm[0] == 0.7
+    assert output.iptm is not None
+    iptm = output.iptm[0]
+    assert iptm is not None
+    assert iptm[0] == 0.8
+    assert output.pae is not None
+    pae = output.pae[0]
+    assert pae is not None
+    assert pae.shape == (2, 2)
+
+
+def test_alphafold2_multimer_command_env_preserves_backend_device_by_default(monkeypatch) -> None:
+    """Backend-selected CUDA visibility should not be overwritten by core defaults."""
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "7")
+
+    assert _command_env(AlphaFold2MultimerCore().config)["CUDA_VISIBLE_DEVICES"] == "7"
+    assert _command_env({**AlphaFold2MultimerCore().config, "device": "cuda:1"})["CUDA_VISIBLE_DEVICES"] == "1"
+    assert _command_env({**AlphaFold2MultimerCore().config, "device": "cpu"})["CUDA_VISIBLE_DEVICES"] == ""

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -10,12 +10,17 @@ from boileroom.images.metadata import DEFAULT_CUDA_VERSION
 from scripts.images import build_model_images
 
 
-def _cuda_supported_model_specs(cuda_version: str = DEFAULT_CUDA_VERSION) -> list[build_model_images.RuntimeImageSpec]:
+def _cuda_supported_model_specs(
+    cuda_version: str = DEFAULT_CUDA_VERSION,
+    platform: str = "linux/amd64",
+) -> list[build_model_images.RuntimeImageSpec]:
     """Return model image specs that should build for a CUDA version."""
+    requested_platforms = set(build_model_images.split_platforms(platform))
     return [
         spec
         for spec in build_model_images.MODEL_IMAGE_SPECS
         if cuda_version in build_model_images.get_supported_cuda(spec)
+        and requested_platforms.issubset(build_model_images.get_supported_platforms(spec))
     ]
 
 
@@ -352,6 +357,58 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch: MonkeyPatch, tmp_p
     assert built_bases == []
     assert built_tasks == expected_built_tasks
     assert checked_refs == expected_checked_refs
+
+
+def test_run_build_skips_model_specs_with_unsupported_platform(
+    monkeypatch: MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """ARM64 builds should skip model images that only advertise AMD64 support."""
+    options = build_model_images.BuildOptions(
+        tag="sha-test",
+        docker_user="docker.io/jakublala",
+        cuda_versions=[DEFAULT_CUDA_VERSION],
+        all_cuda=False,
+        platform="linux/arm64",
+        push=False,
+        load=False,
+        no_cache=False,
+        verbose=False,
+        skip_existing=False,
+        force_rebuild=False,
+        max_workers=1,
+        local_base=False,
+    )
+
+    built_models: list[str] = []
+    warnings: list[str] = []
+
+    def fake_build_base(cuda_version: str, tag: str, docker_repository: str, *_args, **_kwargs) -> str:
+        return f"{docker_repository}/boileroom-base:cuda{cuda_version}-{tag}"
+
+    def fake_build_model(task, *_args, **_kwargs):
+        built_models.append(task.image_spec.image_name)
+        return (f"{task.image_spec.image_name}:built",)
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(build_model_images, "ensure_docker", lambda: None)
+    monkeypatch.setattr(build_model_images, "ensure_buildx_builder", lambda: None)
+    monkeypatch.setattr(build_model_images, "build_base", fake_build_base)
+    monkeypatch.setattr(build_model_images, "build_model", fake_build_model)
+    monkeypatch.setattr(build_model_images, "log_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(build_model_images, "log_warn", lambda message, *args, **kwargs: warnings.append(message))
+    monkeypatch.setattr(build_model_images, "log_success", lambda *args, **kwargs: None)
+
+    build_model_images.run_build(options)
+
+    assert built_models == [spec.image_name for spec in _cuda_supported_model_specs(platform="linux/arm64")]
+    assert built_models == [
+        "boileroom-boltz",
+        "boileroom-chai1",
+        "boileroom-esm",
+    ]
+    assert any("boileroom-alphafold2-multimer" in warning for warning in warnings)
+    assert any("boileroom-protenix" in warning for warning in warnings)
 
 
 def test_local_base_push_builds_locally_then_pushes(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -10,6 +10,15 @@ from boileroom.images.metadata import DEFAULT_CUDA_VERSION
 from scripts.images import build_model_images
 
 
+def _cuda_supported_model_specs(cuda_version: str = DEFAULT_CUDA_VERSION) -> list[build_model_images.RuntimeImageSpec]:
+    """Return model image specs that should build for a CUDA version."""
+    return [
+        spec
+        for spec in build_model_images.MODEL_IMAGE_SPECS
+        if cuda_version in build_model_images.get_supported_cuda(spec)
+    ]
+
+
 def test_build_base_push_uses_registry_cache(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     """Pushed buildx builds should import and export stable registry cache layers."""
     calls: list[tuple[list[str], Path | None, bool]] = []
@@ -327,17 +336,22 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch: MonkeyPatch, tmp_p
 
     build_model_images.run_build(options)
 
-    assert built_bases == []
-    assert built_tasks == [
-        ("boileroom-chai1", f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
-        ("boileroom-esm", f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
+    expected_built_tasks = [
+        (spec.image_name, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test")
+        for spec in _cuda_supported_model_specs()
+        if spec.image_name != "boileroom-boltz"
     ]
-    assert checked_refs == [
+    expected_checked_refs = [
         f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test",
-        f"docker.io/jakublala/boileroom-boltz:cuda{DEFAULT_CUDA_VERSION}-sha-test",
-        f"docker.io/jakublala/boileroom-chai1:cuda{DEFAULT_CUDA_VERSION}-sha-test",
-        f"docker.io/jakublala/boileroom-esm:cuda{DEFAULT_CUDA_VERSION}-sha-test",
+        *[
+            f"docker.io/jakublala/{spec.image_name}:cuda{DEFAULT_CUDA_VERSION}-sha-test"
+            for spec in _cuda_supported_model_specs()
+        ],
     ]
+
+    assert built_bases == []
+    assert built_tasks == expected_built_tasks
+    assert checked_refs == expected_checked_refs
 
 
 def test_local_base_push_builds_locally_then_pushes(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
@@ -403,10 +417,11 @@ def test_local_base_push_builds_locally_then_pushes(monkeypatch: MonkeyPatch, tm
 
     build_model_images.run_build(options)
 
+    expected_model_calls = [
+        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test")
+        for _spec in _cuda_supported_model_specs()
+    ]
+
     assert buildx_calls == 1
     assert base_calls == [(False, True)]
-    assert model_calls == [
-        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
-        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
-        (False, True, f"docker.io/jakublala/boileroom-base:cuda{DEFAULT_CUDA_VERSION}-sha-test"),
-    ]
+    assert model_calls == expected_model_calls

--- a/tests/contracts/test_harness.py
+++ b/tests/contracts/test_harness.py
@@ -1,5 +1,7 @@
 """Fast contract tests for the repo-local harness."""
 
+import subprocess
+import sys
 from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
@@ -17,6 +19,34 @@ def test_current_repo_harness_passes() -> None:
     """The checked-in repository should satisfy the harness contract."""
     issues = check_repo.run_checks(check_repo.REPO_ROOT, check_repo.load_contract())
     assert issues == []
+
+
+def test_apptainer_core_imports_do_not_require_modal() -> None:
+    """Image-backed runtimes should import core modules without Modal installed."""
+    script = """
+import builtins
+
+original_import = builtins.__import__
+
+def block_modal(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "modal":
+        raise ModuleNotFoundError("modal blocked for contract test")
+    return original_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = block_modal
+import boileroom.models.alphafold.core
+import boileroom.models.protenix.core
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=check_repo.REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_required_family_files_reports_missing_files(tmp_path: Path) -> None:

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -4,7 +4,13 @@ import importlib.metadata
 
 import pytest
 
-from boileroom.images.import_checks import compute_cuda_versions, iter_image_targets, package_name_to_import_name
+from boileroom.images.import_checks import (
+    compute_cuda_versions,
+    iter_image_targets,
+    package_name_to_import_name,
+    requirement_import_names,
+    requirement_line_to_package_name,
+)
 from boileroom.images.metadata import (
     IMAGE_TAG_ENV,
     format_image_reference,
@@ -45,9 +51,11 @@ def test_default_image_tag_matches_installed_package_version() -> None:
 
 def test_model_specs_report_supported_cuda_from_config() -> None:
     """Model image specs should report the CUDA variants advertised in config.yaml."""
+    assert get_supported_cuda(get_model_image_spec("alphafold")) == ("12.6",)
     assert get_supported_cuda(get_model_image_spec("boltz")) == ("12.6",)
     assert get_supported_cuda(get_model_image_spec("chai")) == ("11.8", "12.6")
     assert get_supported_cuda(get_model_image_spec("esm")) == ("11.8", "12.6")
+    assert get_supported_cuda(get_model_image_spec("protenix")) == ("12.6",)
 
 
 def test_image_tag_uses_env_override(monkeypatch) -> None:
@@ -140,18 +148,54 @@ def test_compute_cuda_versions_uses_metadata_defaults() -> None:
 
 def test_package_name_to_import_name_handles_overrides_and_hyphens() -> None:
     """Import-name resolution should keep overrides centralized and predictable."""
+    assert package_name_to_import_name("absl-py") == "absl"
+    assert package_name_to_import_name("biopython") == "Bio"
+    assert package_name_to_import_name("dm-haiku") == "haiku"
+    assert package_name_to_import_name("ml-collections") == "ml_collections"
+    assert package_name_to_import_name("tensorflow-cpu") == "tensorflow"
     assert package_name_to_import_name("pytorch-lightning") == "pytorch_lightning"
     assert package_name_to_import_name("torch-tensorrt") is None
     assert package_name_to_import_name("my-package") == "my_package"
+
+
+def test_requirement_line_to_package_name_skips_pip_options() -> None:
+    """Requirements parser should ignore index/option lines in image smoke checks."""
+    assert requirement_line_to_package_name("-f https://example.test/simple") is None
+    assert requirement_line_to_package_name("--extra-index-url https://example.test/simple") is None
+    assert requirement_line_to_package_name("jaxlib==0.4.26+cuda12.cudnn89") == "jaxlib"
+    assert requirement_line_to_package_name("openmm[cuda12]==8.2.0") == "openmm"
+
+
+def test_requirement_import_names_uses_central_parser(tmp_path) -> None:
+    """Image import checks should not treat pip option lines as packages."""
+    requirements_path = tmp_path / "requirements.txt"
+    requirements_path.write_text(
+        "\n".join(
+            [
+                "-f https://example.test/simple",
+                "absl-py==1.0.0",
+                "openmm[cuda12]==8.2.0",
+                "torch-tensorrt==2.0.0",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert requirement_import_names(requirements_path) == ["absl", "openmm"]
 
 
 def test_iter_image_targets_uses_canonical_cuda_tags() -> None:
     """Image smoke targets should honor CUDA-qualified tag selection."""
     targets = iter_image_targets("0.3.0", ["12.6"], docker_repository="example")
     references = {image_key: image_reference for image_key, image_reference, *_ in targets}
+    assert references["alphafold"].startswith("docker.io/example/")
     assert references["boltz"].startswith("docker.io/example/")
     assert references["chai"].startswith("docker.io/example/")
     assert references["esm"].startswith("docker.io/example/")
+    assert references["protenix"].startswith("docker.io/example/")
+    assert references["alphafold"].endswith(":cuda12.6-0.3.0")
     assert references["boltz"].endswith(":cuda12.6-0.3.0")
     assert references["chai"].endswith(":cuda12.6-0.3.0")
     assert references["esm"].endswith(":cuda12.6-0.3.0")
+    assert references["protenix"].endswith(":cuda12.6-0.3.0")

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -20,10 +20,12 @@ from boileroom.images.metadata import (
     get_modal_base_image_reference,
     get_model_image_spec,
     get_supported_cuda,
+    get_supported_platforms,
     normalize_docker_repository,
     published_tags,
     render_modal_runtime_env,
     resolve_registry_tag,
+    split_platforms,
 )
 
 
@@ -56,6 +58,21 @@ def test_model_specs_report_supported_cuda_from_config() -> None:
     assert get_supported_cuda(get_model_image_spec("chai")) == ("11.8", "12.6")
     assert get_supported_cuda(get_model_image_spec("esm")) == ("11.8", "12.6")
     assert get_supported_cuda(get_model_image_spec("protenix")) == ("12.6",)
+
+
+def test_model_specs_report_supported_platforms_from_config() -> None:
+    """Model image specs should report the Docker platforms advertised in config.yaml."""
+    assert get_supported_platforms(get_model_image_spec("alphafold")) == ("linux/amd64",)
+    assert get_supported_platforms(get_model_image_spec("boltz")) == ("linux/amd64", "linux/arm64")
+    assert get_supported_platforms(get_model_image_spec("chai")) == ("linux/amd64", "linux/arm64")
+    assert get_supported_platforms(get_model_image_spec("esm")) == ("linux/amd64", "linux/arm64")
+    assert get_supported_platforms(get_model_image_spec("protenix")) == ("linux/amd64",)
+
+
+def test_split_platforms_normalizes_arch_aliases() -> None:
+    """Build and smoke helpers should normalize common Docker platform shorthands."""
+    assert split_platforms("amd64,arm64") == ("linux/amd64", "linux/arm64")
+    assert split_platforms(" linux/amd64 , aarch64 ") == ("linux/amd64", "linux/arm64")
 
 
 def test_image_tag_uses_env_override(monkeypatch) -> None:
@@ -199,3 +216,11 @@ def test_iter_image_targets_uses_canonical_cuda_tags() -> None:
     assert references["chai"].endswith(":cuda12.6-0.3.0")
     assert references["esm"].endswith(":cuda12.6-0.3.0")
     assert references["protenix"].endswith(":cuda12.6-0.3.0")
+
+
+def test_iter_image_targets_filters_by_platform() -> None:
+    """ARM64 smoke checks should skip images that only advertise AMD64 support."""
+    targets = iter_image_targets("0.3.0", ["12.6"], docker_repository="example", platform="linux/arm64")
+    image_keys = [image_key for image_key, *_ in targets]
+
+    assert image_keys == ["boltz", "chai", "esm"]

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -81,6 +81,13 @@ def test_alphafold_biopython_pin_supports_python312_image_builds() -> None:
     assert (major, minor) >= (1, 83)
 
 
+def test_protenix_image_uses_non_jit_layernorm_by_default() -> None:
+    """Protenix images should avoid runtime CUDA-extension JIT compilation."""
+    dockerfile = (REPO_ROOT / "boileroom" / "models" / "protenix" / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "LAYERNORM_TYPE=openfold" in dockerfile
+
+
 def test_split_platforms_normalizes_arch_aliases() -> None:
     """Build and smoke helpers should normalize common Docker platform shorthands."""
     assert split_platforms("amd64,arm64") == ("linux/amd64", "linux/arm64")

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -126,6 +126,16 @@ def test_modal_runtime_env_carries_image_lookup_overrides(monkeypatch) -> None:
     assert set(env) == {"MODEL_DIR", "BOILEROOM_DOCKER_REPOSITORY", IMAGE_TAG_ENV}
 
 
+def test_protenix_modal_runtime_env_uses_non_jit_layernorm(monkeypatch) -> None:
+    """Modal Protenix should avoid runtime CUDA-extension JIT compilation."""
+    monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "docker.io/example")
+    monkeypatch.setenv(IMAGE_TAG_ENV, "0.3.0.1")
+
+    env = render_modal_runtime_env(get_model_image_spec("protenix"), "/mnt/models")
+
+    assert env["LAYERNORM_TYPE"] == "openfold"
+
+
 def test_docker_repository_uses_env_override(monkeypatch) -> None:
     """Image references should support a shared Docker repository override."""
     monkeypatch.setenv("BOILEROOM_DOCKER_REPOSITORY", "example")

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -1,6 +1,7 @@
 """Fast contract tests for shared image metadata and tag behavior."""
 
 import importlib.metadata
+from pathlib import Path
 
 import pytest
 
@@ -27,6 +28,8 @@ from boileroom.images.metadata import (
     resolve_registry_tag,
     split_platforms,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_published_tags_include_default_cuda_aliases() -> None:
@@ -67,6 +70,15 @@ def test_model_specs_report_supported_platforms_from_config() -> None:
     assert get_supported_platforms(get_model_image_spec("chai")) == ("linux/amd64", "linux/arm64")
     assert get_supported_platforms(get_model_image_spec("esm")) == ("linux/amd64", "linux/arm64")
     assert get_supported_platforms(get_model_image_spec("protenix")) == ("linux/amd64",)
+
+
+def test_alphafold_biopython_pin_supports_python312_image_builds() -> None:
+    """AlphaFold image requirements should avoid Biopython releases broken on Python 3.12."""
+    requirements = (REPO_ROOT / "boileroom" / "models" / "alphafold" / "requirements.txt").read_text(encoding="utf-8")
+    pin = next(line for line in requirements.splitlines() if line.startswith("biopython=="))
+    major, minor, *_ = (int(part) for part in pin.split("==", 1)[1].split("."))
+
+    assert (major, minor) >= (1, 83)
 
 
 def test_split_platforms_normalizes_arch_aliases() -> None:

--- a/tests/contracts/test_model_wrappers.py
+++ b/tests/contracts/test_model_wrappers.py
@@ -11,7 +11,16 @@ from boileroom.images.metadata import IMAGE_TAG_ENV, get_default_image_tag
 from boileroom.models.boltz.types import Boltz2Output
 from boileroom.models.chai.types import Chai1Output
 from boileroom.models.esm.types import ESM2Output, ESMFoldOutput
-from boileroom.models.registry import CHAI1_SPEC, ESM2_SPEC, MODEL_SPECS, ModelSpec, get_model_spec, resolve_object
+from boileroom.models.registry import (
+    ALPHAFOLD2_MULTIMER_SPEC,
+    CHAI1_SPEC,
+    ESM2_SPEC,
+    MODEL_SPECS,
+    PROTENIX_SPEC,
+    ModelSpec,
+    get_model_spec,
+    resolve_object,
+)
 
 pytestmark = pytest.mark.contract
 
@@ -25,6 +34,8 @@ SAMPLE_INPUTS: dict[str, Any] = {
         "NPVFTVFKDNEILYRAQLASEDTNAQKTITNCFLLKNKIWCISLVEIYDTGDNVIRPKLFAVKIPEQCTH"
     ),
     "boltz2": "MLKNVHVLVLGAGDVGSVVVRLLEK",
+    "protenix": "MLKNVHVLVLGAGDVGSVVVRLLEK",
+    "alphafold2_multimer": "MLKNVHVLVLGAGDVGSVVVRLLEK:MLKNVHVLVLGAGDVGSVVVRLLEK",
 }
 EXPECTED_MODAL_APP_NAMES = {spec.key: f"boileroom-{spec.key}" for spec in MODEL_SPECS}
 
@@ -52,6 +63,16 @@ def _make_output(spec: ModelSpec) -> object:
 
     if spec.key == "boltz2":
         return Boltz2Output(metadata=_make_metadata(spec.public_name), atom_array=[object()])
+
+    if spec.key == "protenix":
+        from boileroom.models.protenix.types import ProtenixOutput
+
+        return ProtenixOutput(metadata=_make_metadata(spec.public_name), atom_array=[object()])
+
+    if spec.key == "alphafold2_multimer":
+        from boileroom.models.alphafold.types import AlphaFold2MultimerOutput
+
+        return AlphaFold2MultimerOutput(metadata=_make_metadata(spec.public_name), atom_array=[object()])
 
     raise KeyError(f"Unsupported contract spec: {spec.key}")
 
@@ -223,6 +244,13 @@ def test_chai1_contract_declares_single_input_only() -> None:
     assert CHAI1_SPEC.contract.supports_batch is False
 
 
+@pytest.mark.parametrize("spec", [PROTENIX_SPEC, ALPHAFOLD2_MULTIMER_SPEC], ids=lambda spec: spec.public_name)
+def test_cli_folding_contracts_declare_single_input_multimer_support(spec: ModelSpec) -> None:
+    """CLI-backed folding wrappers should use one top-level sequence with ':' chain joining."""
+    assert spec.contract.supports_batch is False
+    assert spec.contract.supports_multimer is True
+
+
 def test_esm2_contract_declares_lm_logits_optional_field() -> None:
     """ESM2 should advertise lm_logits as an optional output field."""
     assert ESM2_SPEC.contract.optional_output_fields == ("hidden_states", "lm_logits")
@@ -252,5 +280,46 @@ def test_chai1_wrapper_rejects_static_option_overrides(monkeypatch: pytest.Monke
 
     with pytest.raises(ValueError, match="device"):
         wrapper.fold("AAAA", options={"device": "cpu"})
+
+    assert "method" not in records
+
+
+@pytest.mark.parametrize("spec", [PROTENIX_SPEC, ALPHAFOLD2_MULTIMER_SPEC], ids=lambda spec: spec.public_name)
+def test_cli_wrappers_reject_multiple_top_level_sequences(
+    monkeypatch: pytest.MonkeyPatch,
+    spec: ModelSpec,
+) -> None:
+    """CLI-backed wrappers should fail early before dispatching unsupported batches."""
+    records: dict[str, Any] = {}
+    _install_fake_initializer(monkeypatch, records, _make_output(spec))
+
+    wrapper_cls = resolve_object(spec.wrapper_class_path)
+    wrapper = wrapper_cls(backend="apptainer:dev")
+
+    with pytest.raises(ValueError, match="exactly one top-level sequence"):
+        wrapper.fold(["AAAA", "BBBB"])
+
+    assert "method" not in records
+
+
+@pytest.mark.parametrize(
+    ("spec", "static_key"),
+    [(PROTENIX_SPEC, "protenix_command"), (ALPHAFOLD2_MULTIMER_SPEC, "data_dir")],
+    ids=lambda item: item.public_name if isinstance(item, ModelSpec) else item,
+)
+def test_cli_wrappers_reject_static_option_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    spec: ModelSpec,
+    static_key: str,
+) -> None:
+    """CLI-backed wrappers should keep runtime-static paths fixed after construction."""
+    records: dict[str, Any] = {}
+    _install_fake_initializer(monkeypatch, records, _make_output(spec))
+
+    wrapper_cls = resolve_object(spec.wrapper_class_path)
+    wrapper = wrapper_cls(backend="apptainer:dev")
+
+    with pytest.raises(ValueError, match=static_key):
+        wrapper.fold(SAMPLE_INPUTS[spec.key], options={static_key: "override"})
 
     assert "method" not in records

--- a/tests/contracts/test_model_wrappers.py
+++ b/tests/contracts/test_model_wrappers.py
@@ -1,5 +1,7 @@
 """Fast contract tests for public model wrappers."""
 
+import subprocess
+import sys
 from typing import Any
 
 import numpy as np
@@ -38,6 +40,27 @@ SAMPLE_INPUTS: dict[str, Any] = {
     "alphafold2_multimer": "MLKNVHVLVLGAGDVGSVVVRLLEK:MLKNVHVLVLGAGDVGSVVVRLLEK",
 }
 EXPECTED_MODAL_APP_NAMES = {spec.key: f"boileroom-{spec.key}" for spec in MODEL_SPECS}
+
+
+def test_base_import_does_not_require_torch() -> None:
+    """Runtime images without torch should still import wrapper base classes."""
+    code = """
+import builtins
+
+real_import = builtins.__import__
+
+def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == "torch":
+        raise ModuleNotFoundError("No module named 'torch'")
+    return real_import(name, globals, locals, fromlist, level)
+
+builtins.__import__ = guarded_import
+import boileroom.base
+print("ok")
+"""
+    result = subprocess.run([sys.executable, "-c", code], check=True, capture_output=True, text=True)
+
+    assert result.stdout.strip() == "ok"
 
 
 def _make_metadata(model_name: str) -> PredictionMetadata:

--- a/tests/protenix/test_protenix_core.py
+++ b/tests/protenix/test_protenix_core.py
@@ -1,0 +1,99 @@
+import json
+from pathlib import Path
+
+from boileroom.base import PredictionMetadata
+from boileroom.models.protenix.core import ProtenixCore, _command_env
+from boileroom.models.protenix.types import ProtenixOutput
+
+
+def test_protenix_writes_protein_chain_json(tmp_path: Path) -> None:
+    """Protenix input JSON should encode colon-joined chains as separate proteinChain records."""
+    core = ProtenixCore()
+
+    input_json = core._write_input_json("AAAA:CCCC", tmp_path)
+
+    payload = json.loads(input_json.read_text(encoding="utf-8"))
+    assert payload[0]["name"] == "boileroom_target"
+    chains = payload[0]["sequences"]
+    assert [item["proteinChain"]["sequence"] for item in chains] == ["AAAA", "CCCC"]
+    assert [item["proteinChain"]["id"] for item in chains] == [["A"], ["B"]]
+
+
+def test_protenix_builds_official_cli_command(tmp_path: Path) -> None:
+    """The core should map boileroom config to the official `protenix pred` CLI."""
+    core = ProtenixCore({"protenix_command": "protenix-bin"})
+
+    command = core._build_command(
+        tmp_path / "input.json",
+        tmp_path / "out",
+        {
+            **core.config,
+            "model_name": "protenix-v2",
+            "seeds": "101,102",
+            "cycle": 4,
+            "step": 20,
+            "sample": 1,
+            "dtype": "fp32",
+            "use_msa": False,
+            "use_template": True,
+            "use_default_params": False,
+            "trimul_kernel": "torch",
+            "triatt_kernel": "torch",
+            "enable_cache": False,
+            "enable_fusion": False,
+            "enable_tf32": False,
+        },
+    )
+
+    assert command[:2] == ["protenix-bin", "pred"]
+    assert command[command.index("--model_name") + 1] == "protenix-v2"
+    assert command[command.index("--use_msa") + 1] == "false"
+    assert command[command.index("--use_template") + 1] == "true"
+    assert command[command.index("--use_default_params") + 1] == "false"
+
+
+def test_protenix_collects_ranked_cifs_and_confidence(tmp_path: Path) -> None:
+    """Postprocessing should collect ranked CIF files and summary confidence JSON."""
+    cif_text = (Path(__file__).resolve().parents[1] / "data" / "boltz" / "0_model_0.cif").read_text(encoding="utf-8")
+    for seed, plddt_score in [(101, 87.0), (102, 77.0)]:
+        prediction_dir = tmp_path / "dataset" / "target" / f"seed_{seed}" / "predictions"
+        prediction_dir.mkdir(parents=True)
+        (prediction_dir / "boileroom_target_sample_0.cif").write_text(cif_text, encoding="utf-8")
+        (prediction_dir / "boileroom_target_summary_confidence_sample_0.json").write_text(
+            json.dumps({"plddt": plddt_score, "ptm": 0.71, "iptm": 0.62, "ranking_score": 0.65}),
+            encoding="utf-8",
+        )
+
+    core = ProtenixCore()
+    output = core._collect_outputs(
+        tmp_path,
+        PredictionMetadata("Protenix", "test", [4]),
+        {"include_fields": ["*"]},
+    )
+
+    assert isinstance(output, ProtenixOutput)
+    assert output.atom_array is not None and len(output.atom_array) == 2
+    assert output.cif is not None and output.cif[0].startswith("data_")
+    assert output.confidence is not None
+    confidence = output.confidence[0]
+    assert confidence is not None
+    assert confidence["ranking_score"] == 0.65
+    assert confidence["plddt"] == 87.0
+    assert output.plddt is None
+    assert output.ptm is not None
+    ptm = output.ptm[0]
+    assert ptm is not None
+    assert ptm[0] == 0.71
+    assert output.iptm is not None
+    iptm = output.iptm[0]
+    assert iptm is not None
+    assert iptm[0] == 0.62
+
+
+def test_protenix_command_env_preserves_backend_device_by_default(monkeypatch) -> None:
+    """Backend-selected CUDA visibility should not be overwritten by core defaults."""
+    monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "7")
+
+    assert _command_env(ProtenixCore().config)["CUDA_VISIBLE_DEVICES"] == "7"
+    assert _command_env({**ProtenixCore().config, "device": "cuda:1"})["CUDA_VISIBLE_DEVICES"] == "1"
+    assert _command_env({**ProtenixCore().config, "device": "cpu"})["CUDA_VISIBLE_DEVICES"] == ""


### PR DESCRIPTION
## Summary

Adds experimental Boileroom support for two additional structure-prediction backends:

- `Protenix`, wrapping the official `protenix pred` CLI for single-entry monomer or `:`-joined multimer folding.
- `AlphaFold2Multimer`, wrapping the official DeepMind AlphaFold runner with `--model_preset=multimer`.

The PR registers both models for Modal and Apptainer, adds model Dockerfiles/requirements/configs, exposes the public wrappers, and documents basic usage and runtime database expectations.

## Implementation Notes

- Protenix output collection reads ranked CIFs across all produced seed/sample prediction directories and keeps summary confidence JSON under `confidence`; top-level `ptm`/`iptm` are normalised scalar fields.
- AlphaFold2-Multimer writes a multi-record FASTA from `:`-joined chains, emits the official multimer database path flags from `data_dir`, and collects ranked PDB/CIF plus `ranking_debug.json` and result pickle confidence arrays.
- CLI cores preserve backend-selected `CUDA_VISIBLE_DEVICES` by default, while still allowing explicit core-level `device` config for direct use.
- New model package `__init__.py` files use lazy exports so Apptainer/image-backed core imports do not require `modal`.
- Runtime wrapper imports remain lightweight; `boileroom.base` now imports torch lazily so non-torch model images such as AlphaFold can import the core wrapper boundary.
- Image import-smoke parsing now skips pip option lines and centralises package-to-import-name overrides needed by AlphaFold requirements.
- Runtime images are pinned: AlphaFold fetches a fixed upstream commit and Protenix is pinned to `2.0.0`.
- Protenix disables the JIT layernorm path by default in Docker and Modal runtime env, avoiding the Triton signature failure seen in containerised inference.
- Image metadata now supports per-model platform declarations. AlphaFold2-Multimer and Protenix advertise `linux/amd64` only, so ARM64 CI skips those CUDA stacks while still validating ARM64-compatible model images.

## Review Notes

Thermo-nuclear maintainability review was run against the diff. Issues found and fixed before PR:

- Protenix defaults were aligned with upstream CLI defaults.
- Protenix output parsing was changed to include all seed prediction directories instead of the first directory only.
- AlphaFold command construction was expanded to include required official database flags and HH-suite runtime dependencies.

Independent read-only reviewer findings were also addressed:

- Fixed `modal` import leakage from new model package `__init__.py` files.
- Fixed image import-smoke parsing for AlphaFold requirements and package import-name overrides.
- Changed Protenix Modal default GPU to `A100-40GB` for the default `bf16` runtime.
- Fixed AlphaFold Apptainer docs to use the mounted `${MODEL_DIR}/alphafold` default.
- Pinned external runtime versions.
- Fixed CLI core device handling so backend-selected devices are not overwritten.
- Removed misleading top-level Protenix summary `plddt` exposure; summary pLDDT remains in `confidence` until atom/per-residue confidence collection is implemented.
- Added platform-aware build/smoke filtering for model images that do not support ARM64.
- Updated AlphaFold's Biopython pin to a Python 3.12-compatible version.
- Added regression tests for Protenix non-JIT layernorm settings and the lazy torch import boundary.

## Test Plan

- `uv run --extra dev pre-commit run --all-files` passed.
- `uv run pytest -q -n 4 -m "not integration"` passed: 134 passed, 3 skipped, 1 warning.
- `uv run pytest -q tests/contracts/test_model_wrappers.py tests/contracts/test_image_metadata.py` passed: 61 passed.
- `uv pip compile boileroom/models/alphafold/requirements.txt --python-version 3.12 -o /tmp/boileroom-alphafold-lock.txt` resolved successfully.
- `uv pip compile boileroom/models/protenix/requirements.txt --python-version 3.12 -o /tmp/boileroom-protenix-lock.txt` resolved successfully.
- PR checks on `9efaac9` passed: `harness-checks`, `lint-checks`, `unit-tests`, `ARM64 Image Smoke`, and CodeRabbit.
- Manual image workflow `28633655770` on `9efaac9` passed for `linux/amd64` CUDA 12.6, `linux/amd64` CUDA 11.8, and `linux/arm64` CUDA 12.6, including local image import and server-health checks.

Live full AlphaFold2-Multimer inference still requires a mounted AlphaFold database tree, including `pdb_seqres/pdb_seqres.txt`. The wrapper now reaches the official runner and fails clearly when that database is absent.
