### PR TITLE
test: derive base version in derive_version alpha test

### DIFF
--- a/tests/contracts/test_derive_version.py
+++ b/tests/contracts/test_derive_version.py
@@ -18,7 +18,10 @@ def test_main_version_uses_commit_count_after_baseline(monkeypatch) -> None:
 
     monkeypatch.setattr(derive_version, "run_git", fake_run_git)
 
-    assert derive_version.main_version() == "0.4.1-alpha.7"
+    # Derive the expected base from pyproject (as main_version does) instead of
+    # hardcoding it, so this test does not break on every project version bump.
+    base = derive_version.pyproject_version()
+    assert derive_version.main_version() == f"{base}-alpha.7"
 
 
 def test_main_version_counts_from_latest_stable_release_tag(monkeypatch) -> None:


### PR DESCRIPTION
test_main_version_uses_commit_count_after_baseline hardcoded '0.4.1-alpha.7', so bumping project.version to 0.4.2 broke it on main. Read the base from pyproject_version() (as main_version does) so the test checks the alpha-tag format without pinning a specific version.


Claude-Session: https://claude.ai/code/session_01K17pEESCjXA8z9C81vCt88

## Summary

What does this PR do and why?

## Changes

- ...

## Test plan

Describe how you tested these changes.

## Checklist

- [ ] Tests pass (`uv run pytest -n 4`)
- [ ] Linting passes (`pre-commit run --all-files`)
- [ ] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated version contract coverage to derive the expected base version dynamically, keeping tests aligned with the project’s declared version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->