### PR TITLE
Isolate Docker image builds by model

### DIFF
--- a/.github/workflows/arm64-image-smoke.yml
+++ b/.github/workflows/arm64-image-smoke.yml
@@ -46,6 +46,9 @@ jobs:
     name: ARM64 Base Smoke
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
+    env:
+      CUDA_VERSION: ${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }}
+      DOCKER_REPOSITORY: docker.io/jakublala
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -67,7 +70,8 @@ jobs:
       - name: Build ARM64 base image
         run: |
           uv run --no-project --with click --with pyyaml python scripts/images/build_model_images.py \
-            --cuda-version=${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }} \
+            --cuda-version="${CUDA_VERSION}" \
+            --docker-user="${DOCKER_REPOSITORY}" \
             --tag=arm64-ci \
             --platform=linux/arm64 \
             --base-mode=only \
@@ -75,12 +79,10 @@ jobs:
             --verbose
 
       - name: Export ARM64 base image
-        env:
-          CUDA_VERSION: ${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }}
         run: |
           docker save \
             --output /tmp/boileroom-arm64-base.tar \
-            "docker.io/jakublala/boileroom-base:cuda${CUDA_VERSION}-arm64-ci"
+            "${DOCKER_REPOSITORY}/boileroom-base:cuda${CUDA_VERSION}-arm64-ci"
 
       - name: Upload ARM64 base image
         uses: actions/upload-artifact@v4
@@ -97,6 +99,10 @@ jobs:
     name: ARM64 Image Smoke (${{ matrix.model }})
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 180
+    env:
+      CUDA_VERSION: ${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }}
+      DOCKER_REPOSITORY: docker.io/jakublala
+      MODEL: ${{ matrix.model }}
     strategy:
       fail-fast: false
       matrix:
@@ -133,8 +139,9 @@ jobs:
       - name: Build ARM64 model image
         run: |
           uv run --no-project --with click --with pyyaml python scripts/images/build_model_images.py \
-            --cuda-version=${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }} \
-            --model=${{ matrix.model }} \
+            --cuda-version="${CUDA_VERSION}" \
+            --docker-user="${DOCKER_REPOSITORY}" \
+            --model="${MODEL}" \
             --tag=arm64-ci \
             --platform=linux/arm64 \
             --base-mode=existing \
@@ -144,15 +151,17 @@ jobs:
       - name: Run ARM64 import smoke
         run: |
           uv run --no-project --with click --with pyyaml python scripts/images/check_model_imports.py \
-            --cuda-version=${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }} \
-            --model=${{ matrix.model }} \
+            --cuda-version="${CUDA_VERSION}" \
+            --docker-user="${DOCKER_REPOSITORY}" \
+            --model="${MODEL}" \
             --tag=arm64-ci
 
       - name: Run ARM64 server health smoke
         run: |
           uv run --no-project --with click --with pyyaml python scripts/images/check_model_server_health.py \
-            --cuda-version=${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }} \
-            --model=${{ matrix.model }} \
+            --cuda-version="${CUDA_VERSION}" \
+            --docker-user="${DOCKER_REPOSITORY}" \
+            --model="${MODEL}" \
             --tag=arm64-ci \
             --cleanup
 

--- a/.github/workflows/arm64-image-smoke.yml
+++ b/.github/workflows/arm64-image-smoke.yml
@@ -11,10 +11,96 @@ permissions:
 concurrency: arm64-image-smoke-${{ github.ref }}
 
 jobs:
+  prepare-arm64-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      default_cuda_version: ${{ steps.image_metadata.outputs.default_cuda_version }}
+      models: ${{ steps.image_metadata.outputs.models }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Determine ARM64 image matrix
+        id: image_metadata
+        run: |
+          uv run --no-project --with pyyaml python - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+
+          from boileroom.images.metadata import DEFAULT_CUDA_VERSION, MODEL_IMAGE_SPECS, get_supported_cuda
+
+          models = [spec.key for spec in MODEL_IMAGE_SPECS if DEFAULT_CUDA_VERSION in get_supported_cuda(spec)]
+          print(f"default_cuda_version={DEFAULT_CUDA_VERSION}")
+          print(f"models={json.dumps(models, separators=(',', ':'))}")
+          PY
+
+  build-arm64-base:
+    needs: prepare-arm64-matrix
+    name: ARM64 Base Smoke
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: arm64-base-smoke
+
+      - name: Prepare image script dependencies
+        run: uv run --no-project --with click --with pyyaml python -c "import click, yaml"
+
+      - name: Build ARM64 base image
+        run: |
+          uv run --no-project --with click --with pyyaml python scripts/images/build_model_images.py \
+            --cuda-version=${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }} \
+            --tag=arm64-ci \
+            --platform=linux/arm64 \
+            --base-mode=only \
+            --max-workers=1 \
+            --verbose
+
+      - name: Export ARM64 base image
+        env:
+          CUDA_VERSION: ${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }}
+        run: |
+          docker save \
+            --output /tmp/boileroom-arm64-base.tar \
+            "docker.io/jakublala/boileroom-base:cuda${CUDA_VERSION}-arm64-ci"
+
+      - name: Upload ARM64 base image
+        uses: actions/upload-artifact@v4
+        with:
+          name: arm64-base-${{ github.run_id }}
+          path: /tmp/boileroom-arm64-base.tar
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true
+
   arm64-image-smoke:
-    name: ARM64 Image Smoke
+    needs: [prepare-arm64-matrix, build-arm64-base]
+    name: ARM64 Image Smoke (${{ matrix.model }})
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix:
+        model: ${{ fromJSON(needs.prepare-arm64-matrix.outputs.models) }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -33,32 +119,43 @@ jobs:
       - name: Prepare image smoke script dependencies
         run: uv run --no-project --with click --with pyyaml python -c "import click, yaml"
 
-      - name: Determine default CUDA version
-        id: image_metadata
+      - name: Download ARM64 base image
+        uses: actions/download-artifact@v4
+        with:
+          name: arm64-base-${{ github.run_id }}
+          path: /tmp/boileroom-arm64-base
+
+      - name: Load ARM64 base image
         run: |
-          uv run --no-project --with pyyaml python - <<'PY' >> "$GITHUB_OUTPUT"
-          from boileroom.images.metadata import DEFAULT_CUDA_VERSION
+          docker load --input /tmp/boileroom-arm64-base/boileroom-arm64-base.tar
+          rm -- /tmp/boileroom-arm64-base/boileroom-arm64-base.tar
 
-          print(f"default_cuda_version={DEFAULT_CUDA_VERSION}")
-          PY
-
-      - name: Build ARM64 image set
+      - name: Build ARM64 model image
         run: |
           uv run --no-project --with click --with pyyaml python scripts/images/build_model_images.py \
-            --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
+            --cuda-version=${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }} \
+            --model=${{ matrix.model }} \
             --tag=arm64-ci \
             --platform=linux/arm64 \
-            --max-workers=3 \
+            --base-mode=existing \
+            --max-workers=1 \
             --verbose
 
       - name: Run ARM64 import smoke
         run: |
           uv run --no-project --with click --with pyyaml python scripts/images/check_model_imports.py \
-            --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
+            --cuda-version=${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }} \
+            --model=${{ matrix.model }} \
             --tag=arm64-ci
 
       - name: Run ARM64 server health smoke
         run: |
           uv run --no-project --with click --with pyyaml python scripts/images/check_model_server_health.py \
-            --cuda-version=${{ steps.image_metadata.outputs.default_cuda_version }} \
-            --tag=arm64-ci
+            --cuda-version=${{ needs.prepare-arm64-matrix.outputs.default_cuda_version }} \
+            --model=${{ matrix.model }} \
+            --tag=arm64-ci \
+            --cleanup
+
+      - name: Free disk space after build
+        if: always()
+        run: docker builder prune --all --force

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -53,7 +53,6 @@ jobs:
       image_tag: ${{ steps.image_tag.outputs.value }}
       cuda_versions: ${{ steps.image_metadata.outputs.cuda_versions }}
       default_cuda_version: ${{ steps.image_metadata.outputs.default_cuda_version }}
-      docker_repository: ${{ steps.image_metadata.outputs.docker_repository }}
       amd64_model_matrix: ${{ steps.image_metadata.outputs.amd64_model_matrix }}
       arm64_model_matrix: ${{ steps.image_metadata.outputs.arm64_model_matrix }}
     steps:
@@ -82,6 +81,26 @@ jobs:
         with:
           enable-cache: true
           cache-suffix: image-prepare
+
+      - name: Validate Docker publishing configuration
+        env:
+          DOCKERHUB_TOKEN_FOR_RUN: ${{ secrets[env.DOCKERHUB_TOKEN_SECRET_FOR_RUN] }}
+        run: |
+          if [ -z "${DOCKERHUB_USERNAME_FOR_RUN}" ]; then
+            echo "Docker Hub username must not be empty."
+            exit 1
+          fi
+          if [ -z "${DOCKERHUB_TOKEN_FOR_RUN}" ]; then
+            echo "Docker Hub token secret '${DOCKERHUB_TOKEN_SECRET_FOR_RUN}' is missing or empty."
+            exit 1
+          fi
+          uv run --no-project --with pyyaml python - <<'PY'
+          import os
+
+          from boileroom.images.metadata import normalize_docker_repository
+
+          normalize_docker_repository(os.environ["DOCKER_REPOSITORY_FOR_RUN"])
+          PY
 
       - name: Determine Boileroom version
         id: version
@@ -113,14 +132,12 @@ jobs:
         run: |
           uv run --no-project --with pyyaml python - <<'PY' >> "$GITHUB_OUTPUT"
           import json
-          import os
 
           from boileroom.images.metadata import (
               DEFAULT_CUDA_VERSION,
               MODEL_IMAGE_SPECS,
               SUPPORTED_CUDA_VERSIONS,
               get_supported_cuda,
-              normalize_docker_repository,
           )
 
           amd64_model_matrix = {
@@ -140,7 +157,6 @@ jobs:
 
           print(f"cuda_versions={json.dumps(sorted(SUPPORTED_CUDA_VERSIONS))}")
           print(f"default_cuda_version={DEFAULT_CUDA_VERSION}")
-          print(f"docker_repository={normalize_docker_repository(os.environ['DOCKER_REPOSITORY_FOR_RUN'])}")
           print(f"amd64_model_matrix={json.dumps(amd64_model_matrix, separators=(',', ':'))}")
           print(f"arm64_model_matrix={json.dumps(arm64_model_matrix, separators=(',', ':'))}")
           PY
@@ -150,6 +166,9 @@ jobs:
     name: Build Base (linux/amd64, CUDA ${{ matrix.cuda_version }})
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    env:
+      CUDA_VERSION: ${{ matrix.cuda_version }}
+      IMAGE_TAG: ${{ needs.prepare-release.outputs.image_tag }}
     strategy:
       fail-fast: false
       matrix:
@@ -182,9 +201,9 @@ jobs:
       - name: Build and push base image
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/build_model_images.py \
-            --cuda-version=${{ matrix.cuda_version }} \
-            --tag=${{ needs.prepare-release.outputs.image_tag }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --cuda-version="${CUDA_VERSION}" \
+            --tag="${IMAGE_TAG}" \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --platform=linux/amd64 \
             --base-mode=only \
             --push \
@@ -200,6 +219,10 @@ jobs:
     name: Build Model (${{ matrix.model }}, linux/amd64, CUDA ${{ matrix.cuda_version }})
     runs-on: ubuntu-latest
     timeout-minutes: 180
+    env:
+      CUDA_VERSION: ${{ matrix.cuda_version }}
+      IMAGE_TAG: ${{ needs.prepare-release.outputs.image_tag }}
+      MODEL: ${{ matrix.model }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare-release.outputs.amd64_model_matrix) }}
@@ -231,10 +254,10 @@ jobs:
       - name: Build and push model image
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/build_model_images.py \
-            --cuda-version=${{ matrix.cuda_version }} \
-            --model=${{ matrix.model }} \
-            --tag=${{ needs.prepare-release.outputs.image_tag }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --cuda-version="${CUDA_VERSION}" \
+            --model="${MODEL}" \
+            --tag="${IMAGE_TAG}" \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --platform=linux/amd64 \
             --base-mode=existing \
             --push \
@@ -247,37 +270,37 @@ jobs:
       - name: Verify canonical image imports
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
-            --cuda-version=${{ matrix.cuda_version }} \
-            --model=${{ matrix.model }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --cuda-version="${CUDA_VERSION}" \
+            --model="${MODEL}" \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
+            --tag="${IMAGE_TAG}" \
             --pull
 
       - name: Verify canonical image server health
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
-            --cuda-version=${{ matrix.cuda_version }} \
-            --model=${{ matrix.model }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --cuda-version="${CUDA_VERSION}" \
+            --model="${MODEL}" \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
+            --tag="${IMAGE_TAG}" \
             --cleanup
 
       - name: Verify default-CUDA alias image imports
         if: matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
-            --model=${{ matrix.model }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --model="${MODEL}" \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
+            --tag="${IMAGE_TAG}" \
             --pull
 
       - name: Verify default-CUDA alias image server health
         if: matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
-            --model=${{ matrix.model }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --model="${MODEL}" \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
+            --tag="${IMAGE_TAG}" \
             --cleanup
 
       - name: Free disk space after build
@@ -289,6 +312,9 @@ jobs:
     name: Build Base (linux/arm64, CUDA ${{ needs.prepare-release.outputs.default_cuda_version }})
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 60
+    env:
+      CUDA_VERSION: ${{ needs.prepare-release.outputs.default_cuda_version }}
+      IMAGE_TAG: ${{ needs.prepare-release.outputs.image_tag }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -307,22 +333,28 @@ jobs:
       - name: Prepare image script dependencies
         run: uv run --no-project --with click --with pyyaml python -c "import click, yaml"
 
+      - name: Normalize Docker repository
+        run: |
+          uv run --no-project --with pyyaml python - <<'PY' >> "$GITHUB_ENV"
+          import os
+
+          from boileroom.images.metadata import normalize_docker_repository
+
+          print(f"DOCKER_REPOSITORY={normalize_docker_repository(os.environ['DOCKER_REPOSITORY_FOR_RUN'])}")
+          PY
+
       - name: Build ARM64 base image locally
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/build_model_images.py \
-            --cuda-version=${{ needs.prepare-release.outputs.default_cuda_version }} \
-            --tag=${{ needs.prepare-release.outputs.image_tag }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --cuda-version="${CUDA_VERSION}" \
+            --tag="${IMAGE_TAG}" \
+            --docker-user="${DOCKER_REPOSITORY}" \
             --platform=linux/arm64 \
             --base-mode=only \
             --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
             --verbose
 
       - name: Export ARM64 base image
-        env:
-          CUDA_VERSION: ${{ needs.prepare-release.outputs.default_cuda_version }}
-          DOCKER_REPOSITORY: ${{ needs.prepare-release.outputs.docker_repository }}
-          IMAGE_TAG: ${{ needs.prepare-release.outputs.image_tag }}
         run: |
           docker save \
             --output /tmp/boileroom-arm64-base.tar \
@@ -343,6 +375,10 @@ jobs:
     name: Build Model (${{ matrix.model }}, linux/arm64, CUDA ${{ matrix.cuda_version }})
     runs-on: ubuntu-24.04-arm
     timeout-minutes: 180
+    env:
+      CUDA_VERSION: ${{ matrix.cuda_version }}
+      IMAGE_TAG: ${{ needs.prepare-release.outputs.image_tag }}
+      MODEL: ${{ matrix.model }}
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare-release.outputs.arm64_model_matrix) }}
@@ -378,10 +414,10 @@ jobs:
       - name: Build model image locally
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/build_model_images.py \
-            --cuda-version=${{ matrix.cuda_version }} \
-            --model=${{ matrix.model }} \
-            --tag=${{ needs.prepare-release.outputs.image_tag }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --cuda-version="${CUDA_VERSION}" \
+            --model="${MODEL}" \
+            --tag="${IMAGE_TAG}" \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
             --platform=linux/arm64 \
             --base-mode=existing \
             --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
@@ -390,33 +426,33 @@ jobs:
       - name: Verify canonical image imports
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
-            --cuda-version=${{ matrix.cuda_version }} \
-            --model=${{ matrix.model }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }}
+            --cuda-version="${CUDA_VERSION}" \
+            --model="${MODEL}" \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
+            --tag="${IMAGE_TAG}"
 
       - name: Verify canonical image server health
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
-            --cuda-version=${{ matrix.cuda_version }} \
-            --model=${{ matrix.model }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --cuda-version="${CUDA_VERSION}" \
+            --model="${MODEL}" \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
+            --tag="${IMAGE_TAG}" \
             --cleanup
 
       - name: Verify local alias image imports
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
-            --model=${{ matrix.model }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }}
+            --model="${MODEL}" \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
+            --tag="${IMAGE_TAG}"
 
       - name: Verify local alias image server health
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
-            --model=${{ matrix.model }} \
-            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --model="${MODEL}" \
+            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
+            --tag="${IMAGE_TAG}" \
             --cleanup
 
       - name: Free disk space after build

--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - README.md
+      - docs/**
   release:
     types: [published]
   workflow_dispatch:
@@ -38,7 +41,7 @@ env:
   DOCKER_REPOSITORY_FOR_RUN: ${{ github.event.inputs.docker_repository || 'docker.io/jakublala' }}
   DOCKERHUB_USERNAME_FOR_RUN: ${{ github.event.inputs.dockerhub_username || secrets.DOCKERHUB_USERNAME }}
   DOCKERHUB_TOKEN_SECRET_FOR_RUN: ${{ github.event.inputs.dockerhub_token_secret || 'DOCKERHUB_TOKEN' }}
-  IMAGE_BUILD_MAX_WORKERS: "3"
+  IMAGE_BUILD_MAX_WORKERS: "1"
   SHOULD_PROMOTE: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'release' && github.event.release.prerelease == false) || inputs.promote }}
 
 jobs:
@@ -50,6 +53,9 @@ jobs:
       image_tag: ${{ steps.image_tag.outputs.value }}
       cuda_versions: ${{ steps.image_metadata.outputs.cuda_versions }}
       default_cuda_version: ${{ steps.image_metadata.outputs.default_cuda_version }}
+      docker_repository: ${{ steps.image_metadata.outputs.docker_repository }}
+      amd64_model_matrix: ${{ steps.image_metadata.outputs.amd64_model_matrix }}
+      arm64_model_matrix: ${{ steps.image_metadata.outputs.arm64_model_matrix }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -107,26 +113,47 @@ jobs:
         run: |
           uv run --no-project --with pyyaml python - <<'PY' >> "$GITHUB_OUTPUT"
           import json
+          import os
 
-          from boileroom.images.metadata import DEFAULT_CUDA_VERSION, SUPPORTED_CUDA_VERSIONS
+          from boileroom.images.metadata import (
+              DEFAULT_CUDA_VERSION,
+              MODEL_IMAGE_SPECS,
+              SUPPORTED_CUDA_VERSIONS,
+              get_supported_cuda,
+              normalize_docker_repository,
+          )
+
+          amd64_model_matrix = {
+              "include": [
+                  {"model": spec.key, "cuda_version": cuda_version}
+                  for spec in MODEL_IMAGE_SPECS
+                  for cuda_version in get_supported_cuda(spec)
+              ]
+          }
+          arm64_model_matrix = {
+              "include": [
+                  {"model": spec.key, "cuda_version": DEFAULT_CUDA_VERSION}
+                  for spec in MODEL_IMAGE_SPECS
+                  if DEFAULT_CUDA_VERSION in get_supported_cuda(spec)
+              ]
+          }
 
           print(f"cuda_versions={json.dumps(sorted(SUPPORTED_CUDA_VERSIONS))}")
           print(f"default_cuda_version={DEFAULT_CUDA_VERSION}")
+          print(f"docker_repository={normalize_docker_repository(os.environ['DOCKER_REPOSITORY_FOR_RUN'])}")
+          print(f"amd64_model_matrix={json.dumps(amd64_model_matrix, separators=(',', ':'))}")
+          print(f"arm64_model_matrix={json.dumps(arm64_model_matrix, separators=(',', ':'))}")
           PY
 
-  build-images:
+  build-amd64-base:
     needs: prepare-release
-    name: Build Images (${{ matrix.platform }}, CUDA ${{ matrix.cuda_version }})
-    runs-on: ${{ matrix.platform == 'linux/arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    name: Build Base (linux/amd64, CUDA ${{ matrix.cuda_version }})
+    runs-on: ubuntu-latest
     timeout-minutes: 180
     strategy:
       fail-fast: false
       matrix:
         cuda_version: ${{ fromJSON(needs.prepare-release.outputs.cuda_versions) }}
-        platform: [linux/amd64]
-        include:
-          - cuda_version: ${{ needs.prepare-release.outputs.default_cuda_version }}
-            platform: linux/arm64
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -140,65 +167,258 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          cache-suffix: image-build-${{ matrix.platform }}-${{ matrix.cuda_version }}
+          cache-suffix: image-build-base-amd64-${{ matrix.cuda_version }}
 
       - name: Prepare image script dependencies
         run: uv run --no-project --with click --with pyyaml python -c "import click, yaml"
 
       - name: Log in to Docker Hub
-        if: matrix.platform == 'linux/amd64'
         uses: docker/login-action@v3
         with:
           registry: docker.io
           username: ${{ env.DOCKERHUB_USERNAME_FOR_RUN }}
           password: ${{ secrets[env.DOCKERHUB_TOKEN_SECRET_FOR_RUN] }}
 
-      - name: Build images
-        shell: bash
+      - name: Build and push base image
         run: |
-          build_args=()
-          if [ "${{ matrix.platform }}" = "linux/amd64" ]; then
-            build_args+=(--push --local-base)
-          fi
-
           uv run --no-project --with click --with pyyaml python ./scripts/images/build_model_images.py \
             --cuda-version=${{ matrix.cuda_version }} \
             --tag=${{ needs.prepare-release.outputs.image_tag }} \
-            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
-            --platform=${{ matrix.platform }} \
-            "${build_args[@]}" \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --platform=linux/amd64 \
+            --base-mode=only \
+            --push \
             --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
             --verbose
 
-      - name: Verify local canonical image imports
+      - name: Free disk space after build
+        if: always()
+        run: docker builder prune --all --force
+
+  build-amd64-models:
+    needs: [prepare-release, build-amd64-base]
+    name: Build Model (${{ matrix.model }}, linux/amd64, CUDA ${{ matrix.cuda_version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare-release.outputs.amd64_model_matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: image-build-${{ matrix.model }}-amd64-${{ matrix.cuda_version }}
+
+      - name: Prepare image script dependencies
+        run: uv run --no-project --with click --with pyyaml python -c "import click, yaml"
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ env.DOCKERHUB_USERNAME_FOR_RUN }}
+          password: ${{ secrets[env.DOCKERHUB_TOKEN_SECRET_FOR_RUN] }}
+
+      - name: Build and push model image
+        run: |
+          uv run --no-project --with click --with pyyaml python ./scripts/images/build_model_images.py \
+            --cuda-version=${{ matrix.cuda_version }} \
+            --model=${{ matrix.model }} \
+            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --platform=linux/amd64 \
+            --base-mode=existing \
+            --push \
+            --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
+            --verbose
+
+      - name: Free build cache before verification
+        run: docker builder prune --all --force
+
+      - name: Verify canonical image imports
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
             --cuda-version=${{ matrix.cuda_version }} \
-            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }}
+            --model=${{ matrix.model }} \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --pull
 
-      - name: Verify local canonical image server health
+      - name: Verify canonical image server health
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
             --cuda-version=${{ matrix.cuda_version }} \
-            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }}
+            --model=${{ matrix.model }} \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --cleanup
 
-      - name: Verify local alias image imports
-        if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
+      - name: Verify default-CUDA alias image imports
+        if: matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
-            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }}
+            --model=${{ matrix.model }} \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --pull
 
-      - name: Verify local alias image server health
-        if: matrix.platform == 'linux/amd64' && matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
+      - name: Verify default-CUDA alias image server health
+        if: matrix.cuda_version == needs.prepare-release.outputs.default_cuda_version
         run: |
           uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
-            --docker-user="${DOCKER_REPOSITORY_FOR_RUN}" \
-            --tag=${{ needs.prepare-release.outputs.image_tag }}
+            --model=${{ matrix.model }} \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --cleanup
 
       - name: Free disk space after build
         if: always()
+        run: docker builder prune --all --force
+
+  build-arm64-base:
+    needs: prepare-release
+    name: Build Base (linux/arm64, CUDA ${{ needs.prepare-release.outputs.default_cuda_version }})
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: image-build-base-arm64-${{ needs.prepare-release.outputs.default_cuda_version }}
+
+      - name: Prepare image script dependencies
+        run: uv run --no-project --with click --with pyyaml python -c "import click, yaml"
+
+      - name: Build ARM64 base image locally
         run: |
-          docker builder prune --all --force
+          uv run --no-project --with click --with pyyaml python ./scripts/images/build_model_images.py \
+            --cuda-version=${{ needs.prepare-release.outputs.default_cuda_version }} \
+            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --platform=linux/arm64 \
+            --base-mode=only \
+            --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
+            --verbose
+
+      - name: Export ARM64 base image
+        env:
+          CUDA_VERSION: ${{ needs.prepare-release.outputs.default_cuda_version }}
+          DOCKER_REPOSITORY: ${{ needs.prepare-release.outputs.docker_repository }}
+          IMAGE_TAG: ${{ needs.prepare-release.outputs.image_tag }}
+        run: |
+          docker save \
+            --output /tmp/boileroom-arm64-base.tar \
+            "${DOCKER_REPOSITORY}/boileroom-base:cuda${CUDA_VERSION}-${IMAGE_TAG}"
+
+      - name: Upload ARM64 base image
+        uses: actions/upload-artifact@v4
+        with:
+          name: arm64-base-${{ github.run_id }}
+          path: /tmp/boileroom-arm64-base.tar
+          compression-level: 0
+          retention-days: 1
+          if-no-files-found: error
+          overwrite: true
+
+  build-arm64-models:
+    needs: [prepare-release, build-arm64-base]
+    name: Build Model (${{ matrix.model }}, linux/arm64, CUDA ${{ matrix.cuda_version }})
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 180
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare-release.outputs.arm64_model_matrix) }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-suffix: image-build-${{ matrix.model }}-arm64-${{ matrix.cuda_version }}
+
+      - name: Prepare image script dependencies
+        run: uv run --no-project --with click --with pyyaml python -c "import click, yaml"
+
+      - name: Download ARM64 base image
+        uses: actions/download-artifact@v4
+        with:
+          name: arm64-base-${{ github.run_id }}
+          path: /tmp/boileroom-arm64-base
+
+      - name: Load ARM64 base image
+        run: |
+          docker load --input /tmp/boileroom-arm64-base/boileroom-arm64-base.tar
+          rm -- /tmp/boileroom-arm64-base/boileroom-arm64-base.tar
+
+      - name: Build model image locally
+        run: |
+          uv run --no-project --with click --with pyyaml python ./scripts/images/build_model_images.py \
+            --cuda-version=${{ matrix.cuda_version }} \
+            --model=${{ matrix.model }} \
+            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --platform=linux/arm64 \
+            --base-mode=existing \
+            --max-workers=${IMAGE_BUILD_MAX_WORKERS} \
+            --verbose
+
+      - name: Verify canonical image imports
+        run: |
+          uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
+            --cuda-version=${{ matrix.cuda_version }} \
+            --model=${{ matrix.model }} \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --tag=${{ needs.prepare-release.outputs.image_tag }}
+
+      - name: Verify canonical image server health
+        run: |
+          uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
+            --cuda-version=${{ matrix.cuda_version }} \
+            --model=${{ matrix.model }} \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --cleanup
+
+      - name: Verify local alias image imports
+        run: |
+          uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_imports.py \
+            --model=${{ matrix.model }} \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --tag=${{ needs.prepare-release.outputs.image_tag }}
+
+      - name: Verify local alias image server health
+        run: |
+          uv run --no-project --with click --with pyyaml python ./scripts/images/check_model_server_health.py \
+            --model=${{ matrix.model }} \
+            --docker-user="${{ needs.prepare-release.outputs.docker_repository }}" \
+            --tag=${{ needs.prepare-release.outputs.image_tag }} \
+            --cleanup
+
+      - name: Free disk space after build
+        if: always()
+        run: docker builder prune --all --force

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -6,6 +6,7 @@ import importlib.metadata
 import os
 import re
 import tomllib
+from collections.abc import Sequence
 from dataclasses import dataclass
 from functools import cache
 from pathlib import Path
@@ -102,6 +103,7 @@ MODEL_IMAGE_SPECS: Final[tuple[RuntimeImageSpec, ...]] = (
 
 MODEL_IMAGE_SPECS_BY_KEY: Final = {family_key: spec for spec in MODEL_IMAGE_SPECS for family_key in spec.family_keys}
 MODEL_IMAGE_SPECS_BY_NAME: Final = {spec.image_name: spec for spec in MODEL_IMAGE_SPECS}
+MODEL_IMAGE_SELECTOR_KEYS: Final = tuple(family_key for spec in MODEL_IMAGE_SPECS for family_key in spec.family_keys)
 
 
 def get_repo_root() -> Path:
@@ -253,6 +255,22 @@ def get_model_image_spec(identifier: str) -> RuntimeImageSpec:
     if identifier in MODEL_IMAGE_SPECS_BY_NAME:
         return MODEL_IMAGE_SPECS_BY_NAME[identifier]
     raise KeyError(f"Unknown image spec: {identifier}")
+
+
+def select_model_image_specs(identifiers: Sequence[str] | None) -> tuple[RuntimeImageSpec, ...]:
+    """Return the requested model image specs in stable, de-duplicated order."""
+    if not identifiers:
+        return MODEL_IMAGE_SPECS
+
+    selected: list[RuntimeImageSpec] = []
+    seen_image_names: set[str] = set()
+    for identifier in identifiers:
+        spec = get_model_image_spec(identifier)
+        if spec.image_name in seen_image_names:
+            continue
+        selected.append(spec)
+        seen_image_names.add(spec.image_name)
+    return tuple(selected)
 
 
 @cache

--- a/docs/docker_images.md
+++ b/docs/docker_images.md
@@ -19,7 +19,7 @@ Dockerfiles are the canonical image definition for all runtimes. Docker/Apptaine
 Use the Python helper to build all images (base + models) with a single global worker limit.
 
 ```bash
-uv run python scripts/images/build_model_images.py --cuda-version=12.6 --platform=linux/amd64 --max-workers=4
+uv run python scripts/images/build_model_images.py --cuda-version=12.6 --platform=linux/amd64 --max-workers=1
 
 # Optional flags
 uv run python scripts/images/build_model_images.py --no-cache ...
@@ -27,6 +27,8 @@ uv run python scripts/images/build_model_images.py --verbose ...
 uv run python scripts/images/build_model_images.py --all-cuda --tag=0.3.0 --push ...
 uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=0.3.0 --push --local-base ...
 uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=sha-$(git rev-parse --short HEAD) --push ...
+uv run python scripts/images/build_model_images.py --cuda-version=12.6 --model=esmfold2 ...
+uv run python scripts/images/build_model_images.py --cuda-version=12.6 --base-mode=only --push ...
 ```
 
 Images publish to `docker.io/jakublala` by default. If `--tag` is omitted, image helpers use the current boileroom package version from `pyproject.toml`. Pass `--docker-user` and `--tag` to build or publish a specific tag under another Docker Hub namespace:
@@ -64,13 +66,14 @@ For lower-level runtime configuration outside pytest, `BOILEROOM_IMAGE_TAG` is t
 
 Single-platform non-push builds auto-load into the local Docker daemon. Multi-platform builds should generally be paired with `--push`.
 Pushed buildx builds import and export stable per-image registry caches such as `boileroom-chai1:buildcache-cuda12.6`, so GitHub Actions runners can reuse dependency layers across validation tags and releases. Pass `--no-cache` to bypass those caches.
-Model Dockerfiles also mount a shared BuildKit uv cache for the active CUDA line, for example `boileroom-uv-cu12.6`, so parallel model builds in the same GitHub Actions matrix job can reuse downloaded wheels even when a full dependency-install layer has to run again.
+Model Dockerfiles also mount a BuildKit uv cache scoped to the active CUDA line, for example `boileroom-uv-cu12.6`, so repeated builds can reuse downloaded wheels even when a full dependency-install layer has to run again.
 Pass `--verbose` to stream Docker build output and plain BuildKit progress while still writing per-image log files.
-In CI, the release workflow splits CUDA lines across separate GitHub-hosted runners and passes `--max-workers` within each CUDA job. That keeps the base image dependency order intact while letting model image builds and Docker Hub transfers overlap.
+In CI, the release workflow first publishes one AMD64 base image per CUDA line, then builds each model/CUDA pair on a fresh runner with `--max-workers=1`. Model jobs push directly from BuildKit, prune the build cache, and pull only their own image for smoke checks. This isolates disk usage so one large model cannot exhaust a runner used by the others.
+ARM64 validation also uses one fresh runner per model. A dedicated ARM64 runner builds the base once, exports it as a one-day run artifact, and each model runner loads that exact base locally; the published base tag remains AMD64-only.
 For single-platform publishing, pass `--local-base` to build and tag images with `buildx --load` before pushing. This keeps dependent model builds from waiting on Docker Hub to receive and then re-serve the base image. Model builds also receive the loaded base tag as a named `docker-image://` build context so their `FROM` instruction resolves locally while preserving BuildKit registry cache import/export.
 
 ### ARM64 smoke workflow
-The `.github/workflows/arm64-image-smoke.yml` workflow runs on pull requests to `main` and on manual dispatch. It uses an `ubuntu-24.04-arm` runner, builds the image set for `linux/arm64` with the `arm64-ci` tag, and then runs the import and server-health smoke checks. It is informational and does not push images.
+The `.github/workflows/arm64-image-smoke.yml` workflow runs on pull requests to `main` and on manual dispatch. It builds one ARM64 base artifact, then uses one `ubuntu-24.04-arm` runner per model to build `linux/arm64` images with the `arm64-ci` tag and run the import and server-health smoke checks. It is informational and does not push images.
 
 The workflow does not install the full project dependency set on the host runner. Host-side image scripts run with `uv run --no-project --with pyyaml`, while heavy model dependencies such as PyTorch and SciPy are validated inside the Docker images themselves.
 
@@ -79,9 +82,9 @@ On `main`, ARM64 image smoke is folded into the Docker publishing workflow inste
 To reproduce the same path locally on an ARM64 machine, run:
 
 ```bash
-uv run python scripts/images/build_model_images.py --cuda-version=12.6 --tag=arm64-ci --platform=linux/arm64 --max-workers=3
-uv run python scripts/images/check_model_imports.py --cuda-version=12.6 --tag=arm64-ci
-uv run python scripts/images/check_model_server_health.py --cuda-version=12.6 --tag=arm64-ci
+uv run python scripts/images/build_model_images.py --cuda-version=12.6 --model=esmfold2 --tag=arm64-ci --platform=linux/arm64 --max-workers=1
+uv run python scripts/images/check_model_imports.py --cuda-version=12.6 --model=esmfold2 --tag=arm64-ci
+uv run python scripts/images/check_model_server_health.py --cuda-version=12.6 --model=esmfold2 --tag=arm64-ci
 ```
 
 The build helper also supports `--skip-existing` and `--force-rebuild` for registry-aware rebuilds.
@@ -164,11 +167,12 @@ This publishes:
 
 ### 📦 CI publishing (production)
 GitHub Actions at `.github/workflows/build-docker-images.yml` now drives the image publishing pipeline:
-- Triggers automatically on pushes to `main`, on published GitHub releases, and can also be run manually via **Run workflow** from `main`.
-- Manual runs can also be dispatched from a non-`main` branch with `promote` left disabled. That validation-only path builds and pushes temporary `sha-<commit>` validation images, runs the local AMD64 and ARM64 smoke checks, and skips public version-tag publishing.
-- Pushes to `main` build and validate an automatically derived alpha prerelease tag from `scripts/ci/derive_version.py`, such as `0.3.1-alpha.1`. Full GitHub releases build and validate the stable release tag.
-- Builds each CUDA line in its own job, with model images parallelized behind the matching locally available base image by `--local-base` and `--max-workers`.
-- Verifies canonical CUDA-qualified tags from the same runner-local images after each CUDA build. The default-CUDA alias is checked locally in the `12.6` job.
+- Triggers automatically on non-documentation pushes to `main`, on published GitHub releases, and can also be run manually via **Run workflow** from `main`.
+- Manual runs can also be dispatched from a non-`main` branch with `promote` left disabled. That validation-only path builds and pushes temporary `sha-<commit>` validation images, runs the AMD64 and ARM64 smoke checks, and skips public version-tag publishing.
+- Pushes to `main` build and validate an automatically derived alpha prerelease tag from `scripts/ci/derive_version.py`, such as `0.4.2-alpha.1`. Full GitHub releases build and validate the stable release tag.
+- Publishes one AMD64 base image per CUDA line, then builds every supported model/CUDA pair in a separate matrix job with `--max-workers=1`.
+- Prunes BuildKit state before verification and pulls only the selected model image. The default-CUDA alias is checked in that model's `12.6` job.
+- Builds the ARM64 base once per run and shares it as a short-lived artifact across isolated ARM64 model jobs.
 - Runs the ARM64 smoke build and checks in the same publishing workflow on `main`; the standalone ARM64 workflow is reserved for pull requests and manual runs.
 - The alpha suffix counts commits since the latest reachable stable release tag, for example `0.3.1-alpha.1`, `0.3.1-alpha.2`, and so on. Before the first stable release tag, the count falls back to the configured CI baseline.
 - Each successful run publishes canonical CUDA-qualified tags and the unqualified version alias for the default `12.6` line.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "hatchling.build"
 [project]
 name = "boileroom"
 # Release automation treats this as the current stable target. Main-branch
-# image builds publish prerelease tags such as 0.3.2-alpha.1 from it.
-version = "0.4.1"
+# image builds publish prerelease tags such as 0.4.2-alpha.1 from it.
+version = "0.4.2"
 authors = [
     { name="Jakub Lála", email="jakublala@gmail.com" },
     { name="Michael Krása", email="michael.krasa@gmail.com" },

--- a/scripts/cli_utils.py
+++ b/scripts/cli_utils.py
@@ -60,6 +60,24 @@ def all_cuda_option(help_text: str) -> Callable[[F], F]:
     return decorator
 
 
+def model_option(model_keys: Sequence[str], help_text: str) -> Callable[[F], F]:
+    """Return a reusable repeatable model-image selector."""
+
+    def decorator(function: F) -> F:
+        return cast(
+            F,
+            click.option(
+                "--model",
+                "model_keys",
+                multiple=True,
+                type=click.Choice(tuple(model_keys)),
+                help=help_text,
+            )(function),
+        )
+
+    return decorator
+
+
 def pull_option(function: F) -> F:
     """Add the shared Docker pull flag."""
 

--- a/scripts/images/build_model_images.py
+++ b/scripts/images/build_model_images.py
@@ -7,6 +7,7 @@ import subprocess
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 
 import click
@@ -21,6 +22,7 @@ from boileroom.images.metadata import (  # noqa: E402
     CUDA_TORCH_WHEEL_INDEX,
     DEFAULT_DOCKER_REPOSITORY,
     MODEL_IMAGE_SPECS,
+    MODEL_IMAGE_SELECTOR_KEYS,
     RuntimeImageSpec,
     SUPPORTED_CUDA_VERSIONS,
     get_supported_cuda,
@@ -28,8 +30,15 @@ from boileroom.images.metadata import (  # noqa: E402
     normalize_cuda_version,
     normalize_requested_tag,
     published_image_references,
+    select_model_image_specs,
 )
-from scripts.cli_utils import CONTEXT_SETTINGS, all_cuda_option, cuda_version_option, none_if_empty  # noqa: E402
+from scripts.cli_utils import (  # noqa: E402
+    CONTEXT_SETTINGS,
+    all_cuda_option,
+    cuda_version_option,
+    model_option,
+    none_if_empty,
+)
 
 _CUDA_TAG_PATTERN = re.compile(r"^cuda\d+\.\d+(?:-.+)?$")
 
@@ -43,6 +52,14 @@ class BuildTask:
     base_image_reference: str
     docker_repository: str
     tag: str
+
+
+class BaseMode(StrEnum):
+    """How a build invocation should handle the shared base image."""
+
+    BUILD = "build"
+    EXISTING = "existing"
+    ONLY = "only"
 
 
 @dataclass(frozen=True)
@@ -62,6 +79,8 @@ class BuildOptions:
     force_rebuild: bool
     max_workers: int
     local_base: bool
+    model_keys: list[str] | None = None
+    base_mode: BaseMode = BaseMode.BUILD
 
 
 class Colors:
@@ -441,9 +460,24 @@ def run_build(options: BuildOptions) -> None:
         tag = resolve_publish_tag(options.tag)
         docker_repository = normalize_docker_repository(options.docker_user)
         cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
+        model_specs = select_model_image_specs(options.model_keys)
+        if options.base_mode is BaseMode.ONLY and options.model_keys:
+            raise ValueError("--base-mode=only cannot be combined with --model.")
+        unsupported_selections = [
+            spec.key
+            for spec in model_specs
+            if options.model_keys and not set(cuda_versions).intersection(get_supported_cuda(spec))
+        ]
+        if unsupported_selections:
+            raise ValueError(
+                "Requested model image(s) do not support the selected CUDA versions: "
+                + ", ".join(unsupported_selections)
+            )
         output_flag = resolve_output_flag(options.push, options.load, options.platform)
         use_local_docker_build = should_use_local_docker_build(options.push, options.platform)
         if options.local_base:
+            if options.base_mode is BaseMode.EXISTING:
+                raise ValueError("--local-base cannot be combined with --base-mode=existing.")
             if not options.push:
                 raise ValueError("--local-base only applies to pushed builds.")
             if "," in options.platform:
@@ -471,7 +505,10 @@ def run_build(options: BuildOptions) -> None:
 
     log_info(Colors.wrap(f"Boileroom repo root: {REPO_ROOT}", Colors.magenta))
     log_info(f"Docker repository: {docker_repository}")
-    log_info(f"Model images: {', '.join(spec.image_name for spec in MODEL_IMAGE_SPECS)}")
+    if options.base_mode is BaseMode.ONLY:
+        log_info("Model images: none (base-only build)")
+    else:
+        log_info(f"Model images: {', '.join(spec.image_name for spec in model_specs)}")
     log_info(f"CUDA versions: {', '.join(cuda_versions)}")
     log_info(f"Platforms: {options.platform}")
     if options.verbose:
@@ -498,7 +535,10 @@ def run_build(options: BuildOptions) -> None:
                 tag,
                 docker_repository,
             )[0]
-            if options.skip_existing and not options.force_rebuild and image_reference_exists(target_base_reference):
+            if options.base_mode is BaseMode.EXISTING:
+                log_info(f"Using existing base image for CUDA {cuda_version}: {target_base_reference}")
+                base_reference = target_base_reference
+            elif options.skip_existing and not options.force_rebuild and image_reference_exists(target_base_reference):
                 log_info(
                     f"Skipping base build for CUDA {cuda_version}; existing tag already present: "
                     f"{target_base_reference}"
@@ -522,7 +562,10 @@ def run_build(options: BuildOptions) -> None:
 
         published_references.append(base_reference)
 
-        for image_spec in MODEL_IMAGE_SPECS:
+        if options.base_mode is BaseMode.ONLY:
+            continue
+
+        for image_spec in model_specs:
             supported_cuda = get_supported_cuda(image_spec)
             if cuda_version not in supported_cuda:
                 log_warn(
@@ -548,7 +591,7 @@ def run_build(options: BuildOptions) -> None:
                 )
             )
 
-    if not tasks:
+    if not tasks and options.base_mode is not BaseMode.ONLY:
         log_warn("No model images matched the requested CUDA selection.")
     elif options.max_workers <= 1 or len(tasks) == 1:
         for task in tasks:
@@ -614,6 +657,10 @@ def run_build(options: BuildOptions) -> None:
 )
 @cuda_version_option("CUDA version to build (repeatable). Supported values: 11.8, 12.6.")
 @all_cuda_option("Build all supported CUDA variants.")
+@model_option(
+    MODEL_IMAGE_SELECTOR_KEYS,
+    "Build only this model image (repeatable). The shared base is still built unless --skip-existing finds it.",
+)
 @click.option(
     "--docker-user",
     default=DEFAULT_DOCKER_REPOSITORY,
@@ -658,10 +705,18 @@ def run_build(options: BuildOptions) -> None:
         "from that local base before pushing their tags."
     ),
 )
+@click.option(
+    "--base-mode",
+    type=click.Choice(tuple(mode.value for mode in BaseMode)),
+    default=BaseMode.BUILD.value,
+    show_default=True,
+    help="Build the base, use an existing registry base, or build only the base.",
+)
 def cli(
     tag: str | None,
     cuda_versions: tuple[str, ...],
     all_cuda: bool,
+    model_keys: tuple[str, ...],
     docker_user: str,
     platform: str,
     push: bool,
@@ -672,6 +727,7 @@ def cli(
     force_rebuild: bool,
     max_workers: int,
     local_base: bool,
+    base_mode: str,
 ) -> None:
     """Run the Docker image build Click command."""
 
@@ -690,6 +746,8 @@ def cli(
             force_rebuild=force_rebuild,
             max_workers=max_workers,
             local_base=local_base,
+            model_keys=none_if_empty(model_keys),
+            base_mode=BaseMode(base_mode),
         )
     )
 

--- a/scripts/images/check_model_imports.py
+++ b/scripts/images/check_model_imports.py
@@ -20,14 +20,17 @@ from boileroom.images.import_checks import (  # noqa: E402
 )
 from boileroom.images.metadata import (  # noqa: E402
     DEFAULT_DOCKER_REPOSITORY,
+    MODEL_IMAGE_SELECTOR_KEYS,
     normalize_docker_repository,
     normalize_requested_tag,
+    select_model_image_specs,
 )
 from scripts.cli_utils import (  # noqa: E402
     CONTEXT_SETTINGS,
     all_cuda_option,
     cleanup_option,
     cuda_version_option,
+    model_option,
     none_if_empty,
     pull_option,
     tag_option,
@@ -44,6 +47,7 @@ class ImportCheckOptions:
     all_cuda: bool
     pull: bool
     cleanup: bool
+    model_keys: list[str] | None = None
 
 
 def ensure_docker() -> None:
@@ -73,15 +77,14 @@ def _remove_image(image_reference: str) -> None:
         print(f"WARNING: failed to remove image {image_reference}: {err}", file=sys.stderr)
 
 
-def check_image(
+def _check_image(
     image_key: str,
     image_reference: str,
     requirements_path: Path,
     core_path: Path,
     pull: bool,
-    cleanup: bool = False,
 ) -> None:
-    """Run the import smoke test for one image."""
+    """Run the import smoke test body for one image."""
     print(f"Checking imports for {image_key} ({image_reference})")
 
     if pull:
@@ -163,8 +166,22 @@ for dep in deps:
         check=True,
     )
 
-    if cleanup:
-        _remove_image(image_reference)
+
+
+def check_image(
+    image_key: str,
+    image_reference: str,
+    requirements_path: Path,
+    core_path: Path,
+    pull: bool,
+    cleanup: bool = False,
+) -> None:
+    """Run one import smoke test and honor cleanup on every exit path."""
+    try:
+        _check_image(image_key, image_reference, requirements_path, core_path, pull)
+    finally:
+        if cleanup:
+            _remove_image(image_reference)
 
 
 def run_import_checks(options: ImportCheckOptions) -> None:
@@ -173,7 +190,12 @@ def run_import_checks(options: ImportCheckOptions) -> None:
     ensure_docker()
     docker_repository = normalize_docker_repository(options.docker_user)
     cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
-    targets = iter_image_targets(options.tag, cuda_versions, docker_repository=docker_repository)
+    targets = iter_image_targets(
+        options.tag,
+        cuda_versions,
+        docker_repository=docker_repository,
+        image_specs=select_model_image_specs(options.model_keys),
+    )
     if not targets:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 
@@ -188,6 +210,7 @@ def run_import_checks(options: ImportCheckOptions) -> None:
 @click.option("--docker-user", default=DEFAULT_DOCKER_REPOSITORY, help="Docker Hub user or namespace to check.")
 @cuda_version_option("CUDA version to validate canonically (repeatable).")
 @all_cuda_option("Validate all supported CUDA variants canonically.")
+@model_option(MODEL_IMAGE_SELECTOR_KEYS, "Validate only this model image (repeatable).")
 @pull_option
 @cleanup_option
 def cli(
@@ -195,6 +218,7 @@ def cli(
     docker_user: str,
     cuda_versions: tuple[str, ...],
     all_cuda: bool,
+    model_keys: tuple[str, ...],
     pull: bool,
     cleanup: bool,
 ) -> None:
@@ -208,6 +232,7 @@ def cli(
             all_cuda=all_cuda,
             pull=pull,
             cleanup=cleanup,
+            model_keys=none_if_empty(model_keys),
         )
     )
 

--- a/scripts/images/check_model_server_health.py
+++ b/scripts/images/check_model_server_health.py
@@ -20,14 +20,17 @@ from boileroom.backend.transport import TRANSPORT_HMAC_KEY_ENV  # noqa: E402
 from boileroom.images.import_checks import compute_cuda_versions, iter_image_targets  # noqa: E402
 from boileroom.images.metadata import (  # noqa: E402
     DEFAULT_DOCKER_REPOSITORY,
+    MODEL_IMAGE_SELECTOR_KEYS,
     normalize_docker_repository,
     normalize_requested_tag,
+    select_model_image_specs,
 )
 from scripts.cli_utils import (  # noqa: E402
     CONTEXT_SETTINGS,
     all_cuda_option,
     cleanup_option,
     cuda_version_option,
+    model_option,
     none_if_empty,
     pull_option,
     tag_option,
@@ -48,6 +51,7 @@ class HealthCheckOptions:
     pull: bool
     cleanup: bool
     timeout: float
+    model_keys: list[str] | None = None
 
 
 def ensure_docker() -> None:
@@ -102,14 +106,13 @@ def _remove_image(image_reference: str) -> None:
         print(f"WARNING: failed to remove image {image_reference}: {err}", file=sys.stderr)
 
 
-def check_server_health(
+def _check_server_health(
     image_key: str,
     image_reference: str,
     pull: bool,
     timeout: float,
-    cleanup: bool = False,
 ) -> None:
-    """Run the server /health smoke test for one image."""
+    """Run the server /health smoke test body for one image."""
     print(f"Checking server health for {image_key} ({image_reference})")
 
     if pull:
@@ -170,8 +173,21 @@ def check_server_health(
             stderr=subprocess.DEVNULL,
         )
 
-    if cleanup:
-        _remove_image(image_reference)
+
+
+def check_server_health(
+    image_key: str,
+    image_reference: str,
+    pull: bool,
+    timeout: float,
+    cleanup: bool = False,
+) -> None:
+    """Run one server-health check and honor cleanup on every exit path."""
+    try:
+        _check_server_health(image_key, image_reference, pull, timeout)
+    finally:
+        if cleanup:
+            _remove_image(image_reference)
 
 
 def run_server_health_checks(options: HealthCheckOptions) -> None:
@@ -180,7 +196,12 @@ def run_server_health_checks(options: HealthCheckOptions) -> None:
     ensure_docker()
     docker_repository = normalize_docker_repository(options.docker_user)
     cuda_versions = compute_cuda_versions(options.cuda_versions, options.all_cuda)
-    targets = iter_image_targets(options.tag, cuda_versions, docker_repository=docker_repository)
+    targets = iter_image_targets(
+        options.tag,
+        cuda_versions,
+        docker_repository=docker_repository,
+        image_specs=select_model_image_specs(options.model_keys),
+    )
     if not targets:
         raise SystemExit("No image targets matched the requested CUDA selection.")
 
@@ -195,6 +216,7 @@ def run_server_health_checks(options: HealthCheckOptions) -> None:
 @click.option("--docker-user", default=DEFAULT_DOCKER_REPOSITORY, help="Docker Hub user or namespace to check.")
 @cuda_version_option("CUDA version to validate canonically (repeatable).")
 @all_cuda_option("Validate all supported CUDA variants canonically.")
+@model_option(MODEL_IMAGE_SELECTOR_KEYS, "Validate only this model image (repeatable).")
 @pull_option
 @cleanup_option
 @click.option("--timeout", type=float, default=30.0, help="Seconds to wait for each container health check.")
@@ -203,6 +225,7 @@ def cli(
     docker_user: str,
     cuda_versions: tuple[str, ...],
     all_cuda: bool,
+    model_keys: tuple[str, ...],
     pull: bool,
     cleanup: bool,
     timeout: float,
@@ -218,6 +241,7 @@ def cli(
             pull=pull,
             cleanup=cleanup,
             timeout=timeout,
+            model_keys=none_if_empty(model_keys),
         )
     )
 

--- a/tests/contracts/test_build_model_images.py
+++ b/tests/contracts/test_build_model_images.py
@@ -96,6 +96,7 @@ def test_cli_exposes_documented_flags(monkeypatch: MonkeyPatch) -> None:
             "--force-rebuild",
             "--verbose",
             "--local-base",
+            "--model=esm3",
             "--docker-user=example",
         ],
     )
@@ -116,8 +117,22 @@ def test_cli_exposes_documented_flags(monkeypatch: MonkeyPatch) -> None:
             force_rebuild=True,
             max_workers=1,
             local_base=True,
+            model_keys=["esm3"],
         )
     ]
+
+
+def test_cli_rejects_model_selection_with_base_mode_only(monkeypatch: MonkeyPatch) -> None:
+    """A base-only build must not silently ignore an explicit model selector."""
+    monkeypatch.setattr(build_model_images, "ensure_docker", lambda: None)
+
+    result = CliRunner().invoke(
+        build_model_images.cli,
+        ["--cuda-version=12.6", "--model=esm", "--base-mode=only"],
+    )
+
+    assert result.exit_code == 1
+    assert "--base-mode=only cannot be combined with --model" in result.output
 
 
 def test_cli_rejects_unknown_flags(monkeypatch: MonkeyPatch) -> None:
@@ -167,6 +182,42 @@ def test_run_build_validates_cuda_selection_before_docker(
     assert exc_info.value.code == 1
     assert docker_checked is False
     assert "Specify at least one --cuda-version or use --all-cuda." in capsys.readouterr().err
+
+
+def test_run_build_rejects_unsupported_explicit_model_cuda_before_docker(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    """Explicit matrix selections should fail instead of reporting an empty successful build."""
+    options = build_model_images.BuildOptions(
+        tag="sha-test",
+        docker_user="docker.io/jakublala",
+        cuda_versions=["11.8"],
+        all_cuda=False,
+        platform="linux/amd64",
+        push=False,
+        load=False,
+        no_cache=False,
+        verbose=False,
+        skip_existing=False,
+        force_rebuild=False,
+        max_workers=1,
+        local_base=False,
+        model_keys=["boltz"],
+    )
+    docker_checked = False
+
+    def fake_ensure_docker() -> None:
+        nonlocal docker_checked
+        docker_checked = True
+
+    monkeypatch.setattr(build_model_images, "ensure_docker", fake_ensure_docker)
+
+    with pytest.raises(SystemExit) as exc_info:
+        build_model_images.run_build(options)
+
+    assert exc_info.value.code == 1
+    assert docker_checked is False
+    assert "do not support the selected CUDA versions: boltz" in capsys.readouterr().err
 
 
 def test_build_base_verbose_echoes_plain_progress(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
@@ -340,6 +391,90 @@ def test_main_skips_existing_base_and_model_tags(monkeypatch: MonkeyPatch, tmp_p
         f"docker.io/jakublala/boileroom-esm:cuda{DEFAULT_CUDA_VERSION}-sha-test",
         f"docker.io/jakublala/boileroom-esmfold2:cuda{DEFAULT_CUDA_VERSION}-sha-test",
     ]
+
+
+def test_base_only_build_skips_model_tasks(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """The base-image matrix job should not enqueue any model image builds."""
+    options = build_model_images.BuildOptions(
+        tag="sha-test",
+        docker_user="docker.io/jakublala",
+        cuda_versions=[DEFAULT_CUDA_VERSION],
+        all_cuda=False,
+        platform="linux/amd64",
+        push=True,
+        load=False,
+        no_cache=False,
+        verbose=False,
+        skip_existing=False,
+        force_rebuild=False,
+        max_workers=1,
+        local_base=False,
+        base_mode=build_model_images.BaseMode.ONLY,
+    )
+    built_bases: list[str] = []
+    built_models: list[str] = []
+
+    def fake_build_base(cuda_version: str, *_args, **_kwargs) -> str:
+        built_bases.append(cuda_version)
+        return f"docker.io/jakublala/boileroom-base:cuda{cuda_version}-sha-test"
+
+    def fake_build_model(task, *_args, **_kwargs):
+        built_models.append(task.image_spec.key)
+        return ()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(build_model_images, "ensure_docker", lambda: None)
+    monkeypatch.setattr(build_model_images, "ensure_buildx_builder", lambda: None)
+    monkeypatch.setattr(build_model_images, "build_base", fake_build_base)
+    monkeypatch.setattr(build_model_images, "build_model", fake_build_model)
+    monkeypatch.setattr(build_model_images, "log_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(build_model_images, "log_success", lambda *args, **kwargs: None)
+
+    build_model_images.run_build(options)
+
+    assert built_bases == [DEFAULT_CUDA_VERSION]
+    assert built_models == []
+
+
+def test_model_selection_builds_only_requested_image(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """A per-model matrix job should enqueue only its selected image."""
+    options = build_model_images.BuildOptions(
+        tag="sha-test",
+        docker_user="docker.io/jakublala",
+        cuda_versions=[DEFAULT_CUDA_VERSION],
+        all_cuda=False,
+        platform="linux/amd64",
+        push=True,
+        load=False,
+        no_cache=False,
+        verbose=False,
+        skip_existing=True,
+        force_rebuild=False,
+        max_workers=1,
+        local_base=False,
+        model_keys=["esm"],
+        base_mode=build_model_images.BaseMode.EXISTING,
+    )
+    built_models: list[str] = []
+
+    def fake_image_reference_exists(_image_reference: str) -> bool:
+        return False
+
+    def fake_build_model(task, *_args, **_kwargs):
+        built_models.append(task.image_spec.key)
+        return ()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(build_model_images, "ensure_docker", lambda: None)
+    monkeypatch.setattr(build_model_images, "ensure_buildx_builder", lambda: None)
+    monkeypatch.setattr(build_model_images, "image_reference_exists", fake_image_reference_exists)
+    monkeypatch.setattr(build_model_images, "build_model", fake_build_model)
+    monkeypatch.setattr(build_model_images, "log_info", lambda *args, **kwargs: None)
+    monkeypatch.setattr(build_model_images, "log_success", lambda *args, **kwargs: None)
+
+    build_model_images.run_build(options)
+
+    assert built_models == ["esm"]
 
 
 def test_local_base_push_builds_locally_then_pushes(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/contracts/test_cli.py
+++ b/tests/contracts/test_cli.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 from pytest import MonkeyPatch
 
@@ -84,6 +85,56 @@ def test_derive_version_cli_passes_path_options(monkeypatch: MonkeyPatch, tmp_pa
     assert isinstance(captured[0].base_pyproject, Path)
     assert isinstance(captured[0].write_pyproject, Path)
     assert isinstance(captured[0].github_output, Path)
+
+
+def test_image_check_clis_forward_model_selection(monkeypatch: MonkeyPatch) -> None:
+    """Per-model matrix jobs should select exactly one smoke-check target."""
+    import_options: list[check_model_imports.ImportCheckOptions] = []
+    health_options: list[check_model_server_health.HealthCheckOptions] = []
+    monkeypatch.setattr(check_model_imports, "run_import_checks", import_options.append)
+    monkeypatch.setattr(check_model_server_health, "run_server_health_checks", health_options.append)
+
+    import_result = CliRunner().invoke(check_model_imports.cli, ["--model=esm3", "--pull"])
+    health_result = CliRunner().invoke(check_model_server_health.cli, ["--model=chai", "--cleanup"])
+
+    assert import_result.exit_code == 0, import_result.output
+    assert health_result.exit_code == 0, health_result.output
+    assert import_options[0].model_keys == ["esm3"]
+    assert import_options[0].pull is True
+    assert health_options[0].model_keys == ["chai"]
+    assert health_options[0].cleanup is True
+
+
+def test_image_import_cleanup_runs_after_check_failure(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    """Import smoke cleanup should run even when the check body fails."""
+    removed: list[str] = []
+
+    def fail_check(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("failed")
+
+    monkeypatch.setattr(check_model_imports, "_remove_image", removed.append)
+    monkeypatch.setattr(check_model_imports, "_check_image", fail_check)
+
+    with pytest.raises(RuntimeError, match="failed"):
+        check_model_imports.check_image("esm", "example/esm:test", tmp_path, tmp_path, False, cleanup=True)
+
+    assert removed == ["example/esm:test"]
+
+
+def test_server_health_cleanup_runs_after_check_failure(monkeypatch: MonkeyPatch) -> None:
+    """Server smoke cleanup should run even when the check body fails."""
+    removed: list[str] = []
+
+    def fail_check(*_args: object, **_kwargs: object) -> None:
+        raise RuntimeError("failed")
+
+    monkeypatch.setattr(check_model_server_health, "_remove_image", removed.append)
+    monkeypatch.setattr(check_model_server_health, "_check_server_health", fail_check)
+
+    with pytest.raises(RuntimeError, match="failed"):
+        check_model_server_health.check_server_health("esm", "example/esm:test", False, 1.0, cleanup=True)
+
+    assert removed == ["example/esm:test"]
 
 
 def test_promote_cli_validates_cuda_selection_before_buildx(monkeypatch: MonkeyPatch) -> None:

--- a/tests/contracts/test_derive_version.py
+++ b/tests/contracts/test_derive_version.py
@@ -18,7 +18,7 @@ def test_main_version_uses_commit_count_after_baseline(monkeypatch) -> None:
 
     monkeypatch.setattr(derive_version, "run_git", fake_run_git)
 
-    assert derive_version.main_version() == "0.4.1-alpha.7"
+    assert derive_version.main_version() == "0.4.2-alpha.7"
 
 
 def test_main_version_counts_from_latest_stable_release_tag(monkeypatch) -> None:

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -23,6 +23,7 @@ from boileroom.images.metadata import (
     published_tags,
     render_modal_runtime_env,
     resolve_registry_tag,
+    select_model_image_specs,
 )
 
 
@@ -173,3 +174,10 @@ def test_iter_image_targets_uses_canonical_cuda_tags() -> None:
     assert references["chai"].endswith(":cuda12.6-0.3.0")
     assert references["esm"].endswith(":cuda12.6-0.3.0")
     assert references["esmfold2"].endswith(":cuda12.6-0.3.0")
+
+
+def test_select_model_image_specs_preserves_order_and_deduplicates_shared_aliases() -> None:
+    """Per-model CI selectors should resolve aliases without duplicate builds."""
+    specs = select_model_image_specs(["esmfold2", "esm3", "chai"])
+
+    assert [spec.key for spec in specs] == ["esmfold2", "chai"]

--- a/tests/contracts/test_image_metadata.py
+++ b/tests/contracts/test_image_metadata.py
@@ -181,3 +181,9 @@ def test_select_model_image_specs_preserves_order_and_deduplicates_shared_aliase
     specs = select_model_image_specs(["esmfold2", "esm3", "chai"])
 
     assert [spec.key for spec in specs] == ["esmfold2", "chai"]
+
+
+def test_select_model_image_specs_rejects_unknown_identifier() -> None:
+    """Unknown selectors should fail loudly for direct callers."""
+    with pytest.raises(KeyError):
+        select_model_image_specs(["not-a-model"])

--- a/uv.lock
+++ b/uv.lock
@@ -118,7 +118,7 @@ wheels = [
 
 [[package]]
 name = "boileroom"
-version = "0.3.1"
+version = "0.4.2"
 source = { editable = "." }
 dependencies = [
     { name = "biotite" },


### PR DESCRIPTION
## Summary

- Prevent Docker image builds from exhausting GitHub-hosted runner disk by isolating every model/CUDA build.
- Advance the development target to 0.4.2 so main can derive new prerelease tags after v0.4.1.
- Avoid expensive image workflows for README- and docs-only pushes.

## Changes

- **Publishing workflow:** build AMD64 bases once per CUDA line, build each model/CUDA pair on a fresh runner with one worker, prune BuildKit before smoke checks, and preserve canonical/default-alias verification.
- **ARM64 workflows:** build the base once, transfer it as a one-day run artifact, and load it in isolated per-model runners without publishing ARM64 tags.
- **Image tooling:** add explicit base modes and repeatable model selectors, including shared aliases such as `esm3`; reject unsupported explicit model/CUDA pairs.
- **Smoke checks:** select one model per matrix job and guarantee image cleanup on both success and failure.
- **Workflow hardening:** validate Docker publishing configuration before matrix fan-out, avoid secret-masked cross-job repository outputs, and bind matrix values through environment variables rather than interpolating them into shell scripts.
- **Release metadata/docs:** bump the target and lock metadata to 0.4.2 and document the new topology.

## Quality gates

- pre-commit: pass (all hooks)
- pytest contracts: 122 passed, 3 skipped
- pytest live Modal: 190 passed, 19 skipped using `--image-tag=0.3.2-alpha.5`, the newest tag currently published for all model images
- workflow YAML parse: pass
- lockfile consistency: pass
- version derivation: `0.4.2-alpha.2`
- PR checks: 10 passed, including every ARM64 model smoke job
- full promotion-disabled publishing workflow: all 15 jobs passed ([run 30543985263](https://github.com/softnanolab/boileroom/actions/runs/30543985263))
- thermo-nuclear review: 0 blockers, 0 should-fix findings, 0 nits
- Ran on: local macOS workstation and GitHub-hosted AMD64/ARM64 runners

## Review results

### Thermo-nuclear review

**Result: approved.**

- No structural regressions. The explicit `BaseMode` policy replaces boolean-mode growth and makes base ownership clear at the build boundary.
- Shared selector keys, model-spec resolution, and the reusable Click option keep selection in canonical metadata rather than scattering workflow-specific cases.
- New branches remain confined to the existing image orchestration layer; smoke cleanup is isolated behind small wrappers.
- No touched source file crosses 1,000 lines. Workflow growth remains direct, architecture-separated orchestration.
- Building each AMD64 base once and handing one ARM64 base artifact to fresh per-model jobs removes the original shared-runner disk contention while preserving tag and smoke-test behavior.

### Independent reviewers

- Correctness/GitHub Actions review: no actionable findings after the live-run repository propagation fix.
- Security/resource review: its one follow-up should-fix finding was implemented by adding repository/credential validation before runner fan-out.

### CodeRabbit

CodeRabbit completed its full review of the initial revision and raised three trivial comments. All three were checked and implemented:

- direct-caller failure-path coverage for unknown model selectors;
- one explicit repository source for ARM64 smoke build/export;
- environment binding for matrix/needs values used by shell steps.

The follow-up revision hit CodeRabbit's review rate limit, while the CodeRabbit status check remained successful.

## Test plan

- [x] Run every configured pre-commit hook.
- [x] Run the full local contract suite.
- [x] Run the complete live Modal-backed suite against the latest shared published image tag.
- [x] Dispatch **Build and Push Boileroom Images** from this branch with promotion disabled and verify every isolated matrix job.
- [x] Confirm the PR ARM64 image matrix completes for all supported models.

## Checklist

- [x] Tests pass
- [x] Linting passes
- [x] Documentation updated

Generated with the SoftNano plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selective model image builds and smoke checks.
  * Added support for building base images independently or reusing existing bases.
  * Improved ARM64 image validation across supported CUDA versions and models.
  * Updated image build and verification workflows for more reliable releases.

* **Bug Fixes**
  * Ensured temporary Docker images are cleaned up even when checks fail.

* **Documentation**
  * Updated Docker image build, publishing, and ARM64 guidance.

* **Release**
  * Version updated to 0.4.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
