### PR TITLE
feat: add ESM-C sparse-autoencoder feature model

### DIFF
--- a/boileroom/__init__.py
+++ b/boileroom/__init__.py
@@ -29,7 +29,11 @@ def __getattr__(name: str):
         from .models import Boltz2
 
         return Boltz2
+    if name == "SAE":
+        from .models import SAE
+
+        return SAE
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
-__all__ = ["ESMFold", "ESM2", "ESMFold2", "ESMC", "ESM3", "Chai1", "Boltz2"]
+__all__ = ["ESMFold", "ESM2", "ESMFold2", "ESMC", "ESM3", "Chai1", "Boltz2", "SAE"]

--- a/boileroom/images/metadata.py
+++ b/boileroom/images/metadata.py
@@ -95,8 +95,9 @@ MODEL_IMAGE_SPECS: Final[tuple[RuntimeImageSpec, ...]] = (
         context_relative_path="boileroom/models/esmfold2",
         config_relative_path="boileroom/models/esmfold2/config.yaml",
         # ESM-C and ESM3 (the ``esm3`` family) use the same Biohub ``esm``
-        # package, so they share this image instead of building their own.
-        shared_family_keys=("esm3",),
+        # package, so they share this image instead of building their own. The
+        # SAE feature model reuses ESM-C hidden states and shares it too.
+        shared_family_keys=("esm3", "sae"),
     ),
 )
 

--- a/boileroom/models/__init__.py
+++ b/boileroom/models/__init__.py
@@ -29,6 +29,10 @@ def __getattr__(name: str):
         from .boltz.boltz2 import Boltz2
 
         return Boltz2
+    if name == "SAE":
+        from .sae.sae import SAE
+
+        return SAE
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
@@ -40,4 +44,5 @@ __all__ = [
     "ESMFold2",
     "Chai1",
     "Boltz2",
+    "SAE",
 ]

--- a/boileroom/models/registry.py
+++ b/boileroom/models/registry.py
@@ -247,7 +247,42 @@ BOLTZ2_SPEC = ModelSpec(
     ),
 )
 
-MODEL_SPECS = (ESMFOLD_SPEC, ESM2_SPEC, ESMFOLD2_SPEC, ESMC_SPEC, ESM3_SPEC, CHAI1_SPEC, BOLTZ2_SPEC)
+SAE_SPEC = ModelSpec(
+    key="sae",
+    public_name="SAE",
+    family="sae",
+    wrapper_class_path="boileroom.models.sae.sae.SAE",
+    modal_class_path="boileroom.models.sae.sae.ModalSAE",
+    apptainer_core_class_path="boileroom.models.sae.core.SAECore",
+    # Reuses the shared Biohub ESM runtime image (same as ESM-C / ESM3 / ESMFold2).
+    apptainer_image_name=ESMFOLD2_IMAGE_NAME,
+    supported_backends=("modal", "apptainer"),
+    contract=ModelContract(
+        task_method="embed",
+        task_kind="embedding",
+        static_config_keys=frozenset(
+            {
+                "device",
+                "feature_source",
+                "num_features",
+                "k",
+                "sae_layer",
+                "activation",
+                "esmc_model_name",
+                "sae_repo_id",
+                "forge_model",
+                "forge_sae_model",
+                "forge_url",
+                "forge_token",
+            }
+        ),
+        minimal_output_fields=("metadata", "pooled_features", "chain_index", "residue_index"),
+        optional_output_fields=("features",),
+        supports_multimer=True,
+    ),
+)
+
+MODEL_SPECS = (ESMFOLD_SPEC, ESM2_SPEC, ESMFOLD2_SPEC, ESMC_SPEC, ESM3_SPEC, CHAI1_SPEC, BOLTZ2_SPEC, SAE_SPEC)
 MODEL_SPECS_BY_KEY = {spec.key: spec for spec in MODEL_SPECS}
 MODEL_SPECS_BY_PUBLIC_NAME = {spec.public_name: spec for spec in MODEL_SPECS}
 
@@ -273,6 +308,7 @@ __all__ = [
     "MODEL_SPECS",
     "MODEL_SPECS_BY_KEY",
     "MODEL_SPECS_BY_PUBLIC_NAME",
+    "SAE_SPEC",
     "ModelContract",
     "ModelSpec",
     "get_model_spec",

--- a/boileroom/models/registry.py
+++ b/boileroom/models/registry.py
@@ -264,6 +264,7 @@ SAE_SPEC = ModelSpec(
             {
                 "device",
                 "feature_source",
+                "normalize_features",
                 "num_features",
                 "k",
                 "sae_layer",

--- a/boileroom/models/sae/__init__.py
+++ b/boileroom/models/sae/__init__.py
@@ -1,0 +1,28 @@
+"""ESM-C sparse-autoencoder feature model.
+
+Public entry point is :class:`SAE`. The sparse-autoencoder math lives in
+``sae_module`` and is free of Modal / ``esm`` dependencies so it can be imported
+and tested in isolation.
+"""
+
+from .sae_module import SAEModuleConfig, SparseAutoencoder, max_pool_features, topk_activation
+from .types import SAEFeaturesOutput
+
+__all__ = [
+    "SAE",
+    "SAEFeaturesOutput",
+    "SAEModuleConfig",
+    "SparseAutoencoder",
+    "max_pool_features",
+    "topk_activation",
+]
+
+
+def __getattr__(name: str):
+    # Lazy import so the public wrapper (which imports modal) is only pulled in on
+    # demand, mirroring boileroom/__init__.py.
+    if name == "SAE":
+        from .sae import SAE
+
+        return SAE
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/boileroom/models/sae/__init__.py
+++ b/boileroom/models/sae/__init__.py
@@ -5,6 +5,8 @@ Public entry point is :class:`SAE`. The sparse-autoencoder math lives in
 and tested in isolation.
 """
 
+from typing import Any
+
 from .sae_module import SAEModuleConfig, SparseAutoencoder, max_pool_features, topk_activation
 from .types import SAEFeaturesOutput
 
@@ -18,7 +20,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Any:
     # Lazy import so the public wrapper (which imports modal) is only pulled in on
     # demand, mirroring boileroom/__init__.py.
     if name == "SAE":

--- a/boileroom/models/sae/core.py
+++ b/boileroom/models/sae/core.py
@@ -1,0 +1,392 @@
+"""Core SAE feature extraction: from an amino-acid sequence to SAE features.
+
+Two feature sources are supported and selected by the ``feature_source`` config:
+
+``"forge"`` (default)
+    Call Biohub's hosted ``ESMCForgeInferenceClient`` with a ``SAEConfig`` and read
+    back SAE feature activations. This is the only way to use the **ESMC-6B**
+    layer-60 SAE featured in the paper (``k = 64``, codebook ``2**14``), which is
+    too large to run locally. Requires a Biohub API token.
+
+``"local"``
+    Run ESM-C locally / on Modal to get per-layer hidden states, then apply a
+    local :class:`~boileroom.models.sae.sae_module.SparseAutoencoder` loaded from
+    the Biohub per-layer Hugging Face weights. Works for the 300M / 600M SAEs on a
+    single GPU with no API token.
+
+Either way, per-protein feature vectors are formed by **max-pooling** each feature
+across the (unpadded) residues, following *Language Modeling Materializes a World
+Model of Protein Biology* (Biohub, 2026).
+
+The ESM-C embedder, the local SAE, and the Forge backend are all injectable so the
+core can be unit-tested with fakes — no Modal, GPU, ``esm`` SDK, or API token.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+from collections.abc import Sequence
+from typing import Any, ClassVar, Protocol, cast
+
+import numpy as np
+import torch
+
+from ...base import EmbeddingAlgorithm
+from ...utils import Timer
+from .forge import ForgeSAEBackend
+from .sae_module import SparseAutoencoder, max_pool_features
+from .types import SAEFeaturesOutput
+
+logger = logging.getLogger(__name__)
+
+# ESM-C hidden-state dimensionality by model. Used to size the local SAE input.
+ESMC_D_MODEL: dict[str, int] = {
+    "esmc_300m": 960,
+    "esmc_600m": 1152,
+    "esmc_6b": 2560,
+}
+
+
+class _Embedder(Protocol):
+    """Minimal interface the local SAE path needs from an ESM-C embedder."""
+
+    def embed(self, sequences: str | Sequence[str], options: dict | None = None) -> Any: ...
+
+
+class _ForgeFeatures(Protocol):
+    """Minimal interface the forge SAE path needs from a Forge backend."""
+
+    def features(self, sdk_sequence: str) -> np.ndarray: ...
+
+
+class SAECore(EmbeddingAlgorithm):
+    """Map protein sequences to sparse-autoencoder features.
+
+    Parameters
+    ----------
+    config : dict | None
+        Configuration overrides merged into :attr:`DEFAULT_CONFIG`. Key groups:
+
+        Shared
+            ``feature_source`` (``"forge"`` | ``"local"``), ``normalize_features``,
+            ``include_per_residue``, ``num_features``, ``k``, ``sae_layer``,
+            ``device``.
+        Forge backend
+            ``forge_model``, ``forge_sae_model``, ``forge_url``, ``forge_token``
+            (falls back to the ``ESM_API_KEY`` env var).
+        Local backend
+            ``esmc_model_name``, ``sae_repo_id``, ``activation``.
+    embedder : _Embedder | None
+        Optional pre-built ESM-C embedder (local path). Injecting a fake makes the
+        core testable without model dependencies.
+    sae : SparseAutoencoder | None
+        Optional pre-built local SAE. When ``None`` weights are loaded from
+        ``sae_repo_id`` on load.
+    forge_backend : _ForgeFeatures | None
+        Optional pre-built Forge backend. When ``None`` one is constructed from the
+        ``forge_*`` config on load.
+    """
+
+    DEFAULT_CONFIG: ClassVar[dict[str, Any]] = {
+        "device": "cuda:0",
+        # "forge" (hosted API, default) or "local" (ESM-C + local SAE).
+        "feature_source": "forge",
+        "normalize_features": True,
+        "include_per_residue": False,
+        "num_features": 16384,
+        "k": 64,
+        "sae_layer": 60,
+        # Forge backend defaults: the paper's ESMC-6B layer-60 SAE.
+        "forge_model": "esmc-6b-2024-12",
+        "forge_sae_model": "esmc-6b-2024-12-sae-layer60-k64-codebook16384",
+        "forge_url": "https://biohub.ai",
+        "forge_token": None,
+        # Local backend defaults (used when feature_source == "local").
+        "esmc_model_name": "esmc_600m",
+        "sae_repo_id": "biohub/ESMC-600M-sae-k64-codebook16384",
+        "activation": "topk",
+    }
+    STATIC_CONFIG_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "device",
+            "feature_source",
+            "num_features",
+            "k",
+            "sae_layer",
+            "activation",
+            "esmc_model_name",
+            "sae_repo_id",
+            "forge_model",
+            "forge_sae_model",
+            "forge_url",
+            "forge_token",
+        }
+    )
+    MODEL_DISPLAY_NAME: ClassVar[str] = "ESM-C SAE"
+
+    def __init__(
+        self,
+        config: dict | None = None,
+        embedder: _Embedder | None = None,
+        sae: SparseAutoencoder | None = None,
+        forge_backend: _ForgeFeatures | None = None,
+    ) -> None:
+        super().__init__(config)
+        source = str(self.config["feature_source"])
+        if source not in ("forge", "local"):
+            raise ValueError(f"feature_source must be 'forge' or 'local'; got {source!r}.")
+        self._source = source
+        self._embedder = embedder
+        self._sae = sae
+        self._forge = forge_backend
+        model_version = (
+            str(self.config["forge_sae_model"]) if source == "forge" else str(self.config["sae_repo_id"])
+        )
+        self._metadata_template = self._initialize_metadata(
+            model_name=self.MODEL_DISPLAY_NAME, model_version=model_version
+        )
+
+    # ------------------------------------------------------------------
+    # Loading
+    # ------------------------------------------------------------------
+    def _initialize(self) -> None:
+        self._load()
+
+    def _load(self) -> None:
+        """Build whichever backend ``feature_source`` selects (if not injected)."""
+        if self._source == "forge":
+            if self._forge is None:
+                self._forge = ForgeSAEBackend(
+                    model=str(self.config["forge_model"]),
+                    sae_model=str(self.config["forge_sae_model"]),
+                    url=str(self.config["forge_url"]),
+                    token=self.config["forge_token"],
+                    normalize_features=bool(self.config["normalize_features"]),
+                )
+        else:
+            if self._embedder is None:
+                from ..esm3.core import ESMCCore
+
+                self._embedder = ESMCCore(
+                    config={"device": self.config["device"], "model_name": self.config["esmc_model_name"]}
+                )
+                cast(Any, self._embedder)._initialize()
+            if self._sae is None:
+                self._sae = SparseAutoencoder.from_pretrained(
+                    repo_id=str(self.config["sae_repo_id"]),
+                    layer=int(self.config["sae_layer"]),
+                    num_features=int(self.config["num_features"]),
+                    d_model=self._infer_d_model(),
+                    k=int(self.config["k"]),
+                    activation=str(self.config["activation"]),  # type: ignore[arg-type]
+                    device=self.config["device"],
+                )
+            self._sae.eval()
+        self.ready = True
+
+    def _infer_d_model(self) -> int:
+        model_name = str(self.config["esmc_model_name"])
+        try:
+            return ESMC_D_MODEL[model_name]
+        except KeyError as exc:
+            raise ValueError(
+                f"Unknown ESM-C model {model_name!r}; cannot infer d_model. Known: {sorted(ESMC_D_MODEL)}."
+            ) from exc
+
+    @property
+    def sae(self) -> SparseAutoencoder:
+        if self._sae is None:
+            raise RuntimeError("Local SAE is not loaded. Call _load() first with feature_source='local'.")
+        return self._sae
+
+    # ------------------------------------------------------------------
+    # Inference
+    # ------------------------------------------------------------------
+    def embed(self, sequences: str | Sequence[str], options: dict | None = None) -> SAEFeaturesOutput:
+        """Compute SAE features for one or more sequences.
+
+        Parameters
+        ----------
+        sequences : str | Sequence[str]
+            Amino-acid sequence(s); colon-separated chains are supported.
+        options : dict | None
+            Per-call overrides (non-static keys only), e.g.
+            ``{"include_per_residue": True}``.
+
+        Returns
+        -------
+        SAEFeaturesOutput
+            Pooled per-protein features plus per-residue chain/residue indices.
+        """
+        effective = self._merge_options(options)
+        include_per_residue = bool(effective.get("include_per_residue", False))
+
+        if self._source == "forge":
+            return self._embed_forge(sequences, include_per_residue)
+        return self._embed_local(sequences, effective, include_per_residue)
+
+    # ---- local path --------------------------------------------------
+    def _embed_local(
+        self, sequences: str | Sequence[str], effective: dict, include_per_residue: bool
+    ) -> SAEFeaturesOutput:
+        if self._embedder is None or self._sae is None:
+            logger.warning("SAE core not loaded. Forcing load; call _load() first next time.")
+            self._load()
+        assert self._embedder is not None and self._sae is not None
+
+        layer = int(effective["sae_layer"])
+        normalize = bool(effective.get("normalize_features", False))
+
+        with Timer("ESM-C hidden states") as embed_timer:
+            emb = self._embedder.embed(sequences, options={"include_fields": ["hidden_states"]})
+        hidden_states = getattr(emb, "hidden_states", None)
+        if hidden_states is None:
+            raise ValueError("The ESM-C embedder did not return hidden_states; cannot compute SAE features.")
+
+        hidden = np.asarray(hidden_states)
+        layer_states = self._select_layer(hidden, layer)  # (batch, residues, d_model)
+        chain_index = np.asarray(emb.chain_index)
+        residue_index = np.asarray(emb.residue_index)
+
+        with Timer("SAE encode + pool") as sae_timer:
+            pooled, per_residue = self._apply_sae(layer_states, chain_index, normalize, include_per_residue)
+
+        metadata = dataclasses.replace(
+            self._metadata_template,
+            sequence_lengths=[int((row != -1).sum()) for row in chain_index],
+            inference_time=embed_timer.duration,
+            postprocessing_time=sae_timer.duration,
+        )
+        return SAEFeaturesOutput(
+            metadata=metadata,
+            pooled_features=pooled,
+            chain_index=chain_index,
+            residue_index=residue_index,
+            layer=layer,
+            num_features=int(self._sae.num_features),
+            sae_model=str(self.config["sae_repo_id"]),
+            features=per_residue,
+        )
+
+    @staticmethod
+    def _select_layer(hidden: np.ndarray, layer: int) -> np.ndarray:
+        """Return hidden states at ``layer`` with shape ``(batch, residues, d_model)``.
+
+        ESM-C hidden states are returned with the layer axis first
+        (``(layers, batch, residues, d_model)``). A 3-D array is treated as a
+        single already-selected layer (``(batch, residues, d_model)``).
+        """
+        if hidden.ndim == 3:
+            return hidden
+        if hidden.ndim != 4:
+            raise ValueError(
+                f"Expected hidden states with 4 dims (layers, batch, residues, features); got shape {hidden.shape}."
+            )
+        n_layers = hidden.shape[0]
+        if not -n_layers <= layer < n_layers:
+            raise IndexError(f"sae_layer={layer} is out of range for {n_layers} available layers.")
+        return hidden[layer]
+
+    def _apply_sae(
+        self,
+        layer_states: np.ndarray,
+        chain_index: np.ndarray,
+        normalize: bool,
+        include_per_residue: bool,
+    ) -> tuple[np.ndarray, np.ndarray | None]:
+        """Encode residues and max-pool to per-protein vectors (local path)."""
+        assert self._sae is not None
+        device = next(self._sae.parameters()).device
+        dtype = next(self._sae.parameters()).dtype
+        batch = layer_states.shape[0]
+        num_features = int(self._sae.num_features)
+        pooled = np.zeros((batch, num_features), dtype=np.float32)
+        per_residue = (
+            np.zeros((batch, layer_states.shape[1], num_features), dtype=np.float32) if include_per_residue else None
+        )
+        with torch.inference_mode():
+            for i in range(batch):
+                valid = chain_index[i] != -1
+                x = torch.as_tensor(layer_states[i], dtype=dtype, device=device)
+                acts = self._sae.encode(x)  # (residues, num_features)
+                if normalize:
+                    acts = torch.nn.functional.normalize(acts, dim=-1)
+                mask = torch.as_tensor(valid, dtype=torch.bool, device=device)
+                pooled[i] = max_pool_features(acts, mask).float().cpu().numpy()
+                if per_residue is not None:
+                    masked = acts.clone()
+                    masked[~mask] = 0.0
+                    per_residue[i] = masked.float().cpu().numpy()
+        return pooled, per_residue
+
+    # ---- forge path --------------------------------------------------
+    def _embed_forge(self, sequences: str | Sequence[str], include_per_residue: bool) -> SAEFeaturesOutput:
+        if self._forge is None:
+            logger.warning("SAE core not loaded. Forcing load; call _load() first next time.")
+            self._load()
+        assert self._forge is not None
+
+        from ..esm3.core import parse_esm3_sequences
+
+        parsed = parse_esm3_sequences(sequences)
+        layer = int(self.config["sae_layer"])
+
+        pooled_list: list[np.ndarray] = []
+        residue_feature_list: list[np.ndarray] = []
+        num_features = 0
+        with Timer("Forge SAE features") as forge_timer:
+            for item in parsed:
+                dense = np.asarray(self._forge.features(item.sdk_sequence), dtype=np.float32)
+                if dense.ndim != 2:
+                    raise ValueError(f"Forge features must be 2-D (tokens, num_features); got shape {dense.shape}.")
+                # Residue token positions: BOS is index 0, chain-break '|' tokens are
+                # dropped, EOS is the trailing token.
+                keep = [i + 1 for i, token in enumerate(item.sdk_sequence) if token != "|"]
+                residue_feats = dense[keep]  # (residues, num_features)
+                num_features = residue_feats.shape[1]
+                pooled_list.append(residue_feats.max(axis=0) if residue_feats.shape[0] else np.zeros(num_features))
+                residue_feature_list.append(residue_feats)
+
+        pooled = np.stack(pooled_list, axis=0).astype(np.float32)
+        chain_index = _pad_index_arrays([item.chain_index for item in parsed])
+        residue_index = _pad_index_arrays([item.residue_index for item in parsed])
+        per_residue = _pad_feature_arrays(residue_feature_list) if include_per_residue else None
+
+        metadata = dataclasses.replace(
+            self._metadata_template,
+            sequence_lengths=[item.residue_count for item in parsed],
+            inference_time=forge_timer.duration,
+        )
+        return SAEFeaturesOutput(
+            metadata=metadata,
+            pooled_features=pooled,
+            chain_index=chain_index,
+            residue_index=residue_index,
+            layer=layer,
+            num_features=int(num_features),
+            sae_model=str(self.config["forge_sae_model"]),
+            features=per_residue,
+        )
+
+
+def _pad_index_arrays(arrays: list[np.ndarray]) -> np.ndarray:
+    """Stack per-sequence 1-D index arrays into ``(batch, max_residues)`` (-1 pad)."""
+    max_len = max((a.shape[0] for a in arrays), default=0)
+    out = np.full((len(arrays), max_len), -1, dtype=np.int32)
+    for i, a in enumerate(arrays):
+        out[i, : a.shape[0]] = a
+    return out
+
+
+def _pad_feature_arrays(arrays: list[np.ndarray]) -> np.ndarray:
+    """Stack per-sequence ``(residues, features)`` arrays into a padded batch."""
+    max_len = max((a.shape[0] for a in arrays), default=0)
+    num_features = arrays[0].shape[1] if arrays else 0
+    out = np.zeros((len(arrays), max_len, num_features), dtype=np.float32)
+    for i, a in enumerate(arrays):
+        out[i, : a.shape[0]] = a
+    return out
+
+
+__all__ = ["SAECore", "SAEFeaturesOutput", "ESMC_D_MODEL"]

--- a/boileroom/models/sae/core.py
+++ b/boileroom/models/sae/core.py
@@ -164,7 +164,7 @@ class SAECore(EmbeddingAlgorithm):
             model_name=self.MODEL_DISPLAY_NAME, model_version=model_version
         )
 
-    def _apply_local_defaults(self, user_config: dict) -> None:
+    def _apply_local_defaults(self, user_config: dict[str, Any]) -> None:
         """Resolve model-appropriate local SAE defaults not set explicitly.
 
         The base :attr:`DEFAULT_CONFIG` ``sae_repo_id`` / ``sae_layer`` match the
@@ -248,7 +248,7 @@ class SAECore(EmbeddingAlgorithm):
     # ``embeddings``/``hidden_states`` fields -- so this override deliberately
     # narrows the ``EmbeddingAlgorithm.embed`` return type.
     def embed(  # type: ignore[override]
-        self, sequences: str | Sequence[str], options: dict | None = None
+        self, sequences: str | Sequence[str], options: dict[str, Any] | None = None
     ) -> SAEFeaturesOutput:
         """Compute SAE features for one or more sequences.
 

--- a/boileroom/models/sae/core.py
+++ b/boileroom/models/sae/core.py
@@ -47,6 +47,19 @@ ESMC_D_MODEL: dict[str, int] = {
     "esmc_6b": 2560,
 }
 
+# Per-model defaults for the *local* backend: the released Biohub per-layer SAE
+# repo and a representative transformer layer for each locally runnable ESM-C
+# model. The base DEFAULT_CONFIG sae_layer/sae_repo_id target the default Forge
+# ESMC-6B / layer-60 SAE, which is wrong for the local 300M/600M models (600M has
+# no layer 60). The collection ships an SAE per layer; these defaults pick the
+# layer at the same relative depth (~0.75) as the paper's featured 6B / layer-60
+# SAE (60 of 6B's 80 layers), i.e. layer 27 for the 36-layer 600M model and layer
+# 22 for the 30-layer 300M model. Override ``sae_layer`` to target another layer.
+LOCAL_SAE_DEFAULTS: dict[str, dict[str, str | int]] = {
+    "esmc_300m": {"sae_repo_id": "biohub/ESMC-300M-sae-k64-codebook16384", "sae_layer": 22},
+    "esmc_600m": {"sae_repo_id": "biohub/ESMC-600M-sae-k64-codebook16384", "sae_layer": 27},
+}
+
 
 class _Embedder(Protocol):
     """Minimal interface the local SAE path needs from an ESM-C embedder."""
@@ -141,6 +154,8 @@ class SAECore(EmbeddingAlgorithm):
         if source not in ("forge", "local"):
             raise ValueError(f"feature_source must be 'forge' or 'local'; got {source!r}.")
         self._source = source
+        if source == "local":
+            self._apply_local_defaults(config or {})
         self._embedder = embedder
         self._sae = sae
         self._forge = forge_backend
@@ -148,6 +163,27 @@ class SAECore(EmbeddingAlgorithm):
         self._metadata_template = self._initialize_metadata(
             model_name=self.MODEL_DISPLAY_NAME, model_version=model_version
         )
+
+    def _apply_local_defaults(self, user_config: dict) -> None:
+        """Resolve model-appropriate local SAE defaults not set explicitly.
+
+        The base :attr:`DEFAULT_CONFIG` ``sae_repo_id`` / ``sae_layer`` match the
+        default Forge ESMC-6B / layer-60 SAE. For the local backend they must match
+        the selected ESM-C model instead, so fill them from :data:`LOCAL_SAE_DEFAULTS`
+        for ``esmc_model_name`` unless the caller provided them.
+
+        Parameters
+        ----------
+        user_config : dict
+            The raw, unmerged config passed to ``__init__`` — used to tell an
+            explicit override apart from an inherited default.
+        """
+        defaults = LOCAL_SAE_DEFAULTS.get(str(self.config["esmc_model_name"]))
+        if defaults is None:
+            return
+        for key, value in defaults.items():
+            if key not in user_config:
+                self.config[key] = value
 
     # ------------------------------------------------------------------
     # Loading

--- a/boileroom/models/sae/core.py
+++ b/boileroom/models/sae/core.py
@@ -111,6 +111,10 @@ class SAECore(EmbeddingAlgorithm):
         {
             "device",
             "feature_source",
+            # normalize_features is baked into the Forge backend at construction and
+            # applied at encode time locally; keep it init-only so both backends stay
+            # consistent (it cannot be overridden per-call on the hosted path).
+            "normalize_features",
             "num_features",
             "k",
             "sae_layer",
@@ -346,9 +350,18 @@ class SAECore(EmbeddingAlgorithm):
                 dense = np.asarray(self._forge.features(item.sdk_sequence), dtype=np.float32)
                 if dense.ndim != 2:
                     raise ValueError(f"Forge features must be 2-D (tokens, num_features); got shape {dense.shape}.")
+                # Forge returns BOS + one row per SDK token (residues and chain-break
+                # '|' tokens) + EOS. Verify that layout before indexing so a change in
+                # SDK tokenization surfaces as an explicit error, not silent misalignment.
+                expected_rows = len(item.sdk_sequence) + 2
+                if dense.shape[0] != expected_rows:
+                    raise ValueError(
+                        f"Forge returned {dense.shape[0]} token rows for an SDK sequence of "
+                        f"{len(item.sdk_sequence)} tokens; expected {expected_rows} (BOS + tokens + EOS)."
+                    )
                 # Residue token positions: BOS is index 0, chain-break '|' tokens are
                 # dropped, EOS is the trailing token.
-                keep = [i + 1 for i, token in enumerate(item.sdk_sequence) if token != "|"]
+                keep = [i + 1 for i, tok in enumerate(item.sdk_sequence) if tok != "|"]
                 residue_feats = dense[keep]  # (residues, num_features)
                 num_features = residue_feats.shape[1]
                 pooled_list.append(residue_feats.max(axis=0) if residue_feats.shape[0] else np.zeros(num_features))

--- a/boileroom/models/sae/core.py
+++ b/boileroom/models/sae/core.py
@@ -201,9 +201,12 @@ class SAECore(EmbeddingAlgorithm):
     # ------------------------------------------------------------------
     # Inference
     # ------------------------------------------------------------------
-    # SAE deliberately returns pooled feature vectors (``pooled_features``) rather
-    # than a residue ``EmbeddingPrediction``, so its ``embed`` return type is
-    # intentionally narrower/different from the base ``EmbeddingAlgorithm``.
+    # SAE returns a ``SAEFeaturesOutput`` (always the pooled per-protein feature
+    # vectors ``pooled_features``, plus optional dense per-residue activations in
+    # ``features`` when ``include_per_residue=True``). That output intentionally
+    # does not implement the base ``EmbeddingPrediction`` protocol -- it has no
+    # ``embeddings``/``hidden_states`` fields -- so this override deliberately
+    # narrows the ``EmbeddingAlgorithm.embed`` return type.
     def embed(  # type: ignore[override]
         self, sequences: str | Sequence[str], options: dict | None = None
     ) -> SAEFeaturesOutput:

--- a/boileroom/models/sae/core.py
+++ b/boileroom/models/sae/core.py
@@ -140,9 +140,7 @@ class SAECore(EmbeddingAlgorithm):
         self._embedder = embedder
         self._sae = sae
         self._forge = forge_backend
-        model_version = (
-            str(self.config["forge_sae_model"]) if source == "forge" else str(self.config["sae_repo_id"])
-        )
+        model_version = str(self.config["forge_sae_model"]) if source == "forge" else str(self.config["sae_repo_id"])
         self._metadata_template = self._initialize_metadata(
             model_name=self.MODEL_DISPLAY_NAME, model_version=model_version
         )
@@ -203,7 +201,12 @@ class SAECore(EmbeddingAlgorithm):
     # ------------------------------------------------------------------
     # Inference
     # ------------------------------------------------------------------
-    def embed(self, sequences: str | Sequence[str], options: dict | None = None) -> SAEFeaturesOutput:
+    # SAE deliberately returns pooled feature vectors (``pooled_features``) rather
+    # than a residue ``EmbeddingPrediction``, so its ``embed`` return type is
+    # intentionally narrower/different from the base ``EmbeddingAlgorithm``.
+    def embed(  # type: ignore[override]
+        self, sequences: str | Sequence[str], options: dict | None = None
+    ) -> SAEFeaturesOutput:
         """Compute SAE features for one or more sequences.
 
         Parameters

--- a/boileroom/models/sae/forge.py
+++ b/boileroom/models/sae/forge.py
@@ -76,7 +76,9 @@ class ForgeSAEBackend:
         protein_tensor = self._client.encode(ESMProtein(sequence=sdk_sequence))  # type: ignore[attr-defined]
         output = self._client.logits(  # type: ignore[attr-defined]
             protein_tensor,
-            config=LogitsConfig(sae_config=SAEConfig(models=[self.sae_model], normalize_features=self.normalize_features)),
+            config=LogitsConfig(
+                sae_config=SAEConfig(models=[self.sae_model], normalize_features=self.normalize_features)
+            ),
             return_bytes=False,
         )
         if getattr(output, "sae_outputs", None) is None:

--- a/boileroom/models/sae/forge.py
+++ b/boileroom/models/sae/forge.py
@@ -83,6 +83,11 @@ class ForgeSAEBackend:
         )
         if getattr(output, "sae_outputs", None) is None:
             raise ValueError(f"Forge returned no sae_outputs for SAE model {self.sae_model!r}.")
+        if self.sae_model not in output.sae_outputs:
+            raise ValueError(
+                f"Forge returned no activations for SAE model {self.sae_model!r}; "
+                f"available keys: {sorted(output.sae_outputs)}."
+            )
         sae_tensor = output.sae_outputs[self.sae_model]
         dense = sae_tensor.to_dense() if hasattr(sae_tensor, "to_dense") else sae_tensor
         array = dense.cpu().numpy() if hasattr(dense, "cpu") else np.asarray(dense)

--- a/boileroom/models/sae/forge.py
+++ b/boileroom/models/sae/forge.py
@@ -1,0 +1,90 @@
+"""Forge (Biohub API) backend for SAE features.
+
+An alternative to running ESM-C + a local sparse autoencoder: call Biohub's
+hosted ``ESMCForgeInferenceClient`` with a ``SAEConfig`` and read back the SAE
+feature activations directly. This is the only way to use the ESMC-6B SAEs, which
+are too large to run locally.
+
+The heavy client is built lazily and the ``esm`` SDK is imported only inside
+methods, so this module stays importable (and the SAE core stays unit-testable)
+without the SDK or a Biohub token. Tests inject a fake backend exposing the same
+``features`` method.
+"""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+
+
+class ForgeSAEBackend:
+    """Fetch per-token SAE feature activations from the Biohub Forge API.
+
+    Parameters
+    ----------
+    model : str
+        Forge ESM-C model id, e.g. ``"esmc-6b-2024-12"``.
+    sae_model : str
+        Forge SAE model id, e.g. ``"esmc-6b-2024-12-sae-layer60-k64-codebook16384"``.
+    url : str
+        Forge base URL (default ``"https://biohub.ai"``).
+    token : str | None
+        API token. If ``None``, falls back to the ``ESM_API_KEY`` environment
+        variable at first use.
+    normalize_features : bool
+        Whether to request TF-IDF normalized features from the API.
+    """
+
+    def __init__(
+        self,
+        model: str,
+        sae_model: str,
+        url: str = "https://biohub.ai",
+        token: str | None = None,
+        normalize_features: bool = True,
+    ) -> None:
+        self.model = model
+        self.sae_model = sae_model
+        self.url = url
+        self.token = token
+        self.normalize_features = normalize_features
+        self._client: object | None = None
+
+    def _ensure_client(self) -> None:
+        if self._client is not None:
+            return
+        token = self.token or os.environ.get("ESM_API_KEY")
+        if not token:
+            raise ValueError(
+                "Forge SAE backend requires an API token. Set config 'forge_token' or the ESM_API_KEY env var."
+            )
+        from esm.sdk.forge import ESMCForgeInferenceClient
+
+        self._client = ESMCForgeInferenceClient(model=self.model, url=self.url, token=token)
+
+    def features(self, sdk_sequence: str) -> np.ndarray:
+        """Return dense per-token SAE activations of shape ``(tokens, num_features)``.
+
+        The returned array still includes the BOS / EOS (and any chain-break)
+        tokens; the caller selects residue rows.
+        """
+        self._ensure_client()
+        from esm.sdk.api import ESMProtein, LogitsConfig, SAEConfig
+
+        assert self._client is not None
+        protein_tensor = self._client.encode(ESMProtein(sequence=sdk_sequence))  # type: ignore[attr-defined]
+        output = self._client.logits(  # type: ignore[attr-defined]
+            protein_tensor,
+            config=LogitsConfig(sae_config=SAEConfig(models=[self.sae_model], normalize_features=self.normalize_features)),
+            return_bytes=False,
+        )
+        if getattr(output, "sae_outputs", None) is None:
+            raise ValueError(f"Forge returned no sae_outputs for SAE model {self.sae_model!r}.")
+        sae_tensor = output.sae_outputs[self.sae_model]
+        dense = sae_tensor.to_dense() if hasattr(sae_tensor, "to_dense") else sae_tensor
+        array = dense.cpu().numpy() if hasattr(dense, "cpu") else np.asarray(dense)
+        return np.asarray(array, dtype=np.float32)
+
+
+__all__ = ["ForgeSAEBackend"]

--- a/boileroom/models/sae/image.py
+++ b/boileroom/models/sae/image.py
@@ -1,0 +1,11 @@
+"""Modal image for the ESM-C sparse-autoencoder feature model.
+
+The SAE model reuses ESM-C hidden states, so it shares the single Biohub ``esm``
+runtime image (the ``esmfold2`` image, as ESM-C / ESM3 do). The SAE itself only
+adds ``huggingface_hub`` + ``safetensors`` weight loading, both already present in
+that image.
+"""
+
+from ...images.modal import get_modal_image
+
+sae_image = get_modal_image("esmfold2")

--- a/boileroom/models/sae/sae.py
+++ b/boileroom/models/sae/sae.py
@@ -1,0 +1,99 @@
+"""Public and Modal wrappers for the ESM-C sparse-autoencoder feature model."""
+
+import json
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import modal
+
+from ...backend.modal import get_modal_app
+from ...base import ModelWrapper
+from ...images.volumes import model_weights
+from ...utils import MINUTES, MODAL_MODEL_DIR
+from ..registry import SAE_SPEC
+from .image import sae_image
+
+if TYPE_CHECKING:
+    from .types import SAEFeaturesOutput
+
+logger = logging.getLogger(__name__)
+app = get_modal_app("sae")
+
+
+@app.cls(
+    image=sae_image,
+    gpu="T4",
+    timeout=20 * MINUTES,
+    scaledown_window=10 * MINUTES,
+    volumes={MODAL_MODEL_DIR: model_weights},
+)
+class ModalSAE:
+    """Modal wrapper around :class:`~boileroom.models.sae.core.SAECore`."""
+
+    config: bytes = modal.parameter(default=b"{}")
+
+    @modal.enter()
+    def _initialize(self) -> None:
+        from .core import SAECore
+
+        self._core = SAECore(config=json.loads(self.config.decode("utf-8")))
+        self._core._initialize()
+
+    @modal.method()
+    def embed(self, sequences: str | Sequence[str], options: dict | None = None) -> "SAEFeaturesOutput":
+        if getattr(self, "_core", None) is None:
+            raise RuntimeError("ModalSAE has not been initialized")
+        return self._core.embed(sequences, options=options)
+
+
+class SAE(ModelWrapper):
+    """Sequence-to-SAE-features model built on ESM-C representations.
+
+    The model runs ESM-C to obtain per-residue hidden states at a configured
+    transformer layer, then projects them through a trained sparse autoencoder to
+    a high-dimensional, sparse, interpretable feature space. Each protein is
+    summarized by max-pooling each feature across its residues.
+
+    Parameters
+    ----------
+    backend : str
+        BoilerRoom backend, normally ``"modal"`` or ``"apptainer"``.
+    device : str | None
+        Optional device passed to BoilerRoom.
+    config : dict | None
+        Configuration options; see
+        :class:`~boileroom.models.sae.core.SAECore` for supported keys
+        (``esmc_model_name``, ``sae_repo_id``, ``sae_layer``, ``num_features``,
+        ``k``, ``activation``, ``normalize_features``, ``include_per_residue``).
+
+    Examples
+    --------
+    >>> model = SAE(config={"esmc_model_name": "esmc_600m"})  # doctest: +SKIP
+    >>> result = model.get_features("MKTAYIAKQR")             # doctest: +SKIP
+    >>> result.pooled_features.shape                          # doctest: +SKIP
+    (1, 16384)
+    """
+
+    MODEL_SPEC = SAE_SPEC
+
+    def __init__(self, backend: str = "modal", device: str | None = None, config: dict | None = None) -> None:
+        super().__init__(backend=backend, device=device, config=config)
+        self._initialize_backend_from_spec(self.MODEL_SPEC, backend=backend, device=device, config=config)
+
+    def embed(self, sequences: str | Sequence[str], options: dict | None = None) -> "SAEFeaturesOutput":
+        """Compute SAE features for the given sequence(s)."""
+        if options is not None:
+            from .core import SAECore
+
+            conflicting_keys = sorted(set(options) & SAECore.STATIC_CONFIG_KEYS)
+            if conflicting_keys:
+                raise ValueError(
+                    "The following config keys can only be set at initialization and cannot be "
+                    f"overridden per-call: {conflicting_keys}"
+                )
+        return self._call_backend_method("embed", sequences, options=options)
+
+    def get_features(self, sequences: str | Sequence[str], options: dict | None = None) -> "SAEFeaturesOutput":
+        """Alias for :meth:`embed` that reads naturally for feature extraction."""
+        return self.embed(sequences, options=options)

--- a/boileroom/models/sae/sae_module.py
+++ b/boileroom/models/sae/sae_module.py
@@ -1,0 +1,387 @@
+"""Sparse autoencoder (SAE) module for ESM-C representations.
+
+This implements the sparse-autoencoder used to decompose ESM-C residue
+representations into a high-dimensional, sparse, and interpretable feature
+space, as described in *Language Modeling Materializes a World Model of Protein
+Biology* (Biohub, 2026). A separate SAE is trained per transformer layer; the
+featured configuration in the paper uses ``k = 64`` active features per residue
+and a codebook (feature) size of ``2**14 = 16384``.
+
+The module is intentionally free of Modal / ``esm`` SDK dependencies so it can be
+imported and unit-tested with only ``numpy`` and ``torch``. The heavier
+``SAECore`` (which runs ESM-C to obtain hidden states) lives in ``core.py``.
+
+Two encoder activations are supported:
+
+``"topk"``
+    Keep the ``k`` largest positive pre-activations per residue and zero the
+    rest. This is the activation used for the released Biohub SAEs.
+``"relu"``
+    A plain ``ReLU`` sparse autoencoder (no hard sparsity budget), provided for
+    experimentation and comparison.
+
+The forward pass follows the standard tied-bias formulation::
+
+    centered  = x - b_pre
+    pre_acts  = centered @ W_enc + b_enc
+    acts      = activation(pre_acts)          # TopK or ReLU
+    recon     = acts @ W_dec + b_pre
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Literal
+
+import torch
+from torch import Tensor, nn
+
+Activation = Literal["topk", "relu"]
+
+# Candidate parameter-name aliases seen across public SAE checkpoints. ``load_state_dict``
+# maps whichever alias is present onto this module's canonical names.
+_KEY_ALIASES: dict[str, tuple[str, ...]] = {
+    "W_enc": ("W_enc", "encoder.weight", "encoder.W", "w_enc"),
+    "b_enc": ("b_enc", "encoder.bias", "b_encoder", "latent_bias"),
+    "W_dec": ("W_dec", "decoder.weight", "decoder.W", "w_dec"),
+    "b_pre": ("b_pre", "b_dec", "pre_bias", "decoder.bias"),
+}
+
+
+@dataclass(frozen=True)
+class SAEModuleConfig:
+    """Static architecture description for a :class:`SparseAutoencoder`.
+
+    Parameters
+    ----------
+    d_model : int
+        Dimensionality of the ESM-C residue representation the SAE consumes
+        (e.g. 960 for ESM-C 300M, 1152 for ESM-C 600M, 2560 for ESM-C 6B).
+    num_features : int
+        Size of the sparse feature (codebook) space, e.g. ``16384``.
+    k : int
+        Number of active features per residue for the ``"topk"`` activation.
+        Ignored when ``activation == "relu"``.
+    activation : {"topk", "relu"}
+        Encoder sparsity mechanism.
+    normalize_decoder : bool
+        If ``True``, decoder rows are unit-normalized on load, matching the
+        common SAE training convention where dictionary atoms have unit norm.
+    """
+
+    d_model: int
+    num_features: int
+    k: int = 64
+    activation: Activation = "topk"
+    normalize_decoder: bool = False
+
+    def __post_init__(self) -> None:
+        if self.d_model <= 0 or self.num_features <= 0:
+            raise ValueError("d_model and num_features must be positive.")
+        if self.activation not in ("topk", "relu"):
+            raise ValueError(f"Unsupported activation: {self.activation!r}. Use 'topk' or 'relu'.")
+        if self.activation == "topk" and not (0 < self.k <= self.num_features):
+            raise ValueError(f"k must satisfy 0 < k <= num_features; got k={self.k}, num_features={self.num_features}.")
+
+
+def topk_activation(pre_acts: Tensor, k: int) -> Tensor:
+    """Keep the ``k`` largest positive pre-activations per row, zero the rest.
+
+    Parameters
+    ----------
+    pre_acts : Tensor
+        Pre-activation tensor of shape ``(..., num_features)``.
+    k : int
+        Number of features to keep per row.
+
+    Returns
+    -------
+    Tensor
+        Sparse activations with the same shape as ``pre_acts``; at most ``k``
+        entries per row are non-zero and all are non-negative.
+    """
+    if k >= pre_acts.shape[-1]:
+        return torch.relu(pre_acts)
+    values, indices = torch.topk(pre_acts, k=k, dim=-1)
+    values = torch.relu(values)
+    out = torch.zeros_like(pre_acts)
+    out.scatter_(-1, indices, values)
+    return out
+
+
+class SparseAutoencoder(nn.Module):
+    """Tied-bias sparse autoencoder over ESM-C residue representations.
+
+    Parameters
+    ----------
+    config : SAEModuleConfig
+        Architecture description.
+
+    Notes
+    -----
+    Weights are stored as ``W_enc`` of shape ``(d_model, num_features)`` and
+    ``W_dec`` of shape ``(num_features, d_model)`` so that ``encode`` and
+    ``decode`` are plain matrix multiplies without transposes at call time.
+    """
+
+    def __init__(self, config: SAEModuleConfig) -> None:
+        super().__init__()
+        self.config = config
+        d, f = config.d_model, config.num_features
+        self.W_enc = nn.Parameter(torch.zeros(d, f))
+        self.b_enc = nn.Parameter(torch.zeros(f))
+        self.W_dec = nn.Parameter(torch.zeros(f, d))
+        self.b_pre = nn.Parameter(torch.zeros(d))
+        self.reset_parameters()
+
+    @property
+    def d_model(self) -> int:
+        return self.config.d_model
+
+    @property
+    def num_features(self) -> int:
+        return self.config.num_features
+
+    def reset_parameters(self) -> None:
+        """Initialize weights so an untrained module is still well-conditioned."""
+        nn.init.kaiming_uniform_(self.W_enc, a=5**0.5)
+        with torch.no_grad():
+            self.W_dec.copy_(self.W_enc.t())
+            if self.config.normalize_decoder:
+                self._unit_normalize_decoder()
+        nn.init.zeros_(self.b_enc)
+        nn.init.zeros_(self.b_pre)
+
+    def _unit_normalize_decoder(self) -> None:
+        norms = self.W_dec.norm(dim=1, keepdim=True).clamp_min(1e-8)
+        self.W_dec.div_(norms)
+
+    def pre_activations(self, x: Tensor) -> Tensor:
+        """Return encoder pre-activations ``(x - b_pre) @ W_enc + b_enc``."""
+        return (x - self.b_pre) @ self.W_enc + self.b_enc
+
+    def encode(self, x: Tensor) -> Tensor:
+        """Map representations to sparse feature activations.
+
+        Parameters
+        ----------
+        x : Tensor
+            Residue representations of shape ``(..., d_model)``.
+
+        Returns
+        -------
+        Tensor
+            Sparse, non-negative feature activations of shape
+            ``(..., num_features)``.
+        """
+        pre = self.pre_activations(x)
+        if self.config.activation == "topk":
+            return topk_activation(pre, self.config.k)
+        return torch.relu(pre)
+
+    def decode(self, acts: Tensor) -> Tensor:
+        """Reconstruct representations from feature activations."""
+        return acts @ self.W_dec + self.b_pre
+
+    def forward(self, x: Tensor) -> tuple[Tensor, Tensor]:
+        """Return ``(feature_activations, reconstruction)`` for ``x``."""
+        acts = self.encode(x)
+        return acts, self.decode(acts)
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+    def save(self, directory: str | Path) -> Path:
+        """Save weights (``sae.pt``) and ``config.json`` to ``directory``.
+
+        Returns
+        -------
+        Path
+            The directory the checkpoint was written to.
+        """
+        directory = Path(directory)
+        directory.mkdir(parents=True, exist_ok=True)
+        torch.save(self.state_dict(), directory / "sae.pt")
+        (directory / "config.json").write_text(json.dumps(asdict(self.config)))
+        return directory
+
+    @classmethod
+    def load(cls, directory: str | Path, device: str | torch.device | None = None) -> SparseAutoencoder:
+        """Load a checkpoint previously written by :meth:`save`."""
+        directory = Path(directory)
+        config = SAEModuleConfig(**json.loads((directory / "config.json").read_text()))
+        module = cls(config)
+        state = torch.load(directory / "sae.pt", map_location=device or "cpu")
+        module.load_state_dict(state)
+        if device is not None:
+            module = module.to(device)
+        return module.eval()
+
+    @classmethod
+    def from_state_dict(
+        cls,
+        state_dict: dict[str, Tensor],
+        config: SAEModuleConfig,
+        strict: bool = False,
+    ) -> SparseAutoencoder:
+        """Build a module from a possibly foreign ``state_dict``.
+
+        Parameter names are remapped through :data:`_KEY_ALIASES`, so checkpoints
+        that call the encoder weight ``encoder.weight`` (etc.) still load. Encoder
+        / decoder matrices are transposed automatically when their orientation is
+        the transpose of this module's ``(d_model, num_features)`` convention.
+
+        Parameters
+        ----------
+        state_dict : dict[str, Tensor]
+            Source parameters.
+        config : SAEModuleConfig
+            Target architecture. Must match the checkpoint's dimensions.
+        strict : bool
+            If ``True``, raise when a canonical parameter cannot be resolved.
+
+        Returns
+        -------
+        SparseAutoencoder
+            A module in eval mode with weights loaded.
+        """
+        module = cls(config)
+        remapped: dict[str, Tensor] = {}
+        lowered = {key.lower(): value for key, value in state_dict.items()}
+        for canonical, aliases in _KEY_ALIASES.items():
+            tensor = None
+            for alias in aliases:
+                if alias in state_dict:
+                    tensor = state_dict[alias]
+                    break
+                if alias.lower() in lowered:
+                    tensor = lowered[alias.lower()]
+                    break
+            if tensor is None:
+                if strict:
+                    raise KeyError(f"Could not resolve parameter {canonical!r} from state dict keys {sorted(state_dict)}.")
+                continue
+            remapped[canonical] = cls._orient(canonical, torch.as_tensor(tensor), config)
+        missing = module.load_state_dict(remapped, strict=False)
+        if strict and missing.missing_keys:
+            raise KeyError(f"Missing parameters after remap: {missing.missing_keys}.")
+        return module.eval()
+
+    @staticmethod
+    def _orient(name: str, tensor: Tensor, config: SAEModuleConfig) -> Tensor:
+        """Transpose 2-D weights when they arrive in the opposite orientation."""
+        if name == "W_enc":
+            target = (config.d_model, config.num_features)
+        elif name == "W_dec":
+            target = (config.num_features, config.d_model)
+        else:
+            return tensor
+        if tuple(tensor.shape) == target:
+            return tensor
+        if tuple(tensor.shape) == (target[1], target[0]):
+            return tensor.t().contiguous()
+        raise ValueError(f"{name} has shape {tuple(tensor.shape)}, incompatible with target {target}.")
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        repo_id: str,
+        *,
+        layer: int,
+        num_features: int,
+        d_model: int,
+        k: int = 64,
+        activation: Activation = "topk",
+        filename: str | None = None,
+        revision: str | None = None,
+        cache_dir: str | Path | None = None,
+        device: str | torch.device | None = None,
+        normalize_decoder: bool = False,
+    ) -> SparseAutoencoder:
+        """Download and load a released per-layer SAE from the Hugging Face Hub.
+
+        The Biohub SAE collection stores one ``safetensors`` file per transformer
+        layer (e.g. ``layer_60.safetensors``) inside a repo such as
+        ``biohub/ESMC-6B-sae-k64-codebook16384``.
+
+        Parameters
+        ----------
+        repo_id : str
+            Hugging Face repo id hosting the per-layer SAE weights.
+        layer : int
+            Transformer layer index; selects ``layer_{layer}.safetensors`` unless
+            ``filename`` is given.
+        num_features, d_model, k, activation, normalize_decoder
+            Architecture description; see :class:`SAEModuleConfig`.
+        filename : str | None
+            Explicit weight filename, overriding the ``layer_{layer}`` default.
+        revision, cache_dir, device
+            Passed through to the Hub download / tensor placement.
+
+        Returns
+        -------
+        SparseAutoencoder
+            A module in eval mode with the downloaded weights loaded.
+        """
+        from huggingface_hub import hf_hub_download
+        from safetensors.torch import load_file
+
+        weight_file = filename or f"layer_{layer}.safetensors"
+        local_path = hf_hub_download(
+            repo_id=repo_id, filename=weight_file, revision=revision, cache_dir=str(cache_dir) if cache_dir else None
+        )
+        state_dict = load_file(local_path, device="cpu")
+        config = SAEModuleConfig(
+            d_model=d_model,
+            num_features=num_features,
+            k=k,
+            activation=activation,
+            normalize_decoder=normalize_decoder,
+        )
+        module = cls.from_state_dict(state_dict, config)
+        if device is not None:
+            module = module.to(device)
+        return module.eval()
+
+
+def max_pool_features(feature_acts: Tensor, valid_mask: Tensor | None = None) -> Tensor:
+    """Aggregate per-residue feature activations into one per-protein vector.
+
+    Following the paper, a protein is represented by the maximum activation of
+    each feature across its residues.
+
+    Parameters
+    ----------
+    feature_acts : Tensor
+        Per-residue activations of shape ``(residues, num_features)``.
+    valid_mask : Tensor | None
+        Optional boolean mask of shape ``(residues,)``; ``False`` rows (padding)
+        are excluded from the max. If every row is masked out, a zero vector is
+        returned.
+
+    Returns
+    -------
+    Tensor
+        Per-protein feature vector of shape ``(num_features,)``.
+    """
+    if feature_acts.ndim != 2:
+        raise ValueError(f"feature_acts must be 2-D (residues, features); got shape {tuple(feature_acts.shape)}.")
+    if valid_mask is not None:
+        valid_mask = valid_mask.to(dtype=torch.bool)
+        if valid_mask.shape[0] != feature_acts.shape[0]:
+            raise ValueError("valid_mask length must match the residue dimension.")
+        feature_acts = feature_acts[valid_mask]
+    if feature_acts.shape[0] == 0:
+        return torch.zeros(feature_acts.shape[-1], dtype=feature_acts.dtype, device=feature_acts.device)
+    return feature_acts.max(dim=0).values
+
+
+__all__ = [
+    "Activation",
+    "SAEModuleConfig",
+    "SparseAutoencoder",
+    "max_pool_features",
+    "topk_activation",
+]

--- a/boileroom/models/sae/sae_module.py
+++ b/boileroom/models/sae/sae_module.py
@@ -269,6 +269,11 @@ class SparseAutoencoder(nn.Module):
         missing = module.load_state_dict(remapped, strict=False)
         if strict and missing.missing_keys:
             raise KeyError(f"Missing parameters after remap: {missing.missing_keys}.")
+        # load_state_dict overwrites the decoder with checkpoint values, so re-apply
+        # the unit-normalization contract that reset_parameters established.
+        if config.normalize_decoder:
+            with torch.no_grad():
+                module._unit_normalize_decoder()
         return module.eval()
 
     @staticmethod
@@ -342,7 +347,10 @@ class SparseAutoencoder(nn.Module):
             activation=activation,
             normalize_decoder=normalize_decoder,
         )
-        module = cls.from_state_dict(state_dict, config)
+        # Load strictly: a downloaded checkpoint whose parameter names fall outside
+        # _KEY_ALIASES would otherwise silently keep the random init and return
+        # meaningless features.
+        module = cls.from_state_dict(state_dict, config, strict=True)
         if device is not None:
             module = module.to(device)
         return module.eval()

--- a/boileroom/models/sae/sae_module.py
+++ b/boileroom/models/sae/sae_module.py
@@ -261,7 +261,9 @@ class SparseAutoencoder(nn.Module):
                     break
             if tensor is None:
                 if strict:
-                    raise KeyError(f"Could not resolve parameter {canonical!r} from state dict keys {sorted(state_dict)}.")
+                    raise KeyError(
+                        f"Could not resolve parameter {canonical!r} from state dict keys {sorted(state_dict)}."
+                    )
                 continue
             remapped[canonical] = cls._orient(canonical, torch.as_tensor(tensor), config)
         missing = module.load_state_dict(remapped, strict=False)

--- a/boileroom/models/sae/types.py
+++ b/boileroom/models/sae/types.py
@@ -1,0 +1,57 @@
+"""Lightweight output types for SAE feature extraction.
+
+Kept free of heavy dependencies (only ``numpy`` and base protocols) per the
+repository's ``types.py`` policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from ...base import PredictionMetadata
+
+
+@dataclass
+class SAEFeaturesOutput:
+    """Sparse-autoencoder features for one batch of sequences.
+
+    Arrays are padded across the batch to the longest residue sequence, matching
+    the ESM-C embedding outputs they are derived from. Padded residue rows are
+    zero and padded index entries are ``-1``.
+
+    Attributes
+    ----------
+    metadata : PredictionMetadata
+        Model / timing metadata.
+    pooled_features : np.ndarray
+        Per-protein feature vectors of shape ``(batch, num_features)``, obtained
+        by max-pooling each feature across the (unpadded) residues.
+    chain_index : np.ndarray
+        Per-residue chain ids of shape ``(batch, residues)`` (``-1`` = padding).
+    residue_index : np.ndarray
+        Per-residue positions of shape ``(batch, residues)`` (``-1`` = padding).
+    layer : int
+        ESM-C transformer layer the SAE was applied to.
+    num_features : int
+        Size of the SAE feature (codebook) space.
+    sae_model : str
+        Identifier of the SAE weights used.
+    features : np.ndarray | None
+        Optional dense per-residue activations of shape
+        ``(batch, residues, num_features)``. Only populated when explicitly
+        requested via ``include_per_residue=True`` since it can be large.
+    """
+
+    metadata: PredictionMetadata
+    pooled_features: np.ndarray
+    chain_index: np.ndarray
+    residue_index: np.ndarray
+    layer: int
+    num_features: int
+    sae_model: str
+    features: np.ndarray | None = None
+
+
+__all__ = ["SAEFeaturesOutput"]

--- a/docs/sae_features.md
+++ b/docs/sae_features.md
@@ -52,15 +52,15 @@ Request dense per-residue activations with `options={"include_per_residue": True
 | `feature_source` | `forge` | `forge` or `local`. |
 | `num_features` | `16384` | Codebook / feature-space size. |
 | `k` | `64` | Active features per residue (TopK). |
-| `sae_layer` | `60` | Transformer layer the SAE was trained on. `60` matches the default Forge/ESMC-6B SAE; the local 300M/600M SAEs live at different layers, so set `sae_layer` (and a matching `sae_repo_id`) for the `local` backend — the example above uses layer `27`. An out-of-range layer raises at inference. |
+| `sae_layer` | `60` (forge) / per-model (local) | Transformer layer the SAE was trained on. `60` matches the default Forge/ESMC-6B SAE. For the `local` backend it defaults per model to a layer at the same relative depth (`27` for `esmc_600m`, `22` for `esmc_300m`); override to target another layer. An out-of-range layer raises at inference. |
 | `normalize_features` | `True` | Set at initialization (not per-call). Forge: TF-IDF normalization. Local: L2-normalize per-residue activations before pooling. |
 | `include_per_residue` | `False` | Also return dense per-residue activations. |
 | **Forge** `forge_model` | `esmc-6b-2024-12` | Forge ESM-C model id. |
 | **Forge** `forge_sae_model` | `esmc-6b-2024-12-sae-layer60-k64-codebook16384` | Forge SAE model id. |
 | **Forge** `forge_url` | `https://biohub.ai` | Forge base URL. |
 | **Forge** `forge_token` | `None` | API token; falls back to `ESM_API_KEY`. |
-| **Local** `esmc_model_name` | `esmc_600m` | ESM-C variant (`esmc_300m` / `esmc_600m`). |
-| **Local** `sae_repo_id` | `biohub/ESMC-600M-sae-k64-codebook16384` | HF repo with per-layer weights. Confirm ids against the [Biohub SAE collection](https://huggingface.co/collections/biohub/esmc-saes-for-hidden-states-all-layers). |
+| **Local** `esmc_model_name` | `esmc_600m` | ESM-C variant (`esmc_300m` / `esmc_600m`); selects the local `sae_repo_id` / `sae_layer` defaults. |
+| **Local** `sae_repo_id` | per-model (`biohub/ESMC-600M-sae-k64-codebook16384` for `esmc_600m`) | HF repo with per-layer weights; defaults to the repo matching `esmc_model_name` unless set. Confirm ids against the [Biohub SAE collection](https://huggingface.co/collections/biohub/esmc-saes-for-hidden-states-all-layers). |
 | **Local** `activation` | `topk` | `topk` or `relu`. |
 
 ## Weights (local backend)

--- a/docs/sae_features.md
+++ b/docs/sae_features.md
@@ -52,8 +52,8 @@ Request dense per-residue activations with `options={"include_per_residue": True
 | `feature_source` | `forge` | `forge` or `local`. |
 | `num_features` | `16384` | Codebook / feature-space size. |
 | `k` | `64` | Active features per residue (TopK). |
-| `sae_layer` | `60` | Transformer layer the SAE was trained on. |
-| `normalize_features` | `True` | Forge: TF-IDF normalization. Local: L2-normalize per-residue activations before pooling. |
+| `sae_layer` | `60` | Transformer layer the SAE was trained on. `60` matches the default Forge/ESMC-6B SAE; the local 300M/600M SAEs live at different layers, so set `sae_layer` (and a matching `sae_repo_id`) for the `local` backend — the example above uses layer `27`. An out-of-range layer raises at inference. |
+| `normalize_features` | `True` | Set at initialization (not per-call). Forge: TF-IDF normalization. Local: L2-normalize per-residue activations before pooling. |
 | `include_per_residue` | `False` | Also return dense per-residue activations. |
 | **Forge** `forge_model` | `esmc-6b-2024-12` | Forge ESM-C model id. |
 | **Forge** `forge_sae_model` | `esmc-6b-2024-12-sae-layer60-k64-codebook16384` | Forge SAE model id. |

--- a/docs/sae_features.md
+++ b/docs/sae_features.md
@@ -1,0 +1,77 @@
+# SAE features (`SAE`)
+
+The `SAE` model maps an amino-acid sequence to **sparse-autoencoder (SAE)
+features** of the ESM-C representation space. It reproduces the sparse-coding
+analysis from *Language Modeling Materializes a World Model of Protein Biology*
+(Biohub, 2026): a sparse autoencoder is trained per ESM-C transformer layer and
+decomposes each residue representation into a high-dimensional, sparse,
+interpretable feature basis (`k = 64` active features per residue, codebook of
+`2**14 = 16384` features).
+
+A protein is summarized by **max-pooling** each feature across its residues into a
+single per-protein feature vector (`pooled_features`).
+
+## Two feature sources
+
+Select the backend with `feature_source`:
+
+- **`"forge"` (default)** — call Biohub's hosted `ESMCForgeInferenceClient` with a
+  `SAEConfig` and read back SAE activations. This is the **only** way to use the
+  **ESMC-6B layer-60** SAE featured in the paper (the default), which is too large
+  to run locally. Requires a Biohub API token (`forge_token` config or the
+  `ESM_API_KEY` env var).
+- **`"local"`** — run ESM-C locally / on Modal to get per-layer hidden states, then
+  apply a local `SparseAutoencoder` loaded from the Biohub per-layer Hugging Face
+  weights. Works for the **300M / 600M** SAEs on a single GPU, no token needed.
+
+## Usage
+
+```python
+from boileroom import SAE
+
+# Default: ESMC-6B / layer 60 via Forge (needs ESM_API_KEY or config forge_token)
+model = SAE(config={"forge_token": "..."})
+result = model.get_features("MKTAYIAKQRQISFVKSHFSRQLEERLGLIEVQ")
+result.pooled_features.shape   # (1, 16384)
+
+# Local backend with the 600M SAE (no token, needs a GPU)
+local = SAE(config={
+    "feature_source": "local",
+    "esmc_model_name": "esmc_600m",
+    "sae_repo_id": "biohub/ESMC-600M-sae-k64-codebook16384",
+    "sae_layer": 27,
+})
+```
+
+Request dense per-residue activations with `options={"include_per_residue": True}`.
+
+## Configuration
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `feature_source` | `forge` | `forge` or `local`. |
+| `num_features` | `16384` | Codebook / feature-space size. |
+| `k` | `64` | Active features per residue (TopK). |
+| `sae_layer` | `60` | Transformer layer the SAE was trained on. |
+| `normalize_features` | `True` | Forge: TF-IDF normalization. Local: L2-normalize per-residue activations before pooling. |
+| `include_per_residue` | `False` | Also return dense per-residue activations. |
+| **Forge** `forge_model` | `esmc-6b-2024-12` | Forge ESM-C model id. |
+| **Forge** `forge_sae_model` | `esmc-6b-2024-12-sae-layer60-k64-codebook16384` | Forge SAE model id. |
+| **Forge** `forge_url` | `https://biohub.ai` | Forge base URL. |
+| **Forge** `forge_token` | `None` | API token; falls back to `ESM_API_KEY`. |
+| **Local** `esmc_model_name` | `esmc_600m` | ESM-C variant (`esmc_300m` / `esmc_600m`). |
+| **Local** `sae_repo_id` | `biohub/ESMC-600M-sae-k64-codebook16384` | HF repo with per-layer weights. Confirm ids against the [Biohub SAE collection](https://huggingface.co/collections/biohub/esmc-saes-for-hidden-states-all-layers). |
+| **Local** `activation` | `topk` | `topk` or `relu`. |
+
+## Weights (local backend)
+
+`SparseAutoencoder.from_pretrained(repo_id, layer=..., num_features=..., d_model=...)`
+downloads one `layer_{layer}.safetensors` file and remaps common parameter names
+(`W_enc`/`b_enc`/`W_dec`/`b_pre` and encoder/decoder aliases), transposing weight
+matrices when a checkpoint stores them in the opposite orientation. Local
+checkpoints round-trip through `SparseAutoencoder.save` / `.load`, which the test
+suite uses to exercise the model without network access.
+
+The `sae_module` submodule (autoencoder math) and `forge` submodule (API client)
+are free of Modal / heavy `esm` imports at module scope, so the core is
+unit-testable with fakes — no GPU, token, or network.

--- a/tests/contracts/test_model_wrappers.py
+++ b/tests/contracts/test_model_wrappers.py
@@ -13,8 +13,8 @@ from boileroom.models.chai.types import Chai1Output
 from boileroom.models.esm.types import ESM2Output, ESMFoldOutput
 from boileroom.models.esm3.types import ESM3Output, ESMCOutput
 from boileroom.models.esmfold2.types import ESMFold2Output
-from boileroom.models.sae.types import SAEFeaturesOutput
 from boileroom.models.registry import CHAI1_SPEC, ESM2_SPEC, MODEL_SPECS, ModelSpec, get_model_spec, resolve_object
+from boileroom.models.sae.types import SAEFeaturesOutput
 
 pytestmark = pytest.mark.contract
 

--- a/tests/contracts/test_model_wrappers.py
+++ b/tests/contracts/test_model_wrappers.py
@@ -13,6 +13,7 @@ from boileroom.models.chai.types import Chai1Output
 from boileroom.models.esm.types import ESM2Output, ESMFoldOutput
 from boileroom.models.esm3.types import ESM3Output, ESMCOutput
 from boileroom.models.esmfold2.types import ESMFold2Output
+from boileroom.models.sae.types import SAEFeaturesOutput
 from boileroom.models.registry import CHAI1_SPEC, ESM2_SPEC, MODEL_SPECS, ModelSpec, get_model_spec, resolve_object
 
 pytestmark = pytest.mark.contract
@@ -22,6 +23,7 @@ SAMPLE_INPUTS: dict[str, Any] = {
     "esm2": ["MALWMRLLPLLALLALWGPDPAAA"],
     "esmc": ["ACD:EF"],
     "esm3": ["ACD:EF"],
+    "sae": ["ACD:EF"],
     "esmfold2": "MLKNVHVLVLGAGDVGSVVVRLLEK",
     "chai1": (
         "ICLQKTSNQILKPKLISYTLGQSGTCITDPLLAMDEGYFAYSHLERIGSCSRGVSKQRIIGVGEVLDRGDEVPSLFMTNVWTPPNPNTVYHCSAVYNNEFYYVLCAVSTVGD"
@@ -67,6 +69,18 @@ def _make_output(spec: ModelSpec) -> object:
             residue_index=np.arange(3, dtype=np.int64)[None, :],
             hidden_states=None,
             lm_logits=None,
+        )
+
+    if spec.key == "sae":
+        return SAEFeaturesOutput(
+            metadata=_make_metadata(spec.public_name),
+            pooled_features=np.zeros((1, 16), dtype=np.float32),
+            chain_index=np.zeros((1, 3), dtype=np.int64),
+            residue_index=np.arange(3, dtype=np.int64)[None, :],
+            layer=27,
+            num_features=16,
+            sae_model="test/sae",
+            features=None,
         )
 
     if spec.key == "esmfold":

--- a/tests/sae/test_sae_core.py
+++ b/tests/sae/test_sae_core.py
@@ -140,6 +140,37 @@ def test_layer_out_of_range_raises() -> None:
         core.embed(["ACDE", "ACDE"])
 
 
+def test_local_defaults_resolve_per_model() -> None:
+    # Default local model is esmc_600m -> its repo + representative layer 27.
+    core = SAECore(config={"feature_source": "local"})
+    assert core.config["esmc_model_name"] == "esmc_600m"
+    assert core.config["sae_layer"] == 27
+    assert core.config["sae_repo_id"] == "biohub/ESMC-600M-sae-k64-codebook16384"
+    # 300m selects its own repo + layer.
+    core_300 = SAECore(config={"feature_source": "local", "esmc_model_name": "esmc_300m"})
+    assert core_300.config["sae_layer"] == 22
+    assert core_300.config["sae_repo_id"] == "biohub/ESMC-300M-sae-k64-codebook16384"
+
+
+def test_local_defaults_do_not_override_explicit_values() -> None:
+    core = SAECore(
+        config={
+            "feature_source": "local",
+            "esmc_model_name": "esmc_600m",
+            "sae_layer": 12,
+            "sae_repo_id": "acme/custom-sae",
+        }
+    )
+    assert core.config["sae_layer"] == 12
+    assert core.config["sae_repo_id"] == "acme/custom-sae"
+
+
+def test_forge_default_layer_is_unaffected_by_local_resolution() -> None:
+    core = SAECore()
+    assert core.config["feature_source"] == "forge"
+    assert core.config["sae_layer"] == 60
+
+
 def test_infer_d_model_unknown_model() -> None:
     sae = SparseAutoencoder(SAEModuleConfig(d_model=8, num_features=16, k=3))
     core = SAECore(

--- a/tests/sae/test_sae_core.py
+++ b/tests/sae/test_sae_core.py
@@ -1,0 +1,149 @@
+"""Tests for SAECore using a fake ESM-C embedder (no Modal / esm / GPU)."""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from boileroom.models.sae.core import SAECore  # noqa: E402
+from boileroom.models.sae.sae_module import SAEModuleConfig, SparseAutoencoder  # noqa: E402
+
+
+@dataclass
+class _FakeEmbedding:
+    hidden_states: np.ndarray
+    chain_index: np.ndarray
+    residue_index: np.ndarray
+
+
+class _FakeESMC:
+    """Returns canned hidden states shaped (layers, batch, residues, d_model)."""
+
+    def __init__(self, hidden_states: np.ndarray, chain_index: np.ndarray, residue_index: np.ndarray) -> None:
+        self._out = _FakeEmbedding(hidden_states, chain_index, residue_index)
+        self.calls: list[dict | None] = []
+
+    def embed(self, sequences, options=None):  # noqa: ANN001
+        self.calls.append(options)
+        return self._out
+
+
+def _make_core(d_model=8, num_features=16, k=3, layer=1, batch=2, residues=4, seed=0):
+    rng = np.random.default_rng(seed)
+    n_layers = 3
+    hidden = rng.standard_normal((n_layers, batch, residues, d_model)).astype(np.float32)
+    chain_index = np.zeros((batch, residues), dtype=np.int64)
+    chain_index[0, -1] = -1  # first sequence has one padded residue
+    residue_index = np.tile(np.arange(residues), (batch, 1))
+    residue_index[0, -1] = -1
+    embedder = _FakeESMC(hidden, chain_index, residue_index)
+    sae = SparseAutoencoder(SAEModuleConfig(d_model=d_model, num_features=num_features, k=k))
+    with torch.no_grad():
+        sae.W_enc.normal_(generator=torch.Generator().manual_seed(seed))
+    core = SAECore(
+        config={
+            "device": "cpu",
+            "feature_source": "local",
+            "normalize_features": False,
+            "sae_layer": layer,
+            "num_features": num_features,
+            "k": k,
+        },
+        embedder=embedder,
+        sae=sae,
+    )
+    core._load()
+    return core, embedder, sae, hidden, chain_index
+
+
+def test_embed_requests_hidden_states_and_pools() -> None:
+    core, embedder, sae, hidden, chain_index = _make_core()
+    out = core.embed(["ACDE", "ACDE"])
+    # The embedder must have been asked for hidden states.
+    assert embedder.calls and embedder.calls[0] == {"include_fields": ["hidden_states"]}
+    assert out.pooled_features.shape == (2, 16)
+    assert out.layer == 1
+    assert out.num_features == 16
+    # Pooled features are non-negative (TopK/ReLU) and finite.
+    assert (out.pooled_features >= 0).all()
+    assert np.isfinite(out.pooled_features).all()
+
+
+def test_pooled_matches_manual_max_over_valid_residues() -> None:
+    core, embedder, sae, hidden, chain_index = _make_core()
+    out = core.embed(["ACDE", "ACDE"])
+    # Recompute expected pooled vector for sequence 0 (last residue is padding).
+    with torch.no_grad():
+        layer_states = torch.as_tensor(hidden[1, 0], dtype=torch.float32)
+        acts = sae.encode(layer_states)
+        valid = torch.as_tensor(chain_index[0] != -1)
+        expected = acts[valid].max(dim=0).values.numpy()
+    np.testing.assert_allclose(out.pooled_features[0], expected, rtol=1e-5, atol=1e-6)
+
+
+def test_padding_residue_excluded_from_pool() -> None:
+    core, embedder, sae, hidden, chain_index = _make_core()
+    out_padded = core.embed(["ACD", "ACDE"])
+    # Manually build a version where the padded residue has a huge activation;
+    # it must not leak into the pooled vector.
+    with torch.no_grad():
+        layer_states = torch.as_tensor(hidden[1, 0], dtype=torch.float32)
+        acts = sae.encode(layer_states)
+        valid = torch.as_tensor(chain_index[0] != -1)
+        max_valid = float(acts[valid].max())
+    assert out_padded.pooled_features[0].max() == pytest.approx(max_valid, rel=1e-5)
+
+
+def test_include_per_residue_returns_dense_activations() -> None:
+    core, *_ = _make_core()
+    out = core.embed(["ACDE", "ACDE"], options={"include_per_residue": True})
+    assert out.features is not None
+    assert out.features.shape == (2, 4, 16)
+
+
+def test_per_residue_none_by_default() -> None:
+    core, *_ = _make_core()
+    out = core.embed(["ACDE", "ACDE"])
+    assert out.features is None
+
+
+def test_static_config_key_rejected_per_call() -> None:
+    core, *_ = _make_core()
+    with pytest.raises(ValueError):
+        core.embed(["ACDE"], options={"num_features": 999})
+
+
+def test_missing_hidden_states_raises() -> None:
+    class _NoHidden:
+        def embed(self, sequences, options=None):  # noqa: ANN001
+            return _FakeEmbedding(None, np.zeros((1, 3), dtype=np.int64), np.zeros((1, 3), dtype=np.int64))
+
+    sae = SparseAutoencoder(SAEModuleConfig(d_model=8, num_features=16, k=3))
+    core = SAECore(config={"device": "cpu", "feature_source": "local"}, embedder=_NoHidden(), sae=sae)
+    core._load()
+    with pytest.raises(ValueError, match="hidden_states"):
+        core.embed(["ACDE"])
+
+
+def test_layer_out_of_range_raises() -> None:
+    core, *_ = _make_core(layer=99)
+    with pytest.raises(IndexError):
+        core.embed(["ACDE", "ACDE"])
+
+
+def test_infer_d_model_unknown_model() -> None:
+    sae = SparseAutoencoder(SAEModuleConfig(d_model=8, num_features=16, k=3))
+    core = SAECore(
+        config={"feature_source": "local", "esmc_model_name": "esmc_999x"},
+        embedder=_FakeESMC(
+            np.zeros((3, 1, 2, 8), dtype=np.float32),
+            np.zeros((1, 2), dtype=np.int64),
+            np.zeros((1, 2), dtype=np.int64),
+        ),
+        sae=sae,
+    )
+    core._load()
+    with pytest.raises(ValueError, match="Unknown ESM-C model"):
+        core._infer_d_model()

--- a/tests/sae/test_sae_core.py
+++ b/tests/sae/test_sae_core.py
@@ -84,16 +84,23 @@ def test_pooled_matches_manual_max_over_valid_residues() -> None:
 
 
 def test_padding_residue_excluded_from_pool() -> None:
-    core, embedder, sae, hidden, chain_index = _make_core()
+    layer = 1  # matches the default sae_layer used by _make_core
+    core, _embedder, sae, hidden, chain_index = _make_core(layer=layer)
+    # Make the padded residue of sequence 0 dominate the hidden states; its (large)
+    # activation must not leak into the pooled vector because it is masked out.
+    hidden[layer, 0, -1, :] = 1e4
     out_padded = core.embed(["ACD", "ACDE"])
-    # Manually build a version where the padded residue has a huge activation;
-    # it must not leak into the pooled vector.
     with torch.no_grad():
-        layer_states = torch.as_tensor(hidden[1, 0], dtype=torch.float32)
+        layer_states = torch.as_tensor(hidden[layer, 0], dtype=torch.float32)
         acts = sae.encode(layer_states)
         valid = torch.as_tensor(chain_index[0] != -1)
         max_valid = float(acts[valid].max())
-    assert out_padded.pooled_features[0].max() == pytest.approx(max_valid, rel=1e-5)
+        all_max = float(acts.max())
+    pooled_max = float(out_padded.pooled_features[0].max())
+    assert pooled_max == pytest.approx(max_valid, rel=1e-5)
+    # Guard that the test is meaningful: the masked padded residue really is the
+    # dominant activation, so a broken mask would produce a strictly larger pool.
+    assert all_max > pooled_max
 
 
 def test_include_per_residue_returns_dense_activations() -> None:

--- a/tests/sae/test_sae_forge.py
+++ b/tests/sae/test_sae_forge.py
@@ -7,6 +7,10 @@ without the ``esm`` SDK, a token, or the network.
 import numpy as np
 import pytest
 
+# ``core`` imports torch at module scope; skip the whole module when torch is absent
+# instead of failing collection (the forge backend itself stays torch-free).
+pytest.importorskip("torch")
+
 from boileroom.models.sae.core import SAECore  # noqa: E402
 from boileroom.models.sae.forge import ForgeSAEBackend  # noqa: E402
 
@@ -84,6 +88,19 @@ def test_forge_batch_padding():
     assert out.pooled_features.shape == (2, 8)
     assert out.chain_index.shape == (2, 4)  # padded to the longest
     assert out.chain_index[1].tolist() == [0, 0, -1, -1]
+
+
+def test_forge_wrong_token_row_count_raises():
+    class _BadForge(_FakeForge):
+        def features(self, sdk_sequence: str) -> np.ndarray:
+            # Return one fewer row than BOS + tokens + EOS to simulate a
+            # tokenization change; the core must reject it rather than misalign.
+            return np.zeros((len(sdk_sequence) + 1, self.num_features), dtype=np.float32)
+
+    core = SAECore(config={"feature_source": "forge", "num_features": 8}, forge_backend=_BadForge())
+    core._load()
+    with pytest.raises(ValueError, match="token rows"):
+        core.embed(["ACDE"])
 
 
 def test_invalid_feature_source_raises():

--- a/tests/sae/test_sae_forge.py
+++ b/tests/sae/test_sae_forge.py
@@ -1,0 +1,98 @@
+"""Tests for the Forge SAE backend and the forge feature_source path.
+
+A fake Forge backend returns canned per-token activations so the whole path runs
+without the ``esm`` SDK, a token, or the network.
+"""
+
+import numpy as np
+import pytest
+
+from boileroom.models.sae.core import SAECore  # noqa: E402
+from boileroom.models.sae.forge import ForgeSAEBackend  # noqa: E402
+
+
+class _FakeForge:
+    """Returns (tokens, num_features) activations: BOS + residues + EOS."""
+
+    def __init__(self, num_features: int = 8) -> None:
+        self.num_features = num_features
+        self.calls: list[str] = []
+
+    def features(self, sdk_sequence: str) -> np.ndarray:
+        self.calls.append(sdk_sequence)
+        n_tokens = len(sdk_sequence) + 2  # BOS + tokens (incl '|') + EOS
+        arr = np.zeros((n_tokens, self.num_features), dtype=np.float32)
+        # Give each residue token a distinctive activation so pooling is checkable.
+        for pos, ch in enumerate(sdk_sequence):
+            arr[pos + 1, ord(ch) % self.num_features] = float(pos + 1)
+        # Put a huge value on BOS/EOS to ensure they are excluded from the pool.
+        arr[0, :] = 999.0
+        arr[-1, :] = 999.0
+        return arr
+
+
+def _forge_core(num_features: int = 8) -> tuple[SAECore, _FakeForge]:
+    forge = _FakeForge(num_features)
+    core = SAECore(config={"feature_source": "forge", "num_features": num_features}, forge_backend=forge)
+    core._load()
+    return core, forge
+
+
+def test_default_source_is_forge_with_6b_layer60():
+    core = SAECore(forge_backend=_FakeForge())
+    assert core.config["feature_source"] == "forge"
+    assert core.config["sae_layer"] == 60
+    assert core.config["forge_sae_model"] == "esmc-6b-2024-12-sae-layer60-k64-codebook16384"
+
+
+def test_forge_embed_pools_and_excludes_bos_eos():
+    core, forge = _forge_core()
+    out = core.embed(["ACDE"])
+    assert out.pooled_features.shape == (1, 8)
+    # BOS/EOS activations (999) must not appear in the pooled vector.
+    assert out.pooled_features.max() < 999.0
+    assert out.sae_model == "esmc-6b-2024-12-sae-layer60-k64-codebook16384"
+    assert forge.calls == ["ACDE"]
+
+
+def test_forge_drops_chain_break_tokens():
+    core, forge = _forge_core()
+    out = core.embed(["AC:DE"])
+    # Two chains, 4 residues total; residue/chain indices exclude the break token.
+    assert out.chain_index.shape == (1, 4)
+    assert out.chain_index.tolist() == [[0, 0, 1, 1]]
+    # The SDK sequence sent to forge uses '|' as the chain break.
+    assert forge.calls == ["AC|DE"]
+
+
+def test_forge_include_per_residue():
+    core, _ = _forge_core()
+    out = core.embed(["ACDE"], options={"include_per_residue": True})
+    assert out.features is not None
+    assert out.features.shape == (1, 4, 8)
+
+
+def test_forge_per_residue_none_by_default():
+    core, _ = _forge_core()
+    out = core.embed(["ACDE"])
+    assert out.features is None
+
+
+def test_forge_batch_padding():
+    core, _ = _forge_core()
+    out = core.embed(["ACDE", "AC"])
+    assert out.pooled_features.shape == (2, 8)
+    assert out.chain_index.shape == (2, 4)  # padded to the longest
+    assert out.chain_index[1].tolist() == [0, 0, -1, -1]
+
+
+def test_invalid_feature_source_raises():
+    with pytest.raises(ValueError, match="feature_source"):
+        SAECore(config={"feature_source": "banana"})
+
+
+def test_forge_backend_requires_token(monkeypatch):
+    monkeypatch.delenv("ESM_API_KEY", raising=False)
+    backend = ForgeSAEBackend(model="esmc-6b-2024-12", sae_model="x", token=None)
+    with pytest.raises(ValueError, match="token"):
+        backend._ensure_client()

--- a/tests/sae/test_sae_module.py
+++ b/tests/sae/test_sae_module.py
@@ -101,6 +101,29 @@ def test_from_state_dict_strict_raises_on_missing() -> None:
         SparseAutoencoder.from_state_dict({"encoder.weight": torch.randn(8, 16)}, cfg, strict=True)
 
 
+def test_from_state_dict_applies_normalize_decoder() -> None:
+    # Decoder rows in the checkpoint are deliberately non-unit-norm; the loaded
+    # module must unit-normalize them when normalize_decoder=True.
+    cfg = SAEModuleConfig(d_model=8, num_features=16, k=3, normalize_decoder=True)
+    foreign = {
+        "W_enc": torch.randn(8, 16),
+        "b_enc": torch.randn(16),
+        "W_dec": torch.randn(16, 8) * 7.0,
+        "b_pre": torch.randn(8),
+    }
+    sae = SparseAutoencoder.from_state_dict(foreign, cfg)
+    row_norms = sae.W_dec.norm(dim=1)
+    assert torch.allclose(row_norms, torch.ones_like(row_norms), atol=1e-5)
+
+
+def test_from_state_dict_preserves_decoder_when_not_normalizing() -> None:
+    cfg = SAEModuleConfig(d_model=8, num_features=16, k=3, normalize_decoder=False)
+    w_dec = torch.randn(16, 8) * 7.0
+    foreign = {"W_enc": torch.randn(8, 16), "b_enc": torch.randn(16), "W_dec": w_dec, "b_pre": torch.randn(8)}
+    sae = SparseAutoencoder.from_state_dict(foreign, cfg)
+    assert torch.allclose(sae.W_dec, w_dec)
+
+
 def test_max_pool_features_masks_padding() -> None:
     acts = torch.tensor([[1.0, 0.0], [0.0, 9.0], [5.0, 5.0]])
     mask = torch.tensor([True, True, False])  # drop the last residue

--- a/tests/sae/test_sae_module.py
+++ b/tests/sae/test_sae_module.py
@@ -1,6 +1,5 @@
 """Unit tests for the sparse-autoencoder module (torch-only, no model deps)."""
 
-import numpy as np
 import pytest
 
 torch = pytest.importorskip("torch")

--- a/tests/sae/test_sae_module.py
+++ b/tests/sae/test_sae_module.py
@@ -1,0 +1,120 @@
+"""Unit tests for the sparse-autoencoder module (torch-only, no model deps)."""
+
+import numpy as np
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from boileroom.models.sae.sae_module import (  # noqa: E402
+    SAEModuleConfig,
+    SparseAutoencoder,
+    max_pool_features,
+    topk_activation,
+)
+
+
+def test_config_validation() -> None:
+    with pytest.raises(ValueError):
+        SAEModuleConfig(d_model=0, num_features=16)
+    with pytest.raises(ValueError):
+        SAEModuleConfig(d_model=8, num_features=16, activation="softmax")  # type: ignore[arg-type]
+    with pytest.raises(ValueError):
+        SAEModuleConfig(d_model=8, num_features=16, k=32)  # k > num_features
+
+
+def test_topk_activation_keeps_exactly_k_positive() -> None:
+    pre = torch.tensor([[3.0, -1.0, 2.0, 5.0, -4.0]])
+    out = topk_activation(pre, k=2)
+    # Only the two largest positive pre-activations (5, 3) survive.
+    assert torch.count_nonzero(out) == 2
+    assert out[0, 3] == pytest.approx(5.0)
+    assert out[0, 0] == pytest.approx(3.0)
+    assert (out >= 0).all()
+
+
+def test_topk_never_returns_negative_even_if_k_large() -> None:
+    pre = torch.tensor([[-1.0, -2.0, 3.0]])
+    out = topk_activation(pre, k=3)  # k == features -> plain relu
+    assert out.tolist() == [[0.0, 0.0, 3.0]]
+
+
+def test_encode_respects_sparsity_budget() -> None:
+    cfg = SAEModuleConfig(d_model=16, num_features=64, k=5, activation="topk")
+    sae = SparseAutoencoder(cfg)
+    torch.manual_seed(0)
+    x = torch.randn(10, 16)
+    acts = sae.encode(x)
+    assert acts.shape == (10, 64)
+    # At most k active features per residue.
+    assert int((acts > 0).sum(dim=-1).max()) <= 5
+
+
+def test_relu_variant_has_no_hard_budget() -> None:
+    cfg = SAEModuleConfig(d_model=8, num_features=32, activation="relu")
+    sae = SparseAutoencoder(cfg)
+    with torch.no_grad():
+        sae.b_enc.fill_(1.0)  # push activations positive
+    acts = sae.encode(torch.randn(4, 8))
+    assert (acts >= 0).all()
+    assert int((acts > 0).sum()) > 4 * 5  # more than a k=5 budget would allow
+
+
+def test_forward_returns_reconstruction_shape() -> None:
+    cfg = SAEModuleConfig(d_model=12, num_features=48, k=8)
+    sae = SparseAutoencoder(cfg)
+    x = torch.randn(6, 12)
+    acts, recon = sae(x)
+    assert acts.shape == (6, 48)
+    assert recon.shape == (6, 12)
+
+
+def test_save_and_load_roundtrip(tmp_path) -> None:
+    cfg = SAEModuleConfig(d_model=10, num_features=40, k=4)
+    sae = SparseAutoencoder(cfg)
+    with torch.no_grad():
+        sae.W_enc.normal_()
+        sae.b_enc.normal_()
+    sae.save(tmp_path)
+    reloaded = SparseAutoencoder.load(tmp_path)
+    x = torch.randn(5, 10)
+    assert torch.allclose(sae.encode(x), reloaded.encode(x))
+
+
+def test_from_state_dict_remaps_and_transposes() -> None:
+    cfg = SAEModuleConfig(d_model=8, num_features=16, k=3)
+    # Foreign names + transposed encoder orientation (num_features, d_model).
+    foreign = {
+        "encoder.weight": torch.randn(16, 8),
+        "encoder.bias": torch.randn(16),
+        "decoder.weight": torch.randn(16, 8),
+        "pre_bias": torch.randn(8),
+    }
+    sae = SparseAutoencoder.from_state_dict(foreign, cfg)
+    assert sae.W_enc.shape == (8, 16)
+    # Encoder weight should be the transpose of the foreign (16, 8) matrix.
+    assert torch.allclose(sae.W_enc, foreign["encoder.weight"].t())
+    assert torch.allclose(sae.b_pre, foreign["pre_bias"])
+
+
+def test_from_state_dict_strict_raises_on_missing() -> None:
+    cfg = SAEModuleConfig(d_model=8, num_features=16, k=3)
+    with pytest.raises(KeyError):
+        SparseAutoencoder.from_state_dict({"encoder.weight": torch.randn(8, 16)}, cfg, strict=True)
+
+
+def test_max_pool_features_masks_padding() -> None:
+    acts = torch.tensor([[1.0, 0.0], [0.0, 9.0], [5.0, 5.0]])
+    mask = torch.tensor([True, True, False])  # drop the last residue
+    pooled = max_pool_features(acts, mask)
+    assert pooled.tolist() == [1.0, 9.0]
+
+
+def test_max_pool_all_masked_returns_zeros() -> None:
+    acts = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    pooled = max_pool_features(acts, torch.tensor([False, False]))
+    assert pooled.tolist() == [0.0, 0.0]
+
+
+def test_max_pool_requires_2d() -> None:
+    with pytest.raises(ValueError):
+        max_pool_features(torch.zeros(2, 3, 4))


### PR DESCRIPTION
Adds a boileroom SAE model mapping a sequence to sparse-autoencoder features of the ESM-C representation space (Biohub ESM-C paper). Two backends: Forge API (default, ESMC-6B layer-60 k64 codebook16384) and local ESM-C + local TopK SAE (300M/600M). Includes module/core/wrappers, registry spec, docs, and tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the SAE model for generating sparse, pooled protein features from ESM-C representations.
  * Supports hosted Forge and local processing, optional per-residue activations, configurable layers, normalization, and device settings.
  * Added sparse autoencoder loading, activation, pooling, serialization, and checkpoint support.
  * Registered SAE for public package access with structured feature outputs and metadata.

* **Documentation**
  * Added usage and configuration guidance for SAE features, backends, and model weights.

* **Tests**
  * Added comprehensive coverage for local and hosted extraction, pooling, configuration validation, serialization, and output contracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->