### PR TITLE
feat: expose ESM3 non-structure track logits as optional outputs

### DIFF
--- a/boileroom/models/esm3/core.py
+++ b/boileroom/models/esm3/core.py
@@ -85,8 +85,7 @@ def pad_residue_arrays(
     residue_index: list[np.ndarray],
     hidden_states: list[np.ndarray] | None = None,
     lm_logits: list[np.ndarray] | None = None,
-    sasa_logits: list[np.ndarray] | None = None,
-) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None, np.ndarray, np.ndarray, np.ndarray | None]:
+) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None, np.ndarray, np.ndarray]:
     """Pad residue-aligned arrays to a common batch length."""
 
     padded_embeddings = _pad_and_stack(embeddings, residue_axis=0, pad_value=0)
@@ -94,17 +93,23 @@ def pad_residue_arrays(
         _pad_and_stack(hidden_states, residue_axis=1, pad_value=0).swapaxes(0, 1) if hidden_states else None
     )
     padded_lm_logits = _pad_and_stack(lm_logits, residue_axis=0, pad_value=0) if lm_logits else None
-    padded_sasa_logits = _pad_and_stack(sasa_logits, residue_axis=0, pad_value=0) if sasa_logits else None
     padded_chain_index = _pad_and_stack(chain_index, residue_axis=0, pad_value=-1).astype(np.int32, copy=False)
     padded_residue_index = _pad_and_stack(residue_index, residue_axis=0, pad_value=-1).astype(np.int32, copy=False)
-    return (
-        padded_embeddings,
-        padded_hidden_states,
-        padded_lm_logits,
-        padded_chain_index,
-        padded_residue_index,
-        padded_sasa_logits,
-    )
+    return padded_embeddings, padded_hidden_states, padded_lm_logits, padded_chain_index, padded_residue_index
+
+
+# ESM3-only optional per-residue "track logit" outputs. ESM3 is an all-to-all
+# masked model, so any track can be predicted from sequence alone. Each entry maps
+# the public output field to (LogitsConfig kwarg, source attribute paths on the SDK
+# LogitsOutput to try in order). The structure/folding track is intentionally
+# excluded. Residue-annotation logits live at the top level of LogitsOutput (they
+# are multi-hot), the rest under ``logits.<track>``.
+ESM3_TRACK_LOGIT_FIELDS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "sasa_logits": ("sasa", ("logits.sasa", "sasa")),
+    "secondary_structure_logits": ("secondary_structure", ("logits.secondary_structure", "secondary_structure")),
+    "function_logits": ("function", ("logits.function", "function")),
+    "residue_annotation_logits": ("residue_annotations", ("residue_annotation_logits", "residue_annotations")),
+}
 
 
 class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
@@ -121,6 +126,9 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
     VALID_MODEL_NAMES: ClassVar[frozenset[str]]
     MODEL_ALIASES: ClassVar[dict[str, str]] = {}
     SUPPORTED_OPTIONAL_FIELDS: ClassVar[frozenset[str]] = frozenset({"lm_logits"})
+    # Per-residue track-logit outputs this model can produce (empty by default;
+    # ESM3 populates it). See ESM3_TRACK_LOGIT_FIELDS for the value shape.
+    TRACK_LOGIT_FIELDS: ClassVar[dict[str, tuple[str, tuple[str, ...]]]] = {}
 
     def __init__(self, config: dict | None = None) -> None:
         super().__init__(config)
@@ -216,9 +224,16 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
 
         compute_hidden_states = self._include_requested(include_fields, "hidden_states")
         compute_lm_logits = self._include_requested(include_fields, "lm_logits")
-        compute_sasa = self._include_requested(include_fields, "sasa_logits")
-        if compute_sasa and "sasa_logits" not in self.SUPPORTED_OPTIONAL_FIELDS:
-            raise ValueError(f"sasa_logits are only available for ESM3, not {self.MODEL_DISPLAY_NAME}.")
+
+        # ESM3-only per-residue track logits (SASA, secondary structure, function,
+        # residue annotations). Reject any requested on a model that lacks the track.
+        for field in ESM3_TRACK_LOGIT_FIELDS:
+            if self._include_requested(include_fields, field) and field not in self.TRACK_LOGIT_FIELDS:
+                raise ValueError(f"{field} are only available for ESM3, not {self.MODEL_DISPLAY_NAME}.")
+        requested_tracks = [
+            field for field in self.TRACK_LOGIT_FIELDS if self._include_requested(include_fields, field)
+        ]
+        track_flags = {self.TRACK_LOGIT_FIELDS[field][0]: True for field in requested_tracks}
 
         with Timer(f"{self.MODEL_DISPLAY_NAME} preprocessing") as preprocess_timer:
             encoded_inputs = [self._encode_sequence(parsed.sdk_sequence) for parsed in parsed_sequences]
@@ -226,11 +241,11 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
         embeddings: list[np.ndarray] = []
         hidden_states: list[np.ndarray] | None = [] if compute_hidden_states else None
         lm_logits: list[np.ndarray] | None = [] if compute_lm_logits else None
-        sasa_logits: list[np.ndarray] | None = [] if compute_sasa else None
+        track_arrays: dict[str, list[np.ndarray]] = {field: [] for field in requested_tracks}
 
         with Timer("Model Inference") as inference_timer, torch.inference_mode():
             for parsed, encoded in zip(parsed_sequences, encoded_inputs, strict=True):
-                raw_output = self._run_logits(encoded, compute_lm_logits, compute_hidden_states, compute_sasa)
+                raw_output = self._run_logits(encoded, compute_lm_logits, compute_hidden_states, track_flags)
                 keep_indices = self._residue_token_indices(parsed.sdk_sequence)
                 embeddings.append(
                     self._select_residue_rows(self._extract_array(raw_output, "embeddings"), keep_indices)
@@ -247,22 +262,25 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
                     if logits_array is None:
                         raise ValueError("lm_logits were requested but the ESM SDK did not return sequence logits.")
                     lm_logits.append(self._select_residue_rows(logits_array, keep_indices))
-                if sasa_logits is not None:
-                    sasa_array = self._extract_optional_array(raw_output, "logits.sasa", "sasa")
-                    if sasa_array is None:
-                        raise ValueError("sasa_logits were requested but the ESM SDK did not return SASA logits.")
-                    sasa_logits.append(self._select_residue_rows(sasa_array, keep_indices))
+                for field in requested_tracks:
+                    sources = self.TRACK_LOGIT_FIELDS[field][1]
+                    track_array = self._extract_optional_array(raw_output, *sources)
+                    if track_array is None:
+                        raise ValueError(f"{field} were requested but the ESM SDK did not return them.")
+                    track_arrays[field].append(self._select_residue_rows(track_array, keep_indices))
 
         with Timer(f"{self.MODEL_DISPLAY_NAME} postprocessing") as postprocess_timer:
             padded = pad_residue_arrays(
                 embeddings=embeddings,
                 hidden_states=hidden_states,
                 lm_logits=lm_logits,
-                sasa_logits=sasa_logits,
                 chain_index=[parsed.chain_index for parsed in parsed_sequences],
                 residue_index=[parsed.residue_index for parsed in parsed_sequences],
             )
-            embeddings_out, hidden_out, logits_out, chain_out, residue_out, sasa_out = padded
+            embeddings_out, hidden_out, logits_out, chain_out, residue_out = padded
+            padded_tracks = {
+                field: _pad_and_stack(arrays, residue_axis=0, pad_value=0) for field, arrays in track_arrays.items()
+            }
             metadata.preprocessing_time = preprocess_timer.duration
             metadata.inference_time = inference_timer.duration
             metadata.postprocessing_time = postprocess_timer.duration
@@ -271,9 +289,9 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
                 embeddings=embeddings_out,
                 hidden_states=hidden_out,
                 lm_logits=logits_out,
-                sasa_logits=sasa_out,
                 chain_index=chain_out,
                 residue_index=residue_out,
+                **padded_tracks,
             )
             filtered = self._filter_include_fields(full_output, cast(list[str] | None, include_fields))
             return cast(ESMEmbeddingOutput, filtered)
@@ -285,17 +303,22 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
         return self.model.encode(ESMProtein(sequence=sdk_sequence))
 
     def _run_logits(
-        self, encoded: Any, compute_lm_logits: bool, compute_hidden_states: bool, compute_sasa: bool = False
+        self,
+        encoded: Any,
+        compute_lm_logits: bool,
+        compute_hidden_states: bool,
+        track_flags: dict[str, bool] | None = None,
     ) -> Any:
         from esm.sdk.api import LogitsConfig
 
         assert self.model is not None, "Model not loaded"
-        config_kwargs = {
+        config_kwargs: dict[str, Any] = {
             "sequence": compute_lm_logits,
-            "sasa": compute_sasa,
             "return_embeddings": True,
             "return_hidden_states": compute_hidden_states,
         }
+        if track_flags:
+            config_kwargs.update(track_flags)
         return self.model.logits(encoded, LogitsConfig(**config_kwargs))
 
     @staticmethod
@@ -393,7 +416,8 @@ class ESM3Core(_BaseESM3EmbeddingCore):
         "esm3-sm-open-v1": "esm3_sm_open_v1",
         "esm3-open-2024-03": "esm3_sm_open_v1",
     }
-    SUPPORTED_OPTIONAL_FIELDS: ClassVar[frozenset[str]] = frozenset({"lm_logits", "sasa_logits"})
+    TRACK_LOGIT_FIELDS: ClassVar[dict[str, tuple[str, tuple[str, ...]]]] = ESM3_TRACK_LOGIT_FIELDS
+    SUPPORTED_OPTIONAL_FIELDS: ClassVar[frozenset[str]] = frozenset({"lm_logits", *ESM3_TRACK_LOGIT_FIELDS})
 
     def embed(self, sequences: str | Sequence[str], options: dict | None = None) -> ESM3Output:
         return cast(ESM3Output, super().embed(sequences, options=options))

--- a/boileroom/models/esm3/core.py
+++ b/boileroom/models/esm3/core.py
@@ -85,7 +85,8 @@ def pad_residue_arrays(
     residue_index: list[np.ndarray],
     hidden_states: list[np.ndarray] | None = None,
     lm_logits: list[np.ndarray] | None = None,
-) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None, np.ndarray, np.ndarray]:
+    sasa_logits: list[np.ndarray] | None = None,
+) -> tuple[np.ndarray, np.ndarray | None, np.ndarray | None, np.ndarray, np.ndarray, np.ndarray | None]:
     """Pad residue-aligned arrays to a common batch length."""
 
     padded_embeddings = _pad_and_stack(embeddings, residue_axis=0, pad_value=0)
@@ -93,9 +94,17 @@ def pad_residue_arrays(
         _pad_and_stack(hidden_states, residue_axis=1, pad_value=0).swapaxes(0, 1) if hidden_states else None
     )
     padded_lm_logits = _pad_and_stack(lm_logits, residue_axis=0, pad_value=0) if lm_logits else None
+    padded_sasa_logits = _pad_and_stack(sasa_logits, residue_axis=0, pad_value=0) if sasa_logits else None
     padded_chain_index = _pad_and_stack(chain_index, residue_axis=0, pad_value=-1).astype(np.int32, copy=False)
     padded_residue_index = _pad_and_stack(residue_index, residue_axis=0, pad_value=-1).astype(np.int32, copy=False)
-    return padded_embeddings, padded_hidden_states, padded_lm_logits, padded_chain_index, padded_residue_index
+    return (
+        padded_embeddings,
+        padded_hidden_states,
+        padded_lm_logits,
+        padded_chain_index,
+        padded_residue_index,
+        padded_sasa_logits,
+    )
 
 
 class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
@@ -207,6 +216,9 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
 
         compute_hidden_states = self._include_requested(include_fields, "hidden_states")
         compute_lm_logits = self._include_requested(include_fields, "lm_logits")
+        compute_sasa = self._include_requested(include_fields, "sasa_logits")
+        if compute_sasa and "sasa_logits" not in self.SUPPORTED_OPTIONAL_FIELDS:
+            raise ValueError(f"sasa_logits are only available for ESM3, not {self.MODEL_DISPLAY_NAME}.")
 
         with Timer(f"{self.MODEL_DISPLAY_NAME} preprocessing") as preprocess_timer:
             encoded_inputs = [self._encode_sequence(parsed.sdk_sequence) for parsed in parsed_sequences]
@@ -214,10 +226,11 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
         embeddings: list[np.ndarray] = []
         hidden_states: list[np.ndarray] | None = [] if compute_hidden_states else None
         lm_logits: list[np.ndarray] | None = [] if compute_lm_logits else None
+        sasa_logits: list[np.ndarray] | None = [] if compute_sasa else None
 
         with Timer("Model Inference") as inference_timer, torch.inference_mode():
             for parsed, encoded in zip(parsed_sequences, encoded_inputs, strict=True):
-                raw_output = self._run_logits(encoded, compute_lm_logits, compute_hidden_states)
+                raw_output = self._run_logits(encoded, compute_lm_logits, compute_hidden_states, compute_sasa)
                 keep_indices = self._residue_token_indices(parsed.sdk_sequence)
                 embeddings.append(
                     self._select_residue_rows(self._extract_array(raw_output, "embeddings"), keep_indices)
@@ -234,16 +247,22 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
                     if logits_array is None:
                         raise ValueError("lm_logits were requested but the ESM SDK did not return sequence logits.")
                     lm_logits.append(self._select_residue_rows(logits_array, keep_indices))
+                if sasa_logits is not None:
+                    sasa_array = self._extract_optional_array(raw_output, "logits.sasa", "sasa")
+                    if sasa_array is None:
+                        raise ValueError("sasa_logits were requested but the ESM SDK did not return SASA logits.")
+                    sasa_logits.append(self._select_residue_rows(sasa_array, keep_indices))
 
         with Timer(f"{self.MODEL_DISPLAY_NAME} postprocessing") as postprocess_timer:
             padded = pad_residue_arrays(
                 embeddings=embeddings,
                 hidden_states=hidden_states,
                 lm_logits=lm_logits,
+                sasa_logits=sasa_logits,
                 chain_index=[parsed.chain_index for parsed in parsed_sequences],
                 residue_index=[parsed.residue_index for parsed in parsed_sequences],
             )
-            embeddings_out, hidden_out, logits_out, chain_out, residue_out = padded
+            embeddings_out, hidden_out, logits_out, chain_out, residue_out, sasa_out = padded
             metadata.preprocessing_time = preprocess_timer.duration
             metadata.inference_time = inference_timer.duration
             metadata.postprocessing_time = postprocess_timer.duration
@@ -252,6 +271,7 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
                 embeddings=embeddings_out,
                 hidden_states=hidden_out,
                 lm_logits=logits_out,
+                sasa_logits=sasa_out,
                 chain_index=chain_out,
                 residue_index=residue_out,
             )
@@ -264,12 +284,15 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
         assert self.model is not None, "Model not loaded"
         return self.model.encode(ESMProtein(sequence=sdk_sequence))
 
-    def _run_logits(self, encoded: Any, compute_lm_logits: bool, compute_hidden_states: bool) -> Any:
+    def _run_logits(
+        self, encoded: Any, compute_lm_logits: bool, compute_hidden_states: bool, compute_sasa: bool = False
+    ) -> Any:
         from esm.sdk.api import LogitsConfig
 
         assert self.model is not None, "Model not loaded"
         config_kwargs = {
             "sequence": compute_lm_logits,
+            "sasa": compute_sasa,
             "return_embeddings": True,
             "return_hidden_states": compute_hidden_states,
         }
@@ -370,7 +393,7 @@ class ESM3Core(_BaseESM3EmbeddingCore):
         "esm3-sm-open-v1": "esm3_sm_open_v1",
         "esm3-open-2024-03": "esm3_sm_open_v1",
     }
-    SUPPORTED_OPTIONAL_FIELDS: ClassVar[frozenset[str]] = frozenset({"lm_logits"})
+    SUPPORTED_OPTIONAL_FIELDS: ClassVar[frozenset[str]] = frozenset({"lm_logits", "sasa_logits"})
 
     def embed(self, sequences: str | Sequence[str], options: dict | None = None) -> ESM3Output:
         return cast(ESM3Output, super().embed(sequences, options=options))

--- a/boileroom/models/esm3/core.py
+++ b/boileroom/models/esm3/core.py
@@ -309,6 +309,24 @@ class _BaseESM3EmbeddingCore(EmbeddingAlgorithm):
         compute_hidden_states: bool,
         track_flags: dict[str, bool] | None = None,
     ) -> Any:
+        """Run the SDK ``logits`` call, requesting embeddings plus any enabled tracks.
+
+        Parameters
+        ----------
+        encoded : Any
+            The SDK-encoded protein to score.
+        compute_lm_logits : bool
+            Whether to request sequence (masked-LM) logits.
+        compute_hidden_states : bool
+            Whether to request per-layer hidden states.
+        track_flags : dict[str, bool] | None
+            Extra ``LogitsConfig`` track flags to enable (e.g. ``{"sasa": True}``).
+
+        Returns
+        -------
+        Any
+            The SDK ``LogitsOutput`` for the encoded input.
+        """
         from esm.sdk.api import LogitsConfig
 
         assert self.model is not None, "Model not loaded"

--- a/boileroom/models/esm3/types.py
+++ b/boileroom/models/esm3/types.py
@@ -21,11 +21,15 @@ class ESMEmbeddingOutput(EmbeddingPrediction):
     residue_index: np.ndarray
     hidden_states: np.ndarray | None = None
     lm_logits: np.ndarray | None = None
-    # ESM3-only: per-residue logits over the discretized SASA token vocabulary,
-    # predicted from sequence (structure input is optional, not required). Decode
-    # to a SASA estimate downstream via the SDK's SASA tokenizer bins. None unless
-    # "sasa_logits" was requested and the model is ESM3.
-    sasa_logits: np.ndarray | None = None
+    # ESM3-only track logits, each per-residue and predicted from sequence alone
+    # (structure input is optional, not required). Decode to estimates downstream
+    # via the corresponding SDK track tokenizer. Each is None unless requested via
+    # include_fields and the model is ESM3. The structure/folding track is not
+    # exposed here.
+    sasa_logits: np.ndarray | None = None  # over the discretized SASA token vocabulary
+    secondary_structure_logits: np.ndarray | None = None  # over the SS8 token vocabulary
+    function_logits: np.ndarray | None = None  # over the function-annotation vocabulary
+    residue_annotation_logits: np.ndarray | None = None  # multi-hot residue-annotation logits
 
 
 ESMCOutput = ESMEmbeddingOutput

--- a/boileroom/models/esm3/types.py
+++ b/boileroom/models/esm3/types.py
@@ -21,6 +21,11 @@ class ESMEmbeddingOutput(EmbeddingPrediction):
     residue_index: np.ndarray
     hidden_states: np.ndarray | None = None
     lm_logits: np.ndarray | None = None
+    # ESM3-only: per-residue logits over the discretized SASA token vocabulary,
+    # predicted from sequence (structure input is optional, not required). Decode
+    # to a SASA estimate downstream via the SDK's SASA tokenizer bins. None unless
+    # "sasa_logits" was requested and the model is ESM3.
+    sasa_logits: np.ndarray | None = None
 
 
 ESMCOutput = ESMEmbeddingOutput

--- a/boileroom/models/registry.py
+++ b/boileroom/models/registry.py
@@ -153,7 +153,7 @@ ESM3_SPEC = ModelSpec(
         task_kind="embedding",
         static_config_keys=frozenset({"device", "model_name"}),
         minimal_output_fields=("metadata", "embeddings", "chain_index", "residue_index"),
-        optional_output_fields=("lm_logits",),
+        optional_output_fields=("lm_logits", "sasa_logits"),
         supports_multimer=True,
     ),
 )

--- a/boileroom/models/registry.py
+++ b/boileroom/models/registry.py
@@ -153,7 +153,13 @@ ESM3_SPEC = ModelSpec(
         task_kind="embedding",
         static_config_keys=frozenset({"device", "model_name"}),
         minimal_output_fields=("metadata", "embeddings", "chain_index", "residue_index"),
-        optional_output_fields=("lm_logits", "sasa_logits"),
+        optional_output_fields=(
+            "lm_logits",
+            "sasa_logits",
+            "secondary_structure_logits",
+            "function_logits",
+            "residue_annotation_logits",
+        ),
         supports_multimer=True,
     ),
 )

--- a/docs/models.md
+++ b/docs/models.md
@@ -86,7 +86,11 @@ esm3_result = esm3.embed(["ACD", "EF"])
 Optional fields:
 - `include_fields=["lm_logits"]` requests residue-aligned sequence logits when the SDK returns them.
 - `include_fields=["hidden_states"]` is supported for ESM-C when provided by the SDK. ESM3 raises a clear `ValueError` for hidden-state requests.
-- `include_fields=["sasa_logits"]` is supported for **ESM3 only**: per-residue logits over the discretized SASA token vocabulary, predicted from sequence (structure input is optional, not required). Decode to a SASA estimate via the SDK's SASA tokenizer bins. Requesting it on ESM-C raises a clear `ValueError`.
+- **ESM3-only track logits** — ESM3 is an all-to-all masked model, so it can predict its other tracks from sequence alone (structure input is optional, not required). Each is a per-residue logits array; decode to an estimate downstream via the SDK's per-track tokenizer. Requesting any of these on ESM-C raises a clear `ValueError`. The structure/folding track is not exposed.
+    - `sasa_logits` — over the discretized SASA token vocabulary.
+    - `secondary_structure_logits` — over the SS8 vocabulary.
+    - `function_logits` — over the function-annotation vocabulary.
+    - `residue_annotation_logits` — multi-hot residue-annotation logits.
 - `include_fields=["*"]` means all supported optional fields for that model.
 
 ### ESMFold2

--- a/docs/models.md
+++ b/docs/models.md
@@ -86,6 +86,7 @@ esm3_result = esm3.embed(["ACD", "EF"])
 Optional fields:
 - `include_fields=["lm_logits"]` requests residue-aligned sequence logits when the SDK returns them.
 - `include_fields=["hidden_states"]` is supported for ESM-C when provided by the SDK. ESM3 raises a clear `ValueError` for hidden-state requests.
+- `include_fields=["sasa_logits"]` is supported for **ESM3 only**: per-residue logits over the discretized SASA token vocabulary, predicted from sequence (structure input is optional, not required). Decode to a SASA estimate via the SDK's SASA tokenizer bins. Requesting it on ESM-C raises a clear `ValueError`.
 - `include_fields=["*"]` means all supported optional fields for that model.
 
 ### ESMFold2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 name = "boileroom"
 # Release automation treats this as the current stable target. Main-branch
 # image builds publish prerelease tags such as 0.3.2-alpha.1 from it.
-version = "0.3.2"
+version = "0.4.1"
 authors = [
     { name="Jakub Lála", email="jakublala@gmail.com" },
     { name="Michael Krása", email="michael.krasa@gmail.com" },

--- a/tests/contracts/test_derive_version.py
+++ b/tests/contracts/test_derive_version.py
@@ -18,7 +18,7 @@ def test_main_version_uses_commit_count_after_baseline(monkeypatch) -> None:
 
     monkeypatch.setattr(derive_version, "run_git", fake_run_git)
 
-    assert derive_version.main_version() == "0.3.2-alpha.7"
+    assert derive_version.main_version() == "0.4.1-alpha.7"
 
 
 def test_main_version_counts_from_latest_stable_release_tag(monkeypatch) -> None:

--- a/tests/esm3/test_esm3_embeddings.py
+++ b/tests/esm3/test_esm3_embeddings.py
@@ -64,7 +64,7 @@ def test_parse_sequences_rejects_empty_batches() -> None:
 def test_pad_residue_arrays_zero_and_minus_one_padding() -> None:
     from boileroom.models.esm3.core import pad_residue_arrays
 
-    embeddings, hidden_states, lm_logits, chain_index, residue_index, sasa_logits = pad_residue_arrays(
+    embeddings, hidden_states, lm_logits, chain_index, residue_index = pad_residue_arrays(
         embeddings=[np.ones((5, 2), dtype=np.float32), np.full((2, 2), 2, dtype=np.float32)],
         chain_index=[np.array([0, 0, 0, 1, 1]), np.array([0, 0])],
         residue_index=[np.array([0, 1, 2, 0, 1]), np.array([0, 1])],
@@ -78,7 +78,6 @@ def test_pad_residue_arrays_zero_and_minus_one_padding() -> None:
     assert residue_index.tolist() == [[0, 1, 2, 0, 1], [0, 1, -1, -1, -1]]
     assert hidden_states is None
     assert lm_logits is None
-    assert sasa_logits is None
 
 
 def test_pad_residue_arrays_rejects_empty_batches() -> None:
@@ -116,14 +115,33 @@ class _FakeEncoded:
 
 
 class _FakeForwardTrackData:
-    def __init__(self, sequence: Any | None, sasa: Any | None = None) -> None:
+    def __init__(
+        self,
+        sequence: Any | None,
+        sasa: Any | None = None,
+        secondary_structure: Any | None = None,
+        function: Any | None = None,
+    ) -> None:
         self.sequence = sequence
         self.sasa = sasa
+        self.secondary_structure = secondary_structure
+        self.function = function
 
 
 class _FakeLogitsOutput:
-    def __init__(self, sequence: str, include_hidden: bool, include_logits: bool, include_sasa: bool = False) -> None:
+    # Per-track fake vocab sizes, so tests can assert distinct output shapes.
+    _TRACK_VOCAB: ClassVar[dict[str, int]] = {
+        "sasa": 5,
+        "secondary_structure": 6,
+        "function": 7,
+        "residue_annotations": 8,
+    }
+
+    def __init__(
+        self, sequence: str, include_hidden: bool, include_logits: bool, tracks: set[str] | None = None
+    ) -> None:
         torch = pytest.importorskip("torch")
+        tracks = tracks or set()
         token_count = len(sequence) + 2
         values = torch.arange(token_count * 3, dtype=torch.float32).reshape(token_count, 3)
         self.embeddings = values
@@ -131,10 +149,21 @@ class _FakeLogitsOutput:
         sequence_logits = (
             torch.arange(token_count * 4, dtype=torch.float32).reshape(token_count, 4) if include_logits else None
         )
-        sasa_logits = (
-            torch.arange(token_count * 5, dtype=torch.float32).reshape(token_count, 5) if include_sasa else None
+
+        def _track(name: str) -> Any | None:
+            if name not in tracks:
+                return None
+            vocab = self._TRACK_VOCAB[name]
+            return torch.arange(token_count * vocab, dtype=torch.float32).reshape(token_count, vocab)
+
+        self.logits = _FakeForwardTrackData(
+            sequence_logits,
+            sasa=_track("sasa"),
+            secondary_structure=_track("secondary_structure"),
+            function=_track("function"),
         )
-        self.logits = _FakeForwardTrackData(sequence_logits, sasa_logits)
+        # Residue-annotation logits live at the top level of LogitsOutput.
+        self.residue_annotation_logits = _track("residue_annotations")
 
 
 class _FakeSDKModel:
@@ -160,11 +189,16 @@ class _FakeSDKModel:
 
     def logits(self, encoded: _FakeEncoded, config: _FakeLogitsConfig) -> _FakeLogitsOutput:
         self.logits_configs.append(config.kwargs)
+        tracks = {
+            name
+            for name in ("sasa", "secondary_structure", "function", "residue_annotations")
+            if bool(config.kwargs.get(name))
+        }
         return _FakeLogitsOutput(
             encoded.sequence,
             include_hidden=bool(config.kwargs.get("return_hidden_states")),
             include_logits=bool(config.kwargs.get("sequence")),
-            include_sasa=bool(config.kwargs.get("sasa")),
+            tracks=tracks,
         )
 
 
@@ -233,33 +267,50 @@ def test_esm3_core_hidden_states_are_rejected(fake_esm_sdk: type[_FakeSDKModel])
         ESM3Core(config={"device": "cpu"}).embed("ACD", options={"include_fields": ["hidden_states"]})
 
 
-def test_esm3_wildcard_requests_supported_logits_only(fake_esm_sdk: type[_FakeSDKModel]) -> None:
+# (output field, LogitsConfig kwarg, fake vocab size) for each ESM3 track logit.
+_ESM3_TRACK_CASES = [
+    ("sasa_logits", "sasa", 5),
+    ("secondary_structure_logits", "secondary_structure", 6),
+    ("function_logits", "function", 7),
+    ("residue_annotation_logits", "residue_annotations", 8),
+]
+
+
+def test_esm3_wildcard_requests_all_supported_tracks(fake_esm_sdk: type[_FakeSDKModel]) -> None:
     from boileroom.models.esm3.core import ESM3Core
 
     result = ESM3Core(config={"device": "cpu"}).embed("ACD", options={"include_fields": ["*"]})
 
     assert result.lm_logits is not None and result.lm_logits.shape == (1, 3, 4)
     assert result.sasa_logits is not None and result.sasa_logits.shape == (1, 3, 5)
+    assert result.secondary_structure_logits is not None and result.secondary_structure_logits.shape == (1, 3, 6)
+    assert result.function_logits is not None and result.function_logits.shape == (1, 3, 7)
+    assert result.residue_annotation_logits is not None and result.residue_annotation_logits.shape == (1, 3, 8)
+    # hidden_states is not an ESM3-supported optional field, so "*" must not request it.
     assert result.hidden_states is None
 
 
-def test_esm3_core_returns_sasa_logits(fake_esm_sdk: type[_FakeSDKModel]) -> None:
+@pytest.mark.parametrize(("field", "kwarg", "vocab"), _ESM3_TRACK_CASES)
+def test_esm3_returns_requested_track_logits(
+    fake_esm_sdk: type[_FakeSDKModel], field: str, kwarg: str, vocab: int
+) -> None:
     from boileroom.models.esm3.core import ESM3Core
 
-    result = ESM3Core(config={"device": "cpu"}).embed("ACD", options={"include_fields": ["sasa_logits"]})
+    result = ESM3Core(config={"device": "cpu"}).embed("ACD", options={"include_fields": [field]})
 
-    # The SASA track must have been requested from the SDK, and only it (not sequence logits).
-    assert fake_esm_sdk.logits_configs[-1]["sasa"] is True
+    # Only the requested track (and not sequence logits) must be asked of the SDK.
+    assert fake_esm_sdk.logits_configs[-1][kwarg] is True
     assert fake_esm_sdk.logits_configs[-1]["sequence"] is False
-    assert result.sasa_logits is not None and result.sasa_logits.shape == (1, 3, 5)
+    assert getattr(result, field) is not None and getattr(result, field).shape == (1, 3, vocab)
     assert result.lm_logits is None
 
 
-def test_esmc_rejects_sasa_logits(fake_esm_sdk: type[_FakeSDKModel]) -> None:
+@pytest.mark.parametrize(("field", "kwarg", "vocab"), _ESM3_TRACK_CASES)
+def test_esmc_rejects_esm3_track_logits(fake_esm_sdk: type[_FakeSDKModel], field: str, kwarg: str, vocab: int) -> None:
     from boileroom.models.esm3.core import ESMCCore
 
-    with pytest.raises(ValueError, match=r"sasa_logits.*ESM3"):
-        ESMCCore(config={"device": "cpu"}).embed("ACD", options={"include_fields": ["sasa_logits"]})
+    with pytest.raises(ValueError, match=rf"{field}.*ESM3"):
+        ESMCCore(config={"device": "cpu"}).embed("ACD", options={"include_fields": [field]})
 
 
 def test_esm3_alias_model_names_are_valid(fake_esm_sdk: type[_FakeSDKModel]) -> None:

--- a/tests/esm3/test_esm3_embeddings.py
+++ b/tests/esm3/test_esm3_embeddings.py
@@ -62,6 +62,7 @@ def test_parse_sequences_rejects_empty_batches() -> None:
 
 
 def test_pad_residue_arrays_zero_and_minus_one_padding() -> None:
+    """Residue arrays pad with zeros; chain/residue indices pad with -1."""
     from boileroom.models.esm3.core import pad_residue_arrays
 
     embeddings, hidden_states, lm_logits, chain_index, residue_index = pad_residue_arrays(
@@ -122,6 +123,7 @@ class _FakeForwardTrackData:
         secondary_structure: Any | None = None,
         function: Any | None = None,
     ) -> None:
+        """Store fake per-track logits for a ForwardTrackData stand-in."""
         self.sequence = sequence
         self.sasa = sasa
         self.secondary_structure = secondary_structure
@@ -140,6 +142,7 @@ class _FakeLogitsOutput:
     def __init__(
         self, sequence: str, include_hidden: bool, include_logits: bool, tracks: set[str] | None = None
     ) -> None:
+        """Build fake embeddings, hidden states, and logits for the requested tracks."""
         torch = pytest.importorskip("torch")
         tracks = tracks or set()
         token_count = len(sequence) + 2
@@ -151,6 +154,7 @@ class _FakeLogitsOutput:
         )
 
         def _track(name: str) -> Any | None:
+            """Return fake logits for track ``name`` when requested, else ``None``."""
             if name not in tracks:
                 return None
             vocab = self._TRACK_VOCAB[name]
@@ -188,6 +192,7 @@ class _FakeSDKModel:
         return _FakeEncoded(protein.sequence)
 
     def logits(self, encoded: _FakeEncoded, config: _FakeLogitsConfig) -> _FakeLogitsOutput:
+        """Record the requested LogitsConfig and return fake logits for its tracks."""
         self.logits_configs.append(config.kwargs)
         tracks = {
             name
@@ -277,6 +282,7 @@ _ESM3_TRACK_CASES = [
 
 
 def test_esm3_wildcard_requests_all_supported_tracks(fake_esm_sdk: type[_FakeSDKModel]) -> None:
+    """``["*"]`` requests every ESM3-supported track logit, but not hidden states."""
     from boileroom.models.esm3.core import ESM3Core
 
     result = ESM3Core(config={"device": "cpu"}).embed("ACD", options={"include_fields": ["*"]})
@@ -294,6 +300,7 @@ def test_esm3_wildcard_requests_all_supported_tracks(fake_esm_sdk: type[_FakeSDK
 def test_esm3_returns_requested_track_logits(
     fake_esm_sdk: type[_FakeSDKModel], field: str, kwarg: str, vocab: int
 ) -> None:
+    """Each ESM3 track can be requested on its own and returns its own logits shape."""
     from boileroom.models.esm3.core import ESM3Core
 
     result = ESM3Core(config={"device": "cpu"}).embed("ACD", options={"include_fields": [field]})
@@ -307,6 +314,7 @@ def test_esm3_returns_requested_track_logits(
 
 @pytest.mark.parametrize(("field", "kwarg", "vocab"), _ESM3_TRACK_CASES)
 def test_esmc_rejects_esm3_track_logits(fake_esm_sdk: type[_FakeSDKModel], field: str, kwarg: str, vocab: int) -> None:
+    """ESM-C rejects ESM3-only track requests with a clear ``ValueError``."""
     from boileroom.models.esm3.core import ESMCCore
 
     with pytest.raises(ValueError, match=rf"{field}.*ESM3"):

--- a/tests/esm3/test_esm3_embeddings.py
+++ b/tests/esm3/test_esm3_embeddings.py
@@ -64,7 +64,7 @@ def test_parse_sequences_rejects_empty_batches() -> None:
 def test_pad_residue_arrays_zero_and_minus_one_padding() -> None:
     from boileroom.models.esm3.core import pad_residue_arrays
 
-    embeddings, hidden_states, lm_logits, chain_index, residue_index = pad_residue_arrays(
+    embeddings, hidden_states, lm_logits, chain_index, residue_index, sasa_logits = pad_residue_arrays(
         embeddings=[np.ones((5, 2), dtype=np.float32), np.full((2, 2), 2, dtype=np.float32)],
         chain_index=[np.array([0, 0, 0, 1, 1]), np.array([0, 0])],
         residue_index=[np.array([0, 1, 2, 0, 1]), np.array([0, 1])],
@@ -78,6 +78,7 @@ def test_pad_residue_arrays_zero_and_minus_one_padding() -> None:
     assert residue_index.tolist() == [[0, 1, 2, 0, 1], [0, 1, -1, -1, -1]]
     assert hidden_states is None
     assert lm_logits is None
+    assert sasa_logits is None
 
 
 def test_pad_residue_arrays_rejects_empty_batches() -> None:
@@ -115,12 +116,13 @@ class _FakeEncoded:
 
 
 class _FakeForwardTrackData:
-    def __init__(self, sequence: Any | None) -> None:
+    def __init__(self, sequence: Any | None, sasa: Any | None = None) -> None:
         self.sequence = sequence
+        self.sasa = sasa
 
 
 class _FakeLogitsOutput:
-    def __init__(self, sequence: str, include_hidden: bool, include_logits: bool) -> None:
+    def __init__(self, sequence: str, include_hidden: bool, include_logits: bool, include_sasa: bool = False) -> None:
         torch = pytest.importorskip("torch")
         token_count = len(sequence) + 2
         values = torch.arange(token_count * 3, dtype=torch.float32).reshape(token_count, 3)
@@ -129,7 +131,10 @@ class _FakeLogitsOutput:
         sequence_logits = (
             torch.arange(token_count * 4, dtype=torch.float32).reshape(token_count, 4) if include_logits else None
         )
-        self.logits = _FakeForwardTrackData(sequence_logits)
+        sasa_logits = (
+            torch.arange(token_count * 5, dtype=torch.float32).reshape(token_count, 5) if include_sasa else None
+        )
+        self.logits = _FakeForwardTrackData(sequence_logits, sasa_logits)
 
 
 class _FakeSDKModel:
@@ -159,6 +164,7 @@ class _FakeSDKModel:
             encoded.sequence,
             include_hidden=bool(config.kwargs.get("return_hidden_states")),
             include_logits=bool(config.kwargs.get("sequence")),
+            include_sasa=bool(config.kwargs.get("sasa")),
         )
 
 
@@ -233,7 +239,27 @@ def test_esm3_wildcard_requests_supported_logits_only(fake_esm_sdk: type[_FakeSD
     result = ESM3Core(config={"device": "cpu"}).embed("ACD", options={"include_fields": ["*"]})
 
     assert result.lm_logits is not None and result.lm_logits.shape == (1, 3, 4)
+    assert result.sasa_logits is not None and result.sasa_logits.shape == (1, 3, 5)
     assert result.hidden_states is None
+
+
+def test_esm3_core_returns_sasa_logits(fake_esm_sdk: type[_FakeSDKModel]) -> None:
+    from boileroom.models.esm3.core import ESM3Core
+
+    result = ESM3Core(config={"device": "cpu"}).embed("ACD", options={"include_fields": ["sasa_logits"]})
+
+    # The SASA track must have been requested from the SDK, and only it (not sequence logits).
+    assert fake_esm_sdk.logits_configs[-1]["sasa"] is True
+    assert fake_esm_sdk.logits_configs[-1]["sequence"] is False
+    assert result.sasa_logits is not None and result.sasa_logits.shape == (1, 3, 5)
+    assert result.lm_logits is None
+
+
+def test_esmc_rejects_sasa_logits(fake_esm_sdk: type[_FakeSDKModel]) -> None:
+    from boileroom.models.esm3.core import ESMCCore
+
+    with pytest.raises(ValueError, match=r"sasa_logits.*ESM3"):
+        ESMCCore(config={"device": "cpu"}).embed("ACD", options={"include_fields": ["sasa_logits"]})
 
 
 def test_esm3_alias_model_names_are_valid(fake_esm_sdk: type[_FakeSDKModel]) -> None:


### PR DESCRIPTION
## Summary
ESM3 is a multi-track model, but the wrapper surfaced only embeddings + optional sequence logits. This exposes ESM3's remaining **non-structure** tracks as requestable outputs, so callers can get them from **sequence alone** (ESM3 predicts masked tracks all-to-all; structure input is optional). The structure/folding track is intentionally not exposed.

## New ESM3-only optional fields
Each is a per-residue logits array; decode downstream via the SDK's per-track tokenizer:
- `sasa_logits` — discretized SASA vocabulary
- `secondary_structure_logits` — SS8 vocabulary
- `function_logits` — function-annotation vocabulary
- `residue_annotation_logits` — multi-hot residue annotations

## Usage
```python
ESM3(config={"model_name": "esm3_sm_open_v1"}).embed(
    "MKV…", options={"include_fields": ["sasa_logits", "secondary_structure_logits"]}
)
# -> result.sasa_logits, result.secondary_structure_logits : (batch, residues, track_vocab)
```

## Implementation
- One table (`ESM3_TRACK_LOGIT_FIELDS`) maps each public field → its `LogitsConfig` kwarg and SDK source path; `embed` requests/extracts/residue-selects/pads all tracks generically. `_run_logits` takes the requested track flags. Requesting any track on **ESM-C raises** a clear `ValueError`.
- types: four fields added to `ESMEmbeddingOutput` (ESM3-only).
- registry: ESM3 `optional_output_fields` lists the four tracks.
- docs: `include_fields` options documented in `docs/models.md`.
- Bumps `project.version` to **0.4.1** (release target) and updates the derive-version contract test's expected alpha tag.

## Testing
All checks below were run locally and pass.

- **Unit tests (fake-SDK, no GPU)** — `tests/esm3/test_esm3_embeddings.py` (20 passed). A fake `esm` SDK is monkeypatched in, so the core's request/extract/residue-select/pad logic is exercised without model weights. Coverage added for this change:
  - each track (`sasa`/`secondary_structure`/`function`/`residue_annotation` logits) is requested from the SDK and returned with its own per-residue shape (parametrized);
  - `include_fields=["*"]` requests all four tracks (plus lm_logits), and not `hidden_states`;
  - requesting any track on **ESM-C raises** `ValueError` (parametrized);
  - existing embedding/lm_logits/parse/pad/bfloat16 behavior still holds.
- **Contract tests** — `tests/contracts/test_model_wrappers.py` (29 passed): registry entries resolve and output-shape contracts hold, including the ESM3 optional fields.
- **Full non-integration suite** — `pytest -m "not integration and not gpu and not slow"`: **150 passed, 3 skipped** (includes the version-metadata and derive-version contract tests at 0.4.1).
- **Lint/type** — `pre-commit run` (mypy + ruff + ruff-format) clean on all changed files.

**Not covered here:** end-to-end execution against real ESM3 weights on a GPU (Modal/Apptainer) — that's the `integration`/`gpu` suite and needs the published runtime image; the track logits themselves come from the SDK's `LogitsConfig`, which the fake-SDK tests exercise. Decoding the binned/tokenized logits to estimates (e.g. SASA Å²) is a downstream concern (done in the bagel ESM3 oracle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - ESM3 embeddings can now return additional per-residue track logits, including SASA, secondary structure, function, and residue annotation outputs.
  - Supported optional output fields were expanded so these track logits can be requested alongside existing logits.

- **Bug Fixes**
  - Requests for unsupported track logits are now rejected on ESM-C, preventing invalid output requests.
  - Output shapes are now padded and combined consistently across batches for track-level predictions.

- **Tests**
  - Updated embedding and versioning tests to cover the new optional outputs and release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->